### PR TITLE
Fix numpy installation error in requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,5 @@ python-dotenv==1.0.1
 pydantic==2.6.1
 pydantic-settings==2.1.0
 httpx==0.26.0
-numpy==1.26.4
+numpy>=1.26.0,<3.0.0
 tiktoken==0.6.0


### PR DESCRIPTION
Relax numpy version constraint from exact 1.26.4 to >=1.26.0,<3.0.0 to allow pip to find pre-built wheels for various Python versions instead of requiring source compilation.