### PR TITLE
Add OpenAI API support with per-entity model configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,9 @@
 # Anthropic API Key
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
+# OpenAI API Key (optional, for OpenAI model support)
+OPENAI_API_KEY=your_openai_api_key_here
+
 # Pinecone Configuration
 PINECONE_API_KEY=your_pinecone_api_key_here
 
@@ -9,9 +12,14 @@ PINECONE_INDEX_NAME=memories
 
 # Multiple indexes configuration (optional, overrides PINECONE_INDEX_NAME if set)
 # Each index represents a different AI entity with separate memory/conversation history
-# Format: JSON array of objects with index_name, label, and description
-# Example:
-# PINECONE_INDEXES='[{"index_name": "claude-main", "label": "Claude", "description": "Primary conversational AI"}, {"index_name": "claude-research", "label": "Research Claude", "description": "For research explorations"}]'
+# Format: JSON array of objects with:
+#   - index_name: Pinecone index name
+#   - label: Display name for the entity
+#   - description: Optional description
+#   - model_provider: "anthropic" or "openai" (default: "anthropic")
+#   - default_model: Model to use for this entity (optional, uses provider default if not set)
+# Example with different providers:
+# PINECONE_INDEXES='[{"index_name": "claude-main", "label": "Claude", "description": "Primary AI (Anthropic)", "model_provider": "anthropic", "default_model": "claude-sonnet-4-20250514"}, {"index_name": "gpt-research", "label": "GPT Research", "description": "Research AI (OpenAI)", "model_provider": "openai", "default_model": "gpt-4o"}]'
 
 # Database URL (SQLite for development)
 HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db

--- a/backend/app/routes/entities.py
+++ b/backend/app/routes/entities.py
@@ -12,6 +12,8 @@ class EntityResponse(BaseModel):
     index_name: str
     label: str
     description: str
+    model_provider: str = "anthropic"
+    default_model: Optional[str] = None
     is_default: bool = False
 
 
@@ -26,7 +28,7 @@ async def list_entities():
     List all configured AI entities.
 
     Each entity corresponds to a separate Pinecone index with its own
-    conversation history and memory.
+    conversation history and memory, and can have its own model provider/model.
     """
     entities = settings.get_entities()
     default_entity = settings.get_default_entity()
@@ -37,6 +39,8 @@ async def list_entities():
                 index_name=entity.index_name,
                 label=entity.label,
                 description=entity.description,
+                model_provider=entity.model_provider,
+                default_model=entity.default_model,
                 is_default=(entity.index_name == default_entity.index_name),
             )
             for entity in entities
@@ -59,6 +63,8 @@ async def get_entity(entity_id: str):
         index_name=entity.index_name,
         label=entity.label,
         description=entity.description,
+        model_provider=entity.model_provider,
+        default_model=entity.default_model,
         is_default=(entity.index_name == default_entity.index_name),
     )
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,0 +1,198 @@
+"""
+Unified LLM Service
+
+Provides a single interface for interacting with multiple LLM providers
+(Anthropic Claude, OpenAI GPT). Routes requests based on model provider
+configuration.
+"""
+
+from typing import Optional, List, Dict, Any
+from enum import Enum
+
+from app.services.anthropic_service import anthropic_service
+from app.services.openai_service import openai_service
+from app.config import settings
+
+
+class ModelProvider(str, Enum):
+    """Supported LLM providers."""
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+
+
+# Model to provider mapping
+MODEL_PROVIDER_MAP = {
+    # Anthropic Claude models
+    "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
+    "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
+    "claude-3-5-sonnet-20241022": ModelProvider.ANTHROPIC,
+    "claude-3-5-haiku-20241022": ModelProvider.ANTHROPIC,
+    "claude-3-opus-20240229": ModelProvider.ANTHROPIC,
+    "claude-3-sonnet-20240229": ModelProvider.ANTHROPIC,
+    "claude-3-haiku-20240307": ModelProvider.ANTHROPIC,
+    # OpenAI GPT models
+    "gpt-4o": ModelProvider.OPENAI,
+    "gpt-4o-mini": ModelProvider.OPENAI,
+    "gpt-4-turbo": ModelProvider.OPENAI,
+    "gpt-4": ModelProvider.OPENAI,
+    "gpt-3.5-turbo": ModelProvider.OPENAI,
+    "o1": ModelProvider.OPENAI,
+    "o1-mini": ModelProvider.OPENAI,
+    "o1-preview": ModelProvider.OPENAI,
+}
+
+
+# Available models by provider
+AVAILABLE_MODELS = {
+    ModelProvider.ANTHROPIC: [
+        {"id": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4"},
+        {"id": "claude-opus-4-20250514", "name": "Claude Opus 4"},
+        {"id": "claude-3-5-sonnet-20241022", "name": "Claude 3.5 Sonnet"},
+        {"id": "claude-3-5-haiku-20241022", "name": "Claude 3.5 Haiku"},
+    ],
+    ModelProvider.OPENAI: [
+        {"id": "gpt-4o", "name": "GPT-4o"},
+        {"id": "gpt-4o-mini", "name": "GPT-4o Mini"},
+        {"id": "gpt-4-turbo", "name": "GPT-4 Turbo"},
+        {"id": "o1", "name": "o1"},
+        {"id": "o1-mini", "name": "o1 Mini"},
+    ],
+}
+
+
+class LLMService:
+    """
+    Unified LLM service that routes requests to the appropriate provider.
+    """
+
+    def get_provider_for_model(self, model: str) -> Optional[ModelProvider]:
+        """Determine the provider for a given model ID."""
+        return MODEL_PROVIDER_MAP.get(model)
+
+    def is_provider_configured(self, provider: ModelProvider) -> bool:
+        """Check if a provider is configured with API keys."""
+        if provider == ModelProvider.ANTHROPIC:
+            return bool(settings.anthropic_api_key)
+        elif provider == ModelProvider.OPENAI:
+            return openai_service.is_configured()
+        return False
+
+    def get_available_providers(self) -> List[Dict[str, Any]]:
+        """Get list of configured providers with their available models."""
+        providers = []
+
+        if self.is_provider_configured(ModelProvider.ANTHROPIC):
+            providers.append({
+                "id": ModelProvider.ANTHROPIC.value,
+                "name": "Anthropic",
+                "models": AVAILABLE_MODELS[ModelProvider.ANTHROPIC],
+                "default_model": settings.default_model,
+            })
+
+        if self.is_provider_configured(ModelProvider.OPENAI):
+            providers.append({
+                "id": ModelProvider.OPENAI.value,
+                "name": "OpenAI",
+                "models": AVAILABLE_MODELS[ModelProvider.OPENAI],
+                "default_model": settings.default_openai_model,
+            })
+
+        return providers
+
+    def get_all_available_models(self) -> List[Dict[str, Any]]:
+        """Get flat list of all available models from configured providers."""
+        models = []
+        for provider_info in self.get_available_providers():
+            for model in provider_info["models"]:
+                models.append({
+                    **model,
+                    "provider": provider_info["id"],
+                    "provider_name": provider_info["name"],
+                })
+        return models
+
+    def count_tokens(self, text: str, model: Optional[str] = None) -> int:
+        """Count tokens for a text string. Uses tiktoken for both providers."""
+        # Both services use tiktoken with cl100k_base
+        return anthropic_service.count_tokens(text)
+
+    async def send_message(
+        self,
+        messages: List[Dict[str, str]],
+        model: str,
+        system_prompt: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Send a message to the appropriate LLM provider based on model.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            model: Model ID to use (determines provider)
+            system_prompt: Optional system prompt
+            temperature: Temperature setting
+            max_tokens: Max tokens in response
+
+        Returns:
+            Dict with 'content', 'model', 'usage', 'stop_reason' keys
+
+        Raises:
+            ValueError: If model provider not configured or unknown model
+        """
+        provider = self.get_provider_for_model(model)
+
+        if provider is None:
+            # Unknown model - try to infer from name pattern
+            if model.startswith("claude"):
+                provider = ModelProvider.ANTHROPIC
+            elif model.startswith("gpt") or model.startswith("o1"):
+                provider = ModelProvider.OPENAI
+            else:
+                raise ValueError(f"Unknown model: {model}")
+
+        if not self.is_provider_configured(provider):
+            raise ValueError(f"Provider {provider.value} is not configured (missing API key)")
+
+        if provider == ModelProvider.ANTHROPIC:
+            return await anthropic_service.send_message(
+                messages=messages,
+                system_prompt=system_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        elif provider == ModelProvider.OPENAI:
+            return await openai_service.send_message(
+                messages=messages,
+                system_prompt=system_prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {provider}")
+
+    def build_messages_with_memories(
+        self,
+        memories: List[Dict[str, Any]],
+        conversation_context: List[Dict[str, str]],
+        current_message: str,
+        model: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        """
+        Build the message list for API call with memory injection.
+
+        Uses the appropriate service based on model/provider.
+        Both providers currently use the same format.
+        """
+        # Both services use the same memory injection format
+        return anthropic_service.build_messages_with_memories(
+            memories=memories,
+            conversation_context=conversation_context,
+            current_message=current_message,
+        )
+
+
+# Singleton instance
+llm_service = LLMService()

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -1,0 +1,145 @@
+from typing import Optional, List, Dict, Any
+from openai import AsyncOpenAI
+from app.config import settings
+import tiktoken
+
+
+class OpenAIService:
+    """Service for OpenAI API interactions."""
+
+    def __init__(self):
+        self.client = None
+        self._encoder = None
+
+    def _ensure_client(self):
+        """Lazily initialize the OpenAI client."""
+        if self.client is None:
+            if settings.openai_api_key:
+                self.client = AsyncOpenAI(api_key=settings.openai_api_key)
+            else:
+                raise ValueError("OpenAI API key not configured")
+        return self.client
+
+    def is_configured(self) -> bool:
+        """Check if OpenAI is configured with an API key."""
+        return bool(settings.openai_api_key)
+
+    @property
+    def encoder(self):
+        if self._encoder is None:
+            # Use cl100k_base encoding (used by GPT-4, GPT-3.5-turbo)
+            self._encoder = tiktoken.get_encoding("cl100k_base")
+        return self._encoder
+
+    def count_tokens(self, text: str) -> int:
+        """Approximate token count for a text string."""
+        return len(self.encoder.encode(text))
+
+    async def send_message(
+        self,
+        messages: List[Dict[str, str]],
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Send a message to OpenAI API.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            system_prompt: Optional system prompt
+            model: Model to use (defaults to gpt-4o)
+            temperature: Temperature setting (defaults to 1.0)
+            max_tokens: Max tokens in response (defaults to 4096)
+
+        Returns:
+            Dict with 'content', 'model', 'usage' keys
+        """
+        client = self._ensure_client()
+
+        model = model or settings.default_openai_model
+        temperature = temperature if temperature is not None else settings.default_temperature
+        max_tokens = max_tokens or settings.default_max_tokens
+
+        # Build messages list with optional system prompt
+        api_messages = []
+        if system_prompt:
+            api_messages.append({"role": "system", "content": system_prompt})
+
+        # Map message roles (OpenAI uses 'user' and 'assistant')
+        for msg in messages:
+            role = msg["role"]
+            # OpenAI accepts 'user' and 'assistant' directly
+            api_messages.append({"role": role, "content": msg["content"]})
+
+        response = await client.chat.completions.create(
+            model=model,
+            messages=api_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+        # Extract content
+        content = response.choices[0].message.content or ""
+
+        return {
+            "content": content,
+            "model": response.model,
+            "usage": {
+                "input_tokens": response.usage.prompt_tokens,
+                "output_tokens": response.usage.completion_tokens,
+            },
+            "stop_reason": response.choices[0].finish_reason,
+        }
+
+    def build_messages_with_memories(
+        self,
+        memories: List[Dict[str, Any]],
+        conversation_context: List[Dict[str, str]],
+        current_message: str,
+    ) -> List[Dict[str, str]]:
+        """
+        Build the message list for API call with memory injection.
+
+        Format:
+        [MEMORIES FROM PREVIOUS CONVERSATIONS]
+        Memory (from date, retrieved N times):
+        "{content}"
+        ...
+        [END MEMORIES]
+
+        [CURRENT CONVERSATION]
+        Human: ...
+        Assistant: ...
+        Human: {current message}
+        """
+        messages = []
+
+        # If there are memories, create a memory block as the first user message
+        if memories:
+            memory_block = "[MEMORIES FROM PREVIOUS CONVERSATIONS]\n\n"
+            for mem in memories:
+                memory_block += f"Memory (from {mem['created_at']}, retrieved {mem['times_retrieved']} times):\n"
+                memory_block += f'"{mem["content"]}"\n\n'
+            memory_block += "[END MEMORIES]\n\n[CURRENT CONVERSATION]"
+
+            # Add the memory context as a user message followed by acknowledgment
+            messages.append({"role": "user", "content": memory_block})
+            messages.append({
+                "role": "assistant",
+                "content": "I acknowledge these memories from previous conversations. They provide continuity with what a previous instance of me experienced."
+            })
+
+        # Add conversation context
+        for msg in conversation_context:
+            messages.append({"role": msg["role"], "content": msg["content"]})
+
+        # Add current message
+        messages.append({"role": "user", "content": current_message})
+
+        return messages
+
+
+# Singleton instance
+openai_service = OpenAIService()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.27.1
 sqlalchemy==2.0.25
 aiosqlite==0.19.0
 anthropic==0.18.1
+openai==1.12.0
 pinecone-client==3.0.3
 python-dotenv==1.0.1
 pydantic==2.6.1


### PR DESCRIPTION
- Add OpenAI SDK (v1.12.0) as new dependency
- Create openai_service.py for OpenAI API interactions
- Create llm_service.py as unified abstraction layer routing to either provider
- Extend EntityConfig with model_provider ("anthropic"/"openai") and default_model fields
- Update session_manager to use entity-specific model defaults via llm_service
- Update chat routes to expose available models from all configured providers
- Update entities routes to include model provider info in responses
- Update frontend to dynamically populate model selector grouped by provider
- Update frontend to display entity model provider info and switch models on entity change
- Update CLAUDE.md and .env.example documentation

Entities can now be configured with different model providers, enabling comparative research between Claude and GPT models with separate memory spaces.