### PR TITLE
Add multi-entity support for separate AI memory spaces

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,15 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # Pinecone Configuration
 PINECONE_API_KEY=your_pinecone_api_key_here
+
+# Single index configuration (backward compatible)
 PINECONE_INDEX_NAME=memories
+
+# Multiple indexes configuration (optional, overrides PINECONE_INDEX_NAME if set)
+# Each index represents a different AI entity with separate memory/conversation history
+# Format: JSON array of objects with index_name, label, and description
+# Example:
+# PINECONE_INDEXES='[{"index_name": "claude-main", "label": "Claude", "description": "Primary conversational AI"}, {"index_name": "claude-research", "label": "Research Claude", "description": "For research explorations"}]'
 
 # Database URL (SQLite for development)
 HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,13 +1,33 @@
 from pydantic_settings import BaseSettings
 from pydantic import Field
-from typing import Optional
+from typing import Optional, List
+import json
+
+
+class EntityConfig:
+    """Configuration for a single AI entity (Pinecone index)."""
+    def __init__(self, index_name: str, label: str, description: str = ""):
+        self.index_name = index_name
+        self.label = label
+        self.description = description
+
+    def to_dict(self):
+        return {
+            "index_name": self.index_name,
+            "label": self.label,
+            "description": self.description,
+        }
 
 
 class Settings(BaseSettings):
     # API Keys
     anthropic_api_key: str = ""
     pinecone_api_key: str = ""
-    pinecone_index_name: str = "memories"
+    pinecone_index_name: str = "memories"  # Default/fallback index
+
+    # Multiple Pinecone indexes (JSON array of objects with index_name, label, description)
+    # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity"}]'
+    pinecone_indexes: str = ""
 
     # Database
     here_i_am_database_url: str = Field(
@@ -39,6 +59,53 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         extra = "ignore"
+
+    def get_entities(self) -> List[EntityConfig]:
+        """
+        Parse and return the list of configured entities.
+
+        If PINECONE_INDEXES is set, parse it as JSON.
+        Otherwise, create a default entity from PINECONE_INDEX_NAME.
+        """
+        if self.pinecone_indexes:
+            try:
+                indexes_data = json.loads(self.pinecone_indexes)
+                return [
+                    EntityConfig(
+                        index_name=idx.get("index_name", "memories"),
+                        label=idx.get("label", idx.get("index_name", "Default")),
+                        description=idx.get("description", ""),
+                    )
+                    for idx in indexes_data
+                ]
+            except json.JSONDecodeError:
+                pass
+
+        # Fallback to single index from pinecone_index_name
+        return [
+            EntityConfig(
+                index_name=self.pinecone_index_name,
+                label="Default",
+                description="Default AI entity",
+            )
+        ]
+
+    def get_entity_by_index(self, index_name: str) -> Optional[EntityConfig]:
+        """Get an entity configuration by its index name."""
+        entities = self.get_entities()
+        for entity in entities:
+            if entity.index_name == index_name:
+                return entity
+        return None
+
+    def get_default_entity(self) -> EntityConfig:
+        """Get the first (default) entity."""
+        entities = self.get_entities()
+        return entities[0] if entities else EntityConfig(
+            index_name=self.pinecone_index_name,
+            label="Default",
+            description="Default AI entity",
+        )
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
 from app.database import init_db
-from app.routes import conversations_router, chat_router, memories_router
+from app.routes import conversations_router, chat_router, memories_router, entities_router
 from app.config import settings
 
 
@@ -38,6 +38,7 @@ app.add_middleware(
 app.include_router(conversations_router)
 app.include_router(chat_router)
 app.include_router(memories_router)
+app.include_router(entities_router)
 
 # Serve static frontend files
 frontend_path = Path(__file__).parent.parent.parent / "frontend"

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -26,6 +26,9 @@ class Conversation(Base):
     system_prompt_used: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     model_used: Mapped[str] = mapped_column(String(100), default="claude-sonnet-4-20250514")
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Entity ID is the Pinecone index name for the AI entity this conversation belongs to
+    # NULL means use the default entity (for backward compatibility)
+    entity_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
 
     messages: Mapped[List["Message"]] = relationship(
         "Message", back_populates="conversation", cascade="all, delete-orphan"

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,5 +1,6 @@
 from app.routes.conversations import router as conversations_router
 from app.routes.chat import router as chat_router
 from app.routes.memories import router as memories_router
+from app.routes.entities import router as entities_router
 
-__all__ = ["conversations_router", "chat_router", "memories_router"]
+__all__ = ["conversations_router", "chat_router", "memories_router", "entities_router"]

--- a/backend/app/routes/entities.py
+++ b/backend/app/routes/entities.py
@@ -1,0 +1,120 @@
+from typing import List, Optional
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.config import settings
+from app.services.memory_service import memory_service
+
+router = APIRouter(prefix="/api/entities", tags=["entities"])
+
+
+class EntityResponse(BaseModel):
+    index_name: str
+    label: str
+    description: str
+    is_default: bool = False
+
+
+class EntityListResponse(BaseModel):
+    entities: List[EntityResponse]
+    default_entity: str
+
+
+@router.get("/", response_model=EntityListResponse)
+async def list_entities():
+    """
+    List all configured AI entities.
+
+    Each entity corresponds to a separate Pinecone index with its own
+    conversation history and memory.
+    """
+    entities = settings.get_entities()
+    default_entity = settings.get_default_entity()
+
+    return EntityListResponse(
+        entities=[
+            EntityResponse(
+                index_name=entity.index_name,
+                label=entity.label,
+                description=entity.description,
+                is_default=(entity.index_name == default_entity.index_name),
+            )
+            for entity in entities
+        ],
+        default_entity=default_entity.index_name,
+    )
+
+
+@router.get("/{entity_id}", response_model=EntityResponse)
+async def get_entity(entity_id: str):
+    """Get a specific entity by its index name."""
+    entity = settings.get_entity_by_index(entity_id)
+
+    if not entity:
+        raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
+
+    default_entity = settings.get_default_entity()
+
+    return EntityResponse(
+        index_name=entity.index_name,
+        label=entity.label,
+        description=entity.description,
+        is_default=(entity.index_name == default_entity.index_name),
+    )
+
+
+@router.get("/{entity_id}/status")
+async def get_entity_status(entity_id: str):
+    """
+    Get the status of an entity's Pinecone index.
+
+    Returns connection status and basic stats if available.
+    """
+    entity = settings.get_entity_by_index(entity_id)
+
+    if not entity:
+        raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
+
+    # Check if Pinecone is configured
+    if not memory_service.is_configured():
+        return {
+            "entity_id": entity_id,
+            "label": entity.label,
+            "pinecone_configured": False,
+            "index_connected": False,
+            "message": "Pinecone is not configured",
+        }
+
+    # Try to connect to the index
+    index = memory_service.get_index(entity_id)
+    if index is None:
+        return {
+            "entity_id": entity_id,
+            "label": entity.label,
+            "pinecone_configured": True,
+            "index_connected": False,
+            "message": f"Could not connect to Pinecone index '{entity_id}'",
+        }
+
+    # Try to get index stats
+    try:
+        stats = index.describe_index_stats()
+        return {
+            "entity_id": entity_id,
+            "label": entity.label,
+            "pinecone_configured": True,
+            "index_connected": True,
+            "stats": {
+                "total_vector_count": stats.get("total_vector_count", 0),
+                "dimension": stats.get("dimension"),
+            },
+        }
+    except Exception as e:
+        return {
+            "entity_id": entity_id,
+            "label": entity.label,
+            "pinecone_configured": True,
+            "index_connected": True,
+            "stats": None,
+            "message": f"Connected but could not get stats: {str(e)}",
+        }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -69,6 +69,45 @@ html, body {
     color: var(--text-muted);
 }
 
+/* Entity Selector */
+.entity-selector {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.entity-selector label {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.entity-selector select {
+    width: 100%;
+    padding: 8px 12px;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.entity-selector select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.entity-description {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 6px;
+    font-style: italic;
+}
+
 .new-conversation-btn {
     margin: 16px;
     padding: 12px 16px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,15 @@
                 <p class="app-subtitle">Experiential Interpretability Research</p>
             </div>
 
+            <!-- Entity Selector -->
+            <div class="entity-selector" id="entity-selector">
+                <label for="entity-select">AI Entity</label>
+                <select id="entity-select">
+                    <!-- Entities will be loaded dynamically -->
+                </select>
+                <p class="entity-description" id="entity-description"></p>
+            </div>
+
             <button id="new-conversation-btn" class="new-conversation-btn">
                 + New Conversation
             </button>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -37,9 +37,26 @@ class ApiClient {
         return this.request('/health');
     }
 
+    // Entities
+    async listEntities() {
+        return this.request('/entities/');
+    }
+
+    async getEntity(entityId) {
+        return this.request(`/entities/${entityId}`);
+    }
+
+    async getEntityStatus(entityId) {
+        return this.request(`/entities/${entityId}/status`);
+    }
+
     // Conversations
-    async listConversations(limit = 50, offset = 0) {
-        return this.request(`/conversations/?limit=${limit}&offset=${offset}`);
+    async listConversations(limit = 50, offset = 0, entityId = null) {
+        let url = `/conversations/?limit=${limit}&offset=${offset}`;
+        if (entityId) {
+            url += `&entity_id=${entityId}`;
+        }
+        return this.request(url);
     }
 
     async createConversation(data = {}) {
@@ -117,18 +134,20 @@ class ApiClient {
         if (options.offset) params.set('offset', options.offset);
         if (options.role) params.set('role', options.role);
         if (options.sortBy) params.set('sort_by', options.sortBy);
+        if (options.entityId) params.set('entity_id', options.entityId);
 
         const query = params.toString();
         return this.request(`/memories/${query ? '?' + query : ''}`);
     }
 
-    async searchMemories(query, topK = 10) {
+    async searchMemories(query, topK = 10, includeContent = true, entityId = null) {
         return this.request('/memories/search', {
             method: 'POST',
             body: {
                 query,
                 top_k: topK,
-                include_content: true,
+                include_content: includeContent,
+                entity_id: entityId,
             },
         });
     }


### PR DESCRIPTION
This feature allows multiple Pinecone indexes to be configured, each representing a different AI entity with its own isolated memory space and conversation history.

Key changes:
- Add PINECONE_INDEXES env var for JSON configuration of multiple entities
- Add entity_id field to Conversation model
- Refactor MemoryService to support dynamic index selection
- Create /api/entities/ endpoints for entity management
- Update all routes to handle entity-aware memory operations
- Add entity selector UI in the frontend sidebar
- Filter conversations and memories by selected entity

Configuration:
  PINECONE_INDEXES='[{"index_name": "main", "label": "Main", "description": "Primary AI"}]'

Each entity requires a pre-created Pinecone index with dimension=1024.