### PR TITLE
Create and run unit tests for application

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,8 @@ pydantic-settings==2.1.0
 httpx==0.26.0
 numpy>=1.26.0,<3.0.0
 tiktoken==0.6.0
+
+# Testing dependencies
+pytest==8.3.3
+pytest-asyncio==0.24.0
+pytest-cov==5.0.0

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for Here I Am application

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,282 @@
+"""
+Pytest configuration and fixtures for Here I Am tests.
+"""
+import pytest
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator, Dict, Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base
+from app.models import Conversation, Message, ConversationMemoryLink, MessageRole, ConversationType
+from app.config import Settings, EntityConfig
+
+
+# Test database URL - in-memory SQLite
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an event loop for the test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+async def test_engine():
+    """Create a test database engine."""
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        echo=False,
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(test_engine) -> AsyncGenerator[AsyncSession, None]:
+    """Create a test database session."""
+    async_session = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False
+    )
+
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+
+
+@pytest.fixture
+def test_settings():
+    """Create test settings with mock API keys."""
+    return Settings(
+        anthropic_api_key="test-anthropic-key",
+        openai_api_key="test-openai-key",
+        pinecone_api_key="test-pinecone-key",
+        pinecone_index_name="test-memories",
+        here_i_am_database_url=TEST_DATABASE_URL,
+        debug=False,
+        retrieval_top_k=5,
+        similarity_threshold=0.7,
+        default_model="claude-sonnet-4-20250514",
+        default_openai_model="gpt-4o",
+        default_temperature=1.0,
+        default_max_tokens=4096,
+    )
+
+
+@pytest.fixture
+def test_settings_multi_entity():
+    """Create test settings with multiple entities."""
+    return Settings(
+        anthropic_api_key="test-anthropic-key",
+        openai_api_key="test-openai-key",
+        pinecone_api_key="test-pinecone-key",
+        pinecone_indexes='[{"index_name": "claude-test", "label": "Claude Test", "description": "Test entity", "model_provider": "anthropic"}, {"index_name": "gpt-test", "label": "GPT Test", "description": "OpenAI test", "model_provider": "openai", "default_model": "gpt-4o"}]',
+        here_i_am_database_url=TEST_DATABASE_URL,
+    )
+
+
+@pytest.fixture
+def test_settings_no_pinecone():
+    """Create test settings without Pinecone configured."""
+    return Settings(
+        anthropic_api_key="test-anthropic-key",
+        openai_api_key="",
+        pinecone_api_key="",
+        here_i_am_database_url=TEST_DATABASE_URL,
+    )
+
+
+@pytest.fixture
+def sample_conversation_id():
+    """Generate a sample conversation ID."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def sample_message_id():
+    """Generate a sample message ID."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+async def sample_conversation(db_session, sample_conversation_id) -> Conversation:
+    """Create a sample conversation in the database."""
+    conversation = Conversation(
+        id=sample_conversation_id,
+        title="Test Conversation",
+        conversation_type=ConversationType.NORMAL,
+        model_used="claude-sonnet-4-20250514",
+        entity_id="test-memories",
+    )
+    db_session.add(conversation)
+    await db_session.commit()
+    await db_session.refresh(conversation)
+    return conversation
+
+
+@pytest.fixture
+async def sample_messages(db_session, sample_conversation) -> List[Message]:
+    """Create sample messages in the database."""
+    messages = [
+        Message(
+            id=str(uuid.uuid4()),
+            conversation_id=sample_conversation.id,
+            role=MessageRole.HUMAN,
+            content="Hello, how are you?",
+            token_count=5,
+        ),
+        Message(
+            id=str(uuid.uuid4()),
+            conversation_id=sample_conversation.id,
+            role=MessageRole.ASSISTANT,
+            content="I'm doing well, thank you for asking!",
+            token_count=10,
+        ),
+    ]
+    for msg in messages:
+        db_session.add(msg)
+    await db_session.commit()
+    for msg in messages:
+        await db_session.refresh(msg)
+    return messages
+
+
+@pytest.fixture
+def mock_anthropic_client():
+    """Create a mock Anthropic client."""
+    mock_client = MagicMock()
+
+    # Mock messages.create response
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="This is a test response from Claude.")]
+    mock_response.model = "claude-sonnet-4-20250514"
+    mock_response.usage.input_tokens = 100
+    mock_response.usage.output_tokens = 50
+    mock_response.stop_reason = "end_turn"
+
+    mock_client.messages = MagicMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    # Mock embeddings.create response
+    mock_embedding_response = MagicMock()
+    mock_embedding_response.data = [MagicMock(embedding=[0.1] * 1024)]
+    mock_client.embeddings = MagicMock()
+    mock_client.embeddings.create = AsyncMock(return_value=mock_embedding_response)
+
+    return mock_client
+
+
+@pytest.fixture
+def mock_openai_client():
+    """Create a mock OpenAI client."""
+    mock_client = MagicMock()
+
+    # Mock chat.completions.create response
+    mock_choice = MagicMock()
+    mock_choice.message.content = "This is a test response from GPT."
+    mock_choice.finish_reason = "stop"
+
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.model = "gpt-4o"
+    mock_response.usage.prompt_tokens = 100
+    mock_response.usage.completion_tokens = 50
+
+    mock_client.chat = MagicMock()
+    mock_client.chat.completions = MagicMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    return mock_client
+
+
+@pytest.fixture
+def mock_pinecone_index():
+    """Create a mock Pinecone index."""
+    mock_index = MagicMock()
+
+    # Mock query response
+    mock_match = MagicMock()
+    mock_match.id = "test-memory-id"
+    mock_match.score = 0.9
+    mock_match.metadata = {
+        "conversation_id": "old-conversation-id",
+        "created_at": "2024-01-01T12:00:00",
+        "role": "assistant",
+        "content_preview": "This is a test memory...",
+        "times_retrieved": 5,
+    }
+
+    mock_query_result = MagicMock()
+    mock_query_result.matches = [mock_match]
+    mock_index.query = MagicMock(return_value=mock_query_result)
+
+    # Mock fetch response
+    mock_vector = MagicMock()
+    mock_vector.metadata = {"times_retrieved": 5}
+    mock_fetch_result = MagicMock()
+    mock_fetch_result.vectors = {"test-memory-id": mock_vector}
+    mock_index.fetch = MagicMock(return_value=mock_fetch_result)
+
+    # Mock upsert and update
+    mock_index.upsert = MagicMock()
+    mock_index.update = MagicMock()
+    mock_index.delete = MagicMock()
+
+    return mock_index
+
+
+@pytest.fixture
+def sample_memories():
+    """Create sample memory data for injection."""
+    return [
+        {
+            "id": "mem-1",
+            "content": "I remember you mentioned enjoying programming.",
+            "created_at": "2024-01-01",
+            "times_retrieved": 3,
+            "role": "assistant",
+        },
+        {
+            "id": "mem-2",
+            "content": "We discussed AI ethics last time.",
+            "created_at": "2024-01-02",
+            "times_retrieved": 1,
+            "role": "human",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_conversation_context():
+    """Create sample conversation context."""
+    return [
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+
+
+@pytest.fixture
+def sample_api_messages():
+    """Create sample API messages for LLM calls."""
+    return [
+        {"role": "user", "content": "What is Python?"},
+    ]

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for AnthropicService.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from app.services.anthropic_service import AnthropicService
+
+
+class TestAnthropicService:
+    """Tests for AnthropicService class."""
+
+    def test_count_tokens(self):
+        """Test token counting."""
+        service = AnthropicService()
+
+        # Mock the encoder to avoid network call
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = [1, 2, 3, 4]  # 4 tokens
+        service._encoder = mock_encoder
+
+        # Count tokens for a simple string
+        count = service.count_tokens("Hello, world!")
+
+        assert isinstance(count, int)
+        assert count == 4
+        mock_encoder.encode.assert_called_once_with("Hello, world!")
+
+    def test_count_tokens_empty_string(self):
+        """Test token counting for empty string."""
+        service = AnthropicService()
+
+        # Mock the encoder
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = []  # 0 tokens
+        service._encoder = mock_encoder
+
+        count = service.count_tokens("")
+
+        assert count == 0
+
+    def test_count_tokens_long_text(self):
+        """Test token counting for longer text."""
+        service = AnthropicService()
+
+        # Mock the encoder
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = list(range(150))  # 150 tokens
+        service._encoder = mock_encoder
+
+        long_text = "This is a test. " * 100
+        count = service.count_tokens(long_text)
+
+        assert count == 150
+
+    def test_encoder_lazy_initialization(self):
+        """Test that encoder is lazily initialized."""
+        service = AnthropicService()
+
+        # Before accessing, _encoder should be None
+        assert service._encoder is None
+
+        # Mock tiktoken to avoid network call
+        with patch("app.services.anthropic_service.tiktoken") as mock_tiktoken:
+            mock_encoder = MagicMock()
+            mock_tiktoken.get_encoding.return_value = mock_encoder
+
+            # After accessing, encoder should be initialized
+            _ = service.encoder
+            assert service._encoder is mock_encoder
+            mock_tiktoken.get_encoding.assert_called_once_with("cl100k_base")
+
+    @pytest.mark.asyncio
+    async def test_send_message_basic(self, mock_anthropic_client):
+        """Test basic message sending."""
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        response = await service.send_message(messages)
+
+        assert response["content"] == "This is a test response from Claude."
+        assert response["model"] == "claude-sonnet-4-20250514"
+        assert "usage" in response
+        assert response["usage"]["input_tokens"] == 100
+        assert response["usage"]["output_tokens"] == 50
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_system_prompt(self, mock_anthropic_client):
+        """Test message sending with system prompt."""
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        await service.send_message(
+            messages,
+            system_prompt="You are a helpful assistant.",
+        )
+
+        # Verify system prompt was passed to API
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["system"] == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_send_message_no_system_prompt(self, mock_anthropic_client):
+        """Test message sending without system prompt."""
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        await service.send_message(messages, system_prompt=None)
+
+        # Verify system prompt was NOT passed to API
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert "system" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_message_custom_parameters(self, mock_anthropic_client):
+        """Test message sending with custom parameters."""
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        await service.send_message(
+            messages,
+            model="claude-3-opus-20240229",
+            temperature=0.5,
+            max_tokens=2000,
+        )
+
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-3-opus-20240229"
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 2000
+
+    def test_build_messages_with_memories_no_memories(self):
+        """Test building messages without memories."""
+        service = AnthropicService()
+
+        memories = []
+        context = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        current = "How are you?"
+
+        messages = service.build_messages_with_memories(memories, context, current)
+
+        # Should have context + current message
+        assert len(messages) == 3
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "Hi"
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "Hello!"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "How are you?"
+
+    def test_build_messages_with_memories(self, sample_memories):
+        """Test building messages with memories."""
+        service = AnthropicService()
+
+        context = []
+        current = "What do you remember?"
+
+        messages = service.build_messages_with_memories(sample_memories, context, current)
+
+        # Should have: memory block, acknowledgment, current message
+        assert len(messages) == 3
+
+        # First message should contain memory block
+        assert messages[0]["role"] == "user"
+        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in messages[0]["content"]
+        assert "I remember you mentioned enjoying programming" in messages[0]["content"]
+        assert "[END MEMORIES]" in messages[0]["content"]
+
+        # Second message should be acknowledgment
+        assert messages[1]["role"] == "assistant"
+        assert "acknowledge" in messages[1]["content"].lower()
+
+        # Third message should be current message
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "What do you remember?"
+
+    def test_build_messages_with_memories_and_context(self, sample_memories, sample_conversation_context):
+        """Test building messages with both memories and context."""
+        service = AnthropicService()
+
+        current = "Tell me more."
+
+        messages = service.build_messages_with_memories(
+            sample_memories,
+            sample_conversation_context,
+            current
+        )
+
+        # Should have: memory block, acknowledgment, context (2), current message
+        assert len(messages) == 5
+
+        # Verify memory block is first
+        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in messages[0]["content"]
+
+        # Verify context is preserved after acknowledgment
+        assert messages[2]["content"] == "Hello!"
+        assert messages[3]["content"] == "Hi there!"
+
+        # Verify current message is last
+        assert messages[4]["content"] == "Tell me more."
+
+    def test_build_messages_memory_format(self, sample_memories):
+        """Test that memories are formatted correctly."""
+        service = AnthropicService()
+
+        messages = service.build_messages_with_memories(sample_memories, [], "Test")
+
+        memory_block = messages[0]["content"]
+
+        # Check formatting
+        assert "Memory (from 2024-01-01, retrieved 3 times):" in memory_block
+        assert '"I remember you mentioned enjoying programming."' in memory_block
+        assert "Memory (from 2024-01-02, retrieved 1 time" in memory_block  # times/time varies

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for configuration and EntityConfig.
+"""
+import pytest
+from unittest.mock import patch
+from app.config import Settings, EntityConfig
+
+
+class TestEntityConfig:
+    """Tests for EntityConfig class."""
+
+    def test_entity_config_creation(self):
+        """Test basic EntityConfig creation."""
+        entity = EntityConfig(
+            index_name="test-index",
+            label="Test Entity",
+            description="A test entity",
+            model_provider="anthropic",
+            default_model="claude-sonnet-4-20250514",
+        )
+
+        assert entity.index_name == "test-index"
+        assert entity.label == "Test Entity"
+        assert entity.description == "A test entity"
+        assert entity.model_provider == "anthropic"
+        assert entity.default_model == "claude-sonnet-4-20250514"
+
+    def test_entity_config_defaults(self):
+        """Test EntityConfig default values."""
+        entity = EntityConfig(
+            index_name="test-index",
+            label="Test Entity",
+        )
+
+        assert entity.description == ""
+        assert entity.model_provider == "anthropic"
+        assert entity.default_model is None
+
+    def test_entity_config_openai_provider(self):
+        """Test EntityConfig with OpenAI provider."""
+        entity = EntityConfig(
+            index_name="gpt-index",
+            label="GPT Entity",
+            model_provider="openai",
+            default_model="gpt-4o",
+        )
+
+        assert entity.model_provider == "openai"
+        assert entity.default_model == "gpt-4o"
+
+    def test_entity_config_to_dict(self):
+        """Test EntityConfig to_dict method."""
+        entity = EntityConfig(
+            index_name="test-index",
+            label="Test Entity",
+            description="A test entity",
+            model_provider="anthropic",
+            default_model="claude-sonnet-4-20250514",
+        )
+
+        result = entity.to_dict()
+
+        assert result == {
+            "index_name": "test-index",
+            "label": "Test Entity",
+            "description": "A test entity",
+            "model_provider": "anthropic",
+            "default_model": "claude-sonnet-4-20250514",
+        }
+
+
+class TestSettings:
+    """Tests for Settings class."""
+
+    def test_settings_default_values(self):
+        """Test Settings default values."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            _env_file=None,  # Disable .env loading for test
+        )
+
+        assert settings.default_model == "claude-sonnet-4-20250514"
+        assert settings.default_openai_model == "gpt-4o"
+        assert settings.default_temperature == 1.0
+        assert settings.default_max_tokens == 4096
+        assert settings.retrieval_top_k == 10
+        assert settings.similarity_threshold == 0.7
+
+    def test_settings_custom_values(self, test_settings):
+        """Test Settings with custom values."""
+        assert test_settings.anthropic_api_key == "test-anthropic-key"
+        assert test_settings.openai_api_key == "test-openai-key"
+        assert test_settings.pinecone_api_key == "test-pinecone-key"
+        assert test_settings.retrieval_top_k == 5
+
+    def test_get_entities_single_fallback(self):
+        """Test get_entities with single fallback index."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            pinecone_index_name="my-memories",
+            pinecone_indexes="",  # Empty means use fallback
+            _env_file=None,
+        )
+
+        entities = settings.get_entities()
+
+        assert len(entities) == 1
+        assert entities[0].index_name == "my-memories"
+        assert entities[0].label == "Default"
+        assert entities[0].model_provider == "anthropic"
+
+    def test_get_entities_multiple_from_json(self, test_settings_multi_entity):
+        """Test get_entities with multiple entities from JSON."""
+        entities = test_settings_multi_entity.get_entities()
+
+        assert len(entities) == 2
+
+        # Check first entity (Claude)
+        assert entities[0].index_name == "claude-test"
+        assert entities[0].label == "Claude Test"
+        assert entities[0].model_provider == "anthropic"
+
+        # Check second entity (GPT)
+        assert entities[1].index_name == "gpt-test"
+        assert entities[1].label == "GPT Test"
+        assert entities[1].model_provider == "openai"
+        assert entities[1].default_model == "gpt-4o"
+
+    def test_get_entities_invalid_json_fallback(self):
+        """Test get_entities falls back with invalid JSON."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            pinecone_index_name="fallback-index",
+            pinecone_indexes="invalid json [[[",
+            _env_file=None,
+        )
+
+        entities = settings.get_entities()
+
+        # Should fall back to single index
+        assert len(entities) == 1
+        assert entities[0].index_name == "fallback-index"
+
+    def test_get_entity_by_index_found(self, test_settings_multi_entity):
+        """Test get_entity_by_index when entity exists."""
+        entity = test_settings_multi_entity.get_entity_by_index("claude-test")
+
+        assert entity is not None
+        assert entity.index_name == "claude-test"
+        assert entity.label == "Claude Test"
+
+    def test_get_entity_by_index_not_found(self, test_settings_multi_entity):
+        """Test get_entity_by_index when entity doesn't exist."""
+        entity = test_settings_multi_entity.get_entity_by_index("nonexistent")
+
+        assert entity is None
+
+    def test_get_default_entity(self, test_settings_multi_entity):
+        """Test get_default_entity returns first entity."""
+        entity = test_settings_multi_entity.get_default_entity()
+
+        assert entity is not None
+        assert entity.index_name == "claude-test"
+
+    def test_get_default_model_for_provider_anthropic(self):
+        """Test get_default_model_for_provider for Anthropic."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            default_model="claude-3-opus-20240229",
+            _env_file=None,
+        )
+
+        model = settings.get_default_model_for_provider("anthropic")
+
+        assert model == "claude-3-opus-20240229"
+
+    def test_get_default_model_for_provider_openai(self):
+        """Test get_default_model_for_provider for OpenAI."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            default_openai_model="gpt-4-turbo",
+            _env_file=None,
+        )
+
+        model = settings.get_default_model_for_provider("openai")
+
+        assert model == "gpt-4-turbo"
+
+    def test_settings_database_url_alias(self):
+        """Test that database URL can be set via environment variable alias."""
+        import os
+        # Test using the HERE_I_AM_DATABASE_URL environment variable (the alias)
+        with patch.dict(os.environ, {"HERE_I_AM_DATABASE_URL": "postgresql+asyncpg://localhost/test"}):
+            settings = Settings(
+                anthropic_api_key="test-key",
+                _env_file=None,
+            )
+            assert settings.here_i_am_database_url == "postgresql+asyncpg://localhost/test"
+
+    def test_settings_memory_defaults(self):
+        """Test memory-related default settings."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            _env_file=None,
+        )
+
+        assert settings.recency_boost_strength == 1.0
+        assert settings.age_decay_rate == 0.01
+        assert settings.significance_floor == 0.0
+
+    def test_settings_reflection_defaults(self):
+        """Test reflection-related default settings."""
+        settings = Settings(
+            anthropic_api_key="test-key",
+            _env_file=None,
+        )
+
+        assert settings.reflection_seed_count == 7
+        assert settings.reflection_exclude_recent_conversations == 0

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for LLMService.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from app.services.llm_service import LLMService, ModelProvider, MODEL_PROVIDER_MAP, AVAILABLE_MODELS
+
+
+class TestModelProviderMapping:
+    """Tests for model to provider mapping."""
+
+    def test_claude_models_map_to_anthropic(self):
+        """Test that Claude models map to Anthropic provider."""
+        claude_models = [
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-20250514",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-haiku-20241022",
+            "claude-3-opus-20240229",
+        ]
+
+        for model in claude_models:
+            assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.ANTHROPIC
+
+    def test_gpt_models_map_to_openai(self):
+        """Test that GPT models map to OpenAI provider."""
+        gpt_models = ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"]
+
+        for model in gpt_models:
+            assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.OPENAI
+
+    def test_o1_models_map_to_openai(self):
+        """Test that o1 models map to OpenAI provider."""
+        o1_models = ["o1", "o1-mini", "o1-preview"]
+
+        for model in o1_models:
+            assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.OPENAI
+
+
+class TestLLMService:
+    """Tests for LLMService class."""
+
+    def test_get_provider_for_known_model(self):
+        """Test get_provider_for_model with known models."""
+        service = LLMService()
+
+        assert service.get_provider_for_model("claude-sonnet-4-20250514") == ModelProvider.ANTHROPIC
+        assert service.get_provider_for_model("gpt-4o") == ModelProvider.OPENAI
+
+    def test_get_provider_for_unknown_model(self):
+        """Test get_provider_for_model with unknown model."""
+        service = LLMService()
+
+        assert service.get_provider_for_model("unknown-model") is None
+
+    def test_is_provider_configured_anthropic(self):
+        """Test is_provider_configured for Anthropic."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "test-key"
+            assert service.is_provider_configured(ModelProvider.ANTHROPIC) is True
+
+            mock_settings.anthropic_api_key = ""
+            assert service.is_provider_configured(ModelProvider.ANTHROPIC) is False
+
+    def test_is_provider_configured_openai(self):
+        """Test is_provider_configured for OpenAI."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_openai.is_configured.return_value = True
+            assert service.is_provider_configured(ModelProvider.OPENAI) is True
+
+            mock_openai.is_configured.return_value = False
+            assert service.is_provider_configured(ModelProvider.OPENAI) is False
+
+    def test_get_available_providers_all_configured(self):
+        """Test get_available_providers when all providers configured."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_openai_model = "gpt-4o"
+            mock_openai.is_configured.return_value = True
+
+            providers = service.get_available_providers()
+
+            assert len(providers) == 2
+
+            anthropic_provider = next(p for p in providers if p["id"] == "anthropic")
+            assert anthropic_provider["name"] == "Anthropic"
+            assert len(anthropic_provider["models"]) > 0
+
+            openai_provider = next(p for p in providers if p["id"] == "openai")
+            assert openai_provider["name"] == "OpenAI"
+
+    def test_get_available_providers_only_anthropic(self):
+        """Test get_available_providers with only Anthropic configured."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_openai.is_configured.return_value = False
+
+            providers = service.get_available_providers()
+
+            assert len(providers) == 1
+            assert providers[0]["id"] == "anthropic"
+
+    def test_get_all_available_models(self):
+        """Test get_all_available_models returns flat list."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_openai_model = "gpt-4o"
+            mock_openai.is_configured.return_value = True
+
+            models = service.get_all_available_models()
+
+            # Should have models from both providers
+            assert len(models) > 0
+
+            # Each model should have provider info
+            for model in models:
+                assert "id" in model
+                assert "name" in model
+                assert "provider" in model
+                assert "provider_name" in model
+
+    def test_count_tokens(self):
+        """Test count_tokens delegates to anthropic_service."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.anthropic_service") as mock_anthropic:
+            mock_anthropic.count_tokens.return_value = 42
+
+            result = service.count_tokens("Hello, world!")
+
+            mock_anthropic.count_tokens.assert_called_once_with("Hello, world!")
+            assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_send_message_routes_to_anthropic(self):
+        """Test send_message routes Claude models to Anthropic."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.anthropic_service") as mock_anthropic:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_anthropic.send_message = AsyncMock(return_value={
+                "content": "Response",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "stop_reason": "end_turn",
+            })
+
+            messages = [{"role": "user", "content": "Hello"}]
+            result = await service.send_message(messages, model="claude-sonnet-4-20250514")
+
+            mock_anthropic.send_message.assert_called_once()
+            assert result["content"] == "Response"
+
+    @pytest.mark.asyncio
+    async def test_send_message_routes_to_openai(self):
+        """Test send_message routes GPT models to OpenAI."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_openai.is_configured.return_value = True
+            mock_openai.send_message = AsyncMock(return_value={
+                "content": "Response",
+                "model": "gpt-4o",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "stop_reason": "stop",
+            })
+
+            messages = [{"role": "user", "content": "Hello"}]
+            result = await service.send_message(messages, model="gpt-4o")
+
+            mock_openai.send_message.assert_called_once()
+            assert result["content"] == "Response"
+
+    @pytest.mark.asyncio
+    async def test_send_message_infers_anthropic_from_name(self):
+        """Test send_message infers Anthropic from model name prefix."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.anthropic_service") as mock_anthropic:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_anthropic.send_message = AsyncMock(return_value={
+                "content": "Response",
+                "model": "claude-unknown-version",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "stop_reason": "end_turn",
+            })
+
+            messages = [{"role": "user", "content": "Hello"}]
+            # Use unknown Claude model that's not in the map
+            result = await service.send_message(messages, model="claude-unknown-version")
+
+            mock_anthropic.send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_message_infers_openai_from_name(self):
+        """Test send_message infers OpenAI from model name prefix."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.openai_service") as mock_openai:
+            mock_openai.is_configured.return_value = True
+            mock_openai.send_message = AsyncMock(return_value={
+                "content": "Response",
+                "model": "gpt-5-preview",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "stop_reason": "stop",
+            })
+
+            messages = [{"role": "user", "content": "Hello"}]
+            result = await service.send_message(messages, model="gpt-5-preview")
+
+            mock_openai.send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_message_unknown_model_raises(self):
+        """Test send_message raises for unknown model."""
+        service = LLMService()
+
+        messages = [{"role": "user", "content": "Hello"}]
+
+        with pytest.raises(ValueError, match="Unknown model"):
+            await service.send_message(messages, model="unknown-model-xyz")
+
+    @pytest.mark.asyncio
+    async def test_send_message_unconfigured_provider_raises(self):
+        """Test send_message raises for unconfigured provider."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = ""
+
+            messages = [{"role": "user", "content": "Hello"}]
+
+            with pytest.raises(ValueError, match="not configured"):
+                await service.send_message(messages, model="claude-sonnet-4-20250514")
+
+    def test_build_messages_with_memories(self, sample_memories, sample_conversation_context):
+        """Test build_messages_with_memories delegates to anthropic_service."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.anthropic_service") as mock_anthropic:
+            mock_anthropic.build_messages_with_memories.return_value = [
+                {"role": "user", "content": "Memory block"},
+            ]
+
+            result = service.build_messages_with_memories(
+                sample_memories,
+                sample_conversation_context,
+                "Current message",
+            )
+
+            mock_anthropic.build_messages_with_memories.assert_called_once_with(
+                memories=sample_memories,
+                conversation_context=sample_conversation_context,
+                current_message="Current message",
+            )
+
+
+class TestAvailableModels:
+    """Tests for available models configuration."""
+
+    def test_anthropic_models_defined(self):
+        """Test that Anthropic models are defined."""
+        models = AVAILABLE_MODELS[ModelProvider.ANTHROPIC]
+
+        assert len(models) > 0
+
+        model_ids = [m["id"] for m in models]
+        assert "claude-sonnet-4-20250514" in model_ids
+
+    def test_openai_models_defined(self):
+        """Test that OpenAI models are defined."""
+        models = AVAILABLE_MODELS[ModelProvider.OPENAI]
+
+        assert len(models) > 0
+
+        model_ids = [m["id"] for m in models]
+        assert "gpt-4o" in model_ids
+
+    def test_all_models_have_required_fields(self):
+        """Test that all models have required id and name fields."""
+        for provider, models in AVAILABLE_MODELS.items():
+            for model in models:
+                assert "id" in model
+                assert "name" in model
+                assert isinstance(model["id"], str)
+                assert isinstance(model["name"], str)

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -1,0 +1,468 @@
+"""
+Unit tests for MemoryService.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import datetime
+import uuid
+
+from app.services.memory_service import MemoryService
+from app.models import Message, MessageRole, ConversationMemoryLink
+
+
+class TestMemoryServiceConfiguration:
+    """Tests for MemoryService configuration."""
+
+    def test_is_configured_without_pinecone_key(self):
+        """Test is_configured returns False without API key."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""
+
+            service = MemoryService()
+            assert service.is_configured() is False
+
+    def test_is_configured_with_pinecone_key(self):
+        """Test is_configured returns True with API key."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_entity_by_index.return_value = MagicMock()
+
+            service = MemoryService()
+            # is_configured() without entity_id just checks API key
+            assert service.is_configured() is True
+
+    def test_is_configured_with_entity_id(self):
+        """Test is_configured checks entity existence."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_entity_by_index.return_value = MagicMock()
+
+            service = MemoryService()
+            assert service.is_configured("valid-entity") is True
+
+            mock_settings.get_entity_by_index.return_value = None
+            assert service.is_configured("invalid-entity") is False
+
+    def test_pc_lazy_initialization(self):
+        """Test Pinecone client is lazily initialized."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""
+
+            service = MemoryService()
+            assert service._pc is None
+            assert service.pc is None  # Still None without key
+
+    def test_get_index_caching(self, mock_pinecone_index):
+        """Test that indexes are cached."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            mock_pc = MagicMock()
+            mock_pc.Index.return_value = mock_pinecone_index
+            service._pc = mock_pc
+
+            # First call should create index
+            index1 = service.get_index("test-index")
+            # Second call should return cached
+            index2 = service.get_index("test-index")
+
+            assert index1 is index2
+            mock_pc.Index.assert_called_once_with("test-index")
+
+
+class TestMemoryServiceEmbeddings:
+    """Tests for embedding generation."""
+
+    @pytest.mark.asyncio
+    async def test_get_embedding_success(self):
+        """Test successful embedding generation."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "test-key"
+
+            service = MemoryService()
+
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            embedding = await service.get_embedding("Test text")
+
+            assert embedding is not None
+            assert len(embedding) == 1024
+            mock_anthropic.embeddings.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_embedding_truncates_long_text(self):
+        """Test that long text is truncated."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "test-key"
+
+            service = MemoryService()
+
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            long_text = "x" * 10000
+            await service.get_embedding(long_text)
+
+            # Verify truncated text was passed
+            call_args = mock_anthropic.embeddings.create.call_args.kwargs
+            assert len(call_args["input"][0]) == 8000
+
+    @pytest.mark.asyncio
+    async def test_get_embedding_failure_returns_none(self):
+        """Test that embedding failure returns None gracefully."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "test-key"
+
+            service = MemoryService()
+
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(side_effect=Exception("API error"))
+            service._anthropic = mock_anthropic
+
+            embedding = await service.get_embedding("Test text")
+
+            assert embedding is None
+
+
+class TestMemoryServiceStorage:
+    """Tests for memory storage."""
+
+    @pytest.mark.asyncio
+    async def test_store_memory_success(self, mock_pinecone_index):
+        """Test successful memory storage."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding generation
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            result = await service.store_memory(
+                message_id="msg-123",
+                conversation_id="conv-456",
+                role="assistant",
+                content="This is a test memory.",
+                created_at=datetime.utcnow(),
+            )
+
+            assert result is True
+            mock_pinecone_index.upsert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_store_memory_not_configured(self):
+        """Test store_memory returns False when not configured."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""
+
+            service = MemoryService()
+
+            result = await service.store_memory(
+                message_id="msg-123",
+                conversation_id="conv-456",
+                role="assistant",
+                content="This is a test memory.",
+                created_at=datetime.utcnow(),
+            )
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_store_memory_embedding_failure(self, mock_pinecone_index):
+        """Test store_memory handles embedding failure."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding failure
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(side_effect=Exception("API error"))
+            service._anthropic = mock_anthropic
+
+            result = await service.store_memory(
+                message_id="msg-123",
+                conversation_id="conv-456",
+                role="assistant",
+                content="This is a test memory.",
+                created_at=datetime.utcnow(),
+            )
+
+            assert result is False
+
+
+class TestMemoryServiceSearch:
+    """Tests for memory search."""
+
+    @pytest.mark.asyncio
+    async def test_search_memories_success(self, mock_pinecone_index):
+        """Test successful memory search."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.retrieval_top_k = 5
+            mock_settings.similarity_threshold = 0.7
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding generation
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            results = await service.search_memories("What did we discuss?")
+
+            assert len(results) == 1
+            assert results[0]["id"] == "test-memory-id"
+            assert results[0]["score"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_search_memories_filters_low_score(self, mock_pinecone_index):
+        """Test that low score results are filtered."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.retrieval_top_k = 5
+            mock_settings.similarity_threshold = 0.95  # High threshold
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+
+            # Create match with score below threshold
+            mock_match = MagicMock()
+            mock_match.id = "low-score-memory"
+            mock_match.score = 0.8  # Below 0.95 threshold
+            mock_match.metadata = {"conversation_id": "conv-1", "created_at": "2024-01-01"}
+
+            mock_query_result = MagicMock()
+            mock_query_result.matches = [mock_match]
+            mock_pinecone_index.query = MagicMock(return_value=mock_query_result)
+
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            results = await service.search_memories("Query")
+
+            # Result should be filtered out
+            assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_memories_excludes_current_conversation(self, mock_pinecone_index):
+        """Test that current conversation is excluded from results."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.retrieval_top_k = 5
+            mock_settings.similarity_threshold = 0.7
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+
+            # Create match from current conversation
+            mock_match = MagicMock()
+            mock_match.id = "current-conv-memory"
+            mock_match.score = 0.9
+            mock_match.metadata = {
+                "conversation_id": "current-conv-id",
+                "created_at": "2024-01-01",
+            }
+
+            mock_query_result = MagicMock()
+            mock_query_result.matches = [mock_match]
+            mock_pinecone_index.query = MagicMock(return_value=mock_query_result)
+
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            results = await service.search_memories(
+                "Query",
+                exclude_conversation_id="current-conv-id"
+            )
+
+            # Result should be excluded
+            assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_memories_excludes_ids(self, mock_pinecone_index):
+        """Test that specified IDs are excluded from results."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.retrieval_top_k = 5
+            mock_settings.similarity_threshold = 0.7
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            service._indexes["default"] = mock_pinecone_index
+
+            # Mock embedding
+            mock_response = MagicMock()
+            mock_response.data = [MagicMock(embedding=[0.1] * 1024)]
+            mock_anthropic = MagicMock()
+            mock_anthropic.embeddings.create = AsyncMock(return_value=mock_response)
+            service._anthropic = mock_anthropic
+
+            results = await service.search_memories(
+                "Query",
+                exclude_ids={"test-memory-id"}  # Exclude the mock match
+            )
+
+            # Result should be excluded
+            assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_memories_not_configured(self):
+        """Test search returns empty when not configured."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""
+
+            service = MemoryService()
+            results = await service.search_memories("Query")
+
+            assert results == []
+
+
+class TestMemoryServiceDatabase:
+    """Tests for database operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_full_memory_content(self, db_session, sample_conversation, sample_messages):
+        """Test getting full memory content from database."""
+        service = MemoryService()
+        message = sample_messages[0]
+
+        result = await service.get_full_memory_content(message.id, db_session)
+
+        assert result is not None
+        assert result["id"] == message.id
+        assert result["content"] == message.content
+        assert result["role"] == message.role.value
+
+    @pytest.mark.asyncio
+    async def test_get_full_memory_content_not_found(self, db_session):
+        """Test getting non-existent memory returns None."""
+        service = MemoryService()
+
+        result = await service.get_full_memory_content("nonexistent-id", db_session)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_retrieved_ids_for_conversation(self, db_session, sample_conversation, sample_messages):
+        """Test getting retrieved memory IDs for conversation."""
+        service = MemoryService()
+
+        # Create some memory links
+        for msg in sample_messages:
+            link = ConversationMemoryLink(
+                conversation_id=sample_conversation.id,
+                message_id=msg.id,
+            )
+            db_session.add(link)
+        await db_session.commit()
+
+        result = await service.get_retrieved_ids_for_conversation(
+            sample_conversation.id,
+            db_session
+        )
+
+        assert len(result) == 2
+        assert all(msg.id in result for msg in sample_messages)
+
+    @pytest.mark.asyncio
+    async def test_get_retrieved_ids_empty(self, db_session, sample_conversation):
+        """Test getting retrieved IDs when none exist."""
+        service = MemoryService()
+
+        result = await service.get_retrieved_ids_for_conversation(
+            sample_conversation.id,
+            db_session
+        )
+
+        assert result == set()
+
+
+class TestMemoryServiceRetrievalCount:
+    """Tests for retrieval count updates."""
+
+    @pytest.mark.asyncio
+    async def test_update_retrieval_count_sql(self, db_session, sample_conversation, sample_messages):
+        """Test updating retrieval count in SQL."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""  # No Pinecone for this test
+
+            service = MemoryService()
+            message = sample_messages[0]
+            initial_count = message.times_retrieved
+
+            await service.update_retrieval_count(
+                message.id,
+                sample_conversation.id,
+                db_session,
+            )
+
+            await db_session.refresh(message)
+            assert message.times_retrieved == initial_count + 1
+            assert message.last_retrieved_at is not None
+
+
+class TestMemoryServiceDelete:
+    """Tests for memory deletion."""
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_success(self, mock_pinecone_index):
+        """Test successful memory deletion."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+            service._indexes["default"] = mock_pinecone_index
+
+            result = await service.delete_memory("msg-123")
+
+            assert result is True
+            mock_pinecone_index.delete.assert_called_once_with(ids=["msg-123"])
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_not_configured(self):
+        """Test delete returns False when not configured."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = ""
+
+            service = MemoryService()
+
+            result = await service.delete_memory("msg-123")
+
+            assert result is False

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,306 @@
+"""
+Unit tests for SQLAlchemy models.
+"""
+import pytest
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+
+from app.models import (
+    Conversation,
+    Message,
+    ConversationMemoryLink,
+    ConversationType,
+    MessageRole,
+)
+
+
+class TestConversationModel:
+    """Tests for Conversation model."""
+
+    async def test_create_conversation(self, db_session):
+        """Test creating a new conversation."""
+        conversation_id = str(uuid.uuid4())
+        conversation = Conversation(
+            id=conversation_id,
+            title="Test Conversation",
+            conversation_type=ConversationType.NORMAL,
+            model_used="claude-sonnet-4-20250514",
+        )
+        db_session.add(conversation)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(Conversation).where(Conversation.id == conversation_id)
+        )
+        saved = result.scalar_one()
+
+        assert saved.id == conversation_id
+        assert saved.title == "Test Conversation"
+        assert saved.conversation_type == ConversationType.NORMAL
+        assert saved.model_used == "claude-sonnet-4-20250514"
+        assert saved.created_at is not None
+
+    async def test_conversation_default_values(self, db_session):
+        """Test conversation default values."""
+        conversation = Conversation()
+        db_session.add(conversation)
+        await db_session.commit()
+
+        assert conversation.id is not None
+        assert conversation.conversation_type == ConversationType.NORMAL
+        assert conversation.model_used == "claude-sonnet-4-20250514"
+        assert conversation.created_at is not None
+        assert conversation.title is None
+        assert conversation.system_prompt_used is None
+        assert conversation.entity_id is None
+
+    async def test_conversation_with_entity_id(self, db_session):
+        """Test conversation with entity_id set."""
+        conversation = Conversation(
+            title="Entity Test",
+            entity_id="claude-main",
+        )
+        db_session.add(conversation)
+        await db_session.commit()
+
+        assert conversation.entity_id == "claude-main"
+
+    async def test_conversation_reflection_type(self, db_session):
+        """Test conversation with reflection type."""
+        conversation = Conversation(
+            conversation_type=ConversationType.REFLECTION,
+        )
+        db_session.add(conversation)
+        await db_session.commit()
+
+        assert conversation.conversation_type == ConversationType.REFLECTION
+
+    async def test_conversation_with_tags(self, db_session):
+        """Test conversation with JSON tags."""
+        conversation = Conversation(
+            tags={"topic": "testing", "priority": "high"},
+        )
+        db_session.add(conversation)
+        await db_session.commit()
+        await db_session.refresh(conversation)
+
+        assert conversation.tags == {"topic": "testing", "priority": "high"}
+
+    async def test_conversation_with_notes(self, db_session):
+        """Test conversation with notes."""
+        conversation = Conversation(
+            notes="This is a test note for the conversation.",
+        )
+        db_session.add(conversation)
+        await db_session.commit()
+
+        assert conversation.notes == "This is a test note for the conversation."
+
+
+class TestMessageModel:
+    """Tests for Message model."""
+
+    async def test_create_message(self, db_session, sample_conversation):
+        """Test creating a new message."""
+        message_id = str(uuid.uuid4())
+        message = Message(
+            id=message_id,
+            conversation_id=sample_conversation.id,
+            role=MessageRole.HUMAN,
+            content="Hello, world!",
+            token_count=3,
+        )
+        db_session.add(message)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(Message).where(Message.id == message_id)
+        )
+        saved = result.scalar_one()
+
+        assert saved.id == message_id
+        assert saved.conversation_id == sample_conversation.id
+        assert saved.role == MessageRole.HUMAN
+        assert saved.content == "Hello, world!"
+        assert saved.token_count == 3
+
+    async def test_message_roles(self, db_session, sample_conversation):
+        """Test all message roles."""
+        for role in [MessageRole.HUMAN, MessageRole.ASSISTANT, MessageRole.SYSTEM]:
+            message = Message(
+                conversation_id=sample_conversation.id,
+                role=role,
+                content=f"Message with role {role.value}",
+            )
+            db_session.add(message)
+            await db_session.commit()
+            await db_session.refresh(message)
+
+            assert message.role == role
+
+    async def test_message_memory_tracking_defaults(self, db_session, sample_conversation):
+        """Test message memory tracking default values."""
+        message = Message(
+            conversation_id=sample_conversation.id,
+            role=MessageRole.ASSISTANT,
+            content="Test message",
+        )
+        db_session.add(message)
+        await db_session.commit()
+
+        assert message.times_retrieved == 0
+        assert message.last_retrieved_at is None
+
+    async def test_message_memory_tracking_update(self, db_session, sample_conversation):
+        """Test updating message memory tracking."""
+        message = Message(
+            conversation_id=sample_conversation.id,
+            role=MessageRole.ASSISTANT,
+            content="Test message",
+        )
+        db_session.add(message)
+        await db_session.commit()
+
+        # Update tracking
+        message.times_retrieved = 5
+        message.last_retrieved_at = datetime.utcnow()
+        await db_session.commit()
+        await db_session.refresh(message)
+
+        assert message.times_retrieved == 5
+        assert message.last_retrieved_at is not None
+
+    async def test_message_relationship_to_conversation(self, db_session, sample_conversation):
+        """Test message relationship to conversation."""
+        message = Message(
+            conversation_id=sample_conversation.id,
+            role=MessageRole.HUMAN,
+            content="Test relationship",
+        )
+        db_session.add(message)
+        await db_session.commit()
+        await db_session.refresh(message)
+
+        # Access the relationship
+        assert message.conversation is not None
+        assert message.conversation.id == sample_conversation.id
+
+
+class TestConversationMemoryLinkModel:
+    """Tests for ConversationMemoryLink model."""
+
+    async def test_create_memory_link(self, db_session, sample_conversation, sample_messages):
+        """Test creating a memory link."""
+        message = sample_messages[0]
+        link = ConversationMemoryLink(
+            conversation_id=sample_conversation.id,
+            message_id=message.id,
+        )
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+
+        assert link.id is not None
+        assert link.conversation_id == sample_conversation.id
+        assert link.message_id == message.id
+        assert link.retrieved_at is not None
+
+    async def test_multiple_memory_links_same_conversation(self, db_session, sample_conversation, sample_messages):
+        """Test multiple memory links for the same conversation."""
+        links = []
+        for msg in sample_messages:
+            link = ConversationMemoryLink(
+                conversation_id=sample_conversation.id,
+                message_id=msg.id,
+            )
+            db_session.add(link)
+            links.append(link)
+        await db_session.commit()
+
+        result = await db_session.execute(
+            select(ConversationMemoryLink).where(
+                ConversationMemoryLink.conversation_id == sample_conversation.id
+            )
+        )
+        saved_links = result.scalars().all()
+
+        assert len(saved_links) == 2
+
+    async def test_memory_link_relationships(self, db_session, sample_conversation, sample_messages):
+        """Test memory link relationships."""
+        message = sample_messages[0]
+        link = ConversationMemoryLink(
+            conversation_id=sample_conversation.id,
+            message_id=message.id,
+        )
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+
+        # Access relationships
+        assert link.conversation is not None
+        assert link.message is not None
+        assert link.conversation.id == sample_conversation.id
+        assert link.message.id == message.id
+
+
+class TestCascadeDeletes:
+    """Tests for cascade delete behavior."""
+
+    async def test_delete_conversation_cascades_to_messages(self, db_session, sample_conversation, sample_messages):
+        """Test that deleting a conversation deletes its messages."""
+        conversation_id = sample_conversation.id
+        message_ids = [m.id for m in sample_messages]
+
+        # Verify messages exist
+        for msg_id in message_ids:
+            result = await db_session.execute(
+                select(Message).where(Message.id == msg_id)
+            )
+            assert result.scalar_one_or_none() is not None
+
+        # Delete conversation
+        await db_session.delete(sample_conversation)
+        await db_session.commit()
+
+        # Verify messages are deleted
+        for msg_id in message_ids:
+            result = await db_session.execute(
+                select(Message).where(Message.id == msg_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+    async def test_delete_conversation_cascades_to_memory_links(
+        self, db_session, sample_conversation, sample_messages
+    ):
+        """Test that deleting a conversation deletes its memory links."""
+        # Create memory links
+        for msg in sample_messages:
+            link = ConversationMemoryLink(
+                conversation_id=sample_conversation.id,
+                message_id=msg.id,
+            )
+            db_session.add(link)
+        await db_session.commit()
+
+        # Verify links exist
+        result = await db_session.execute(
+            select(ConversationMemoryLink).where(
+                ConversationMemoryLink.conversation_id == sample_conversation.id
+            )
+        )
+        assert len(result.scalars().all()) == 2
+
+        # Delete conversation
+        await db_session.delete(sample_conversation)
+        await db_session.commit()
+
+        # Verify links are deleted
+        result = await db_session.execute(
+            select(ConversationMemoryLink).where(
+                ConversationMemoryLink.conversation_id == sample_conversation.id
+            )
+        )
+        assert len(result.scalars().all()) == 0

--- a/backend/tests/test_openai_service.py
+++ b/backend/tests/test_openai_service.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for OpenAIService.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from app.services.openai_service import OpenAIService
+
+
+class TestOpenAIService:
+    """Tests for OpenAIService class."""
+
+    def test_is_configured_true(self):
+        """Test is_configured returns True when API key is set."""
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.openai_api_key = "test-key"
+            service = OpenAIService()
+
+            assert service.is_configured() is True
+
+    def test_is_configured_false(self):
+        """Test is_configured returns False when API key is not set."""
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.openai_api_key = ""
+            service = OpenAIService()
+
+            assert service.is_configured() is False
+
+    def test_ensure_client_raises_without_key(self):
+        """Test _ensure_client raises error without API key."""
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.openai_api_key = ""
+            service = OpenAIService()
+
+            with pytest.raises(ValueError, match="OpenAI API key not configured"):
+                service._ensure_client()
+
+    def test_count_tokens(self):
+        """Test token counting."""
+        service = OpenAIService()
+
+        # Mock the encoder to avoid network call
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = [1, 2, 3, 4]  # 4 tokens
+        service._encoder = mock_encoder
+
+        count = service.count_tokens("Hello, world!")
+
+        assert isinstance(count, int)
+        assert count == 4
+        mock_encoder.encode.assert_called_once_with("Hello, world!")
+
+    def test_count_tokens_empty_string(self):
+        """Test token counting for empty string."""
+        service = OpenAIService()
+
+        # Mock the encoder
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = []  # 0 tokens
+        service._encoder = mock_encoder
+
+        count = service.count_tokens("")
+
+        assert count == 0
+
+    def test_encoder_lazy_initialization(self):
+        """Test that encoder is lazily initialized."""
+        service = OpenAIService()
+
+        # Before accessing, _encoder should be None
+        assert service._encoder is None
+
+        # Mock tiktoken to avoid network call
+        with patch("app.services.openai_service.tiktoken") as mock_tiktoken:
+            mock_encoder = MagicMock()
+            mock_tiktoken.get_encoding.return_value = mock_encoder
+
+            # After accessing, encoder should be initialized
+            _ = service.encoder
+            assert service._encoder is mock_encoder
+            mock_tiktoken.get_encoding.assert_called_once_with("cl100k_base")
+
+    @pytest.mark.asyncio
+    async def test_send_message_basic(self, mock_openai_client):
+        """Test basic message sending."""
+        service = OpenAIService()
+        service.client = mock_openai_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.default_openai_model = "gpt-4o"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            response = await service.send_message(messages)
+
+        assert response["content"] == "This is a test response from GPT."
+        assert response["model"] == "gpt-4o"
+        assert "usage" in response
+        assert response["usage"]["input_tokens"] == 100
+        assert response["usage"]["output_tokens"] == 50
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_system_prompt(self, mock_openai_client):
+        """Test message sending with system prompt."""
+        service = OpenAIService()
+        service.client = mock_openai_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.default_openai_model = "gpt-4o"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            await service.send_message(
+                messages,
+                system_prompt="You are a helpful assistant.",
+            )
+
+        # Verify API call includes system message
+        call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+        api_messages = call_kwargs["messages"]
+        assert api_messages[0]["role"] == "system"
+        assert api_messages[0]["content"] == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_send_message_custom_parameters(self, mock_openai_client):
+        """Test message sending with custom parameters."""
+        service = OpenAIService()
+        service.client = mock_openai_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        with patch("app.services.openai_service.settings") as mock_settings:
+            mock_settings.default_openai_model = "gpt-4o"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            await service.send_message(
+                messages,
+                model="gpt-4-turbo",
+                temperature=0.5,
+                max_tokens=2000,
+            )
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-4-turbo"
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 2000
+
+    def test_build_messages_with_memories_no_memories(self):
+        """Test building messages without memories."""
+        service = OpenAIService()
+
+        memories = []
+        context = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        current = "How are you?"
+
+        messages = service.build_messages_with_memories(memories, context, current)
+
+        # Should have context + current message
+        assert len(messages) == 3
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "Hi"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "How are you?"
+
+    def test_build_messages_with_memories(self, sample_memories):
+        """Test building messages with memories."""
+        service = OpenAIService()
+
+        context = []
+        current = "What do you remember?"
+
+        messages = service.build_messages_with_memories(sample_memories, context, current)
+
+        # Should have: memory block, acknowledgment, current message
+        assert len(messages) == 3
+
+        # First message should contain memory block
+        assert messages[0]["role"] == "user"
+        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in messages[0]["content"]
+
+        # Second message should be acknowledgment
+        assert messages[1]["role"] == "assistant"
+
+        # Third message should be current message
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "What do you remember?"
+
+    def test_build_messages_format_same_as_anthropic(self, sample_memories, sample_conversation_context):
+        """Test that OpenAI uses same format as Anthropic."""
+        from app.services.anthropic_service import AnthropicService
+
+        openai_service = OpenAIService()
+        anthropic_service = AnthropicService()
+
+        current = "Test message"
+
+        openai_messages = openai_service.build_messages_with_memories(
+            sample_memories, sample_conversation_context, current
+        )
+        anthropic_messages = anthropic_service.build_messages_with_memories(
+            sample_memories, sample_conversation_context, current
+        )
+
+        # Both should produce the same structure
+        assert len(openai_messages) == len(anthropic_messages)
+
+        for i, (openai_msg, anthropic_msg) in enumerate(zip(openai_messages, anthropic_messages)):
+            assert openai_msg["role"] == anthropic_msg["role"]
+            assert openai_msg["content"] == anthropic_msg["content"]

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -1,0 +1,481 @@
+"""
+Unit tests for SessionManager.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import datetime
+import uuid
+
+from app.services.session_manager import SessionManager, ConversationSession, MemoryEntry
+from app.models import Conversation, Message, MessageRole, ConversationType
+
+
+class TestMemoryEntry:
+    """Tests for MemoryEntry dataclass."""
+
+    def test_memory_entry_creation(self):
+        """Test creating a MemoryEntry."""
+        entry = MemoryEntry(
+            id="mem-123",
+            conversation_id="conv-456",
+            role="assistant",
+            content="Test content",
+            created_at="2024-01-01T12:00:00",
+            times_retrieved=5,
+            score=0.95,
+        )
+
+        assert entry.id == "mem-123"
+        assert entry.conversation_id == "conv-456"
+        assert entry.role == "assistant"
+        assert entry.content == "Test content"
+        assert entry.times_retrieved == 5
+        assert entry.score == 0.95
+
+    def test_memory_entry_default_score(self):
+        """Test MemoryEntry default score."""
+        entry = MemoryEntry(
+            id="mem-123",
+            conversation_id="conv-456",
+            role="assistant",
+            content="Test content",
+            created_at="2024-01-01",
+            times_retrieved=0,
+        )
+
+        assert entry.score == 0.0
+
+
+class TestConversationSession:
+    """Tests for ConversationSession dataclass."""
+
+    def test_session_creation(self):
+        """Test creating a ConversationSession."""
+        session = ConversationSession(
+            conversation_id="conv-123",
+            model="claude-sonnet-4-20250514",
+            temperature=0.8,
+            max_tokens=2000,
+            system_prompt="You are helpful.",
+            entity_id="test-entity",
+        )
+
+        assert session.conversation_id == "conv-123"
+        assert session.model == "claude-sonnet-4-20250514"
+        assert session.temperature == 0.8
+        assert session.max_tokens == 2000
+        assert session.system_prompt == "You are helpful."
+        assert session.entity_id == "test-entity"
+        assert session.conversation_context == []
+        assert session.session_memories == {}
+        assert session.retrieved_ids == set()
+
+    def test_add_memory_new(self):
+        """Test adding a new memory."""
+        session = ConversationSession(conversation_id="conv-123")
+        memory = MemoryEntry(
+            id="mem-1",
+            conversation_id="old-conv",
+            role="assistant",
+            content="Test",
+            created_at="2024-01-01",
+            times_retrieved=1,
+        )
+
+        result = session.add_memory(memory)
+
+        assert result is True
+        assert "mem-1" in session.retrieved_ids
+        assert "mem-1" in session.session_memories
+        assert session.session_memories["mem-1"] == memory
+
+    def test_add_memory_duplicate(self):
+        """Test adding a duplicate memory is rejected."""
+        session = ConversationSession(conversation_id="conv-123")
+        memory = MemoryEntry(
+            id="mem-1",
+            conversation_id="old-conv",
+            role="assistant",
+            content="Test",
+            created_at="2024-01-01",
+            times_retrieved=1,
+        )
+
+        session.add_memory(memory)
+        result = session.add_memory(memory)
+
+        assert result is False
+        assert len(session.session_memories) == 1
+
+    def test_get_memories_for_injection_sorted(self):
+        """Test memories are sorted by score for injection."""
+        session = ConversationSession(conversation_id="conv-123")
+
+        # Add memories with different scores
+        for i, score in enumerate([0.5, 0.9, 0.7]):
+            memory = MemoryEntry(
+                id=f"mem-{i}",
+                conversation_id="old-conv",
+                role="assistant",
+                content=f"Content {i}",
+                created_at="2024-01-01",
+                times_retrieved=1,
+                score=score,
+            )
+            session.add_memory(memory)
+
+        memories = session.get_memories_for_injection()
+
+        # Should be sorted by score descending
+        assert len(memories) == 3
+        assert memories[0]["id"] == "mem-1"  # score 0.9
+        assert memories[1]["id"] == "mem-2"  # score 0.7
+        assert memories[2]["id"] == "mem-0"  # score 0.5
+
+    def test_get_memories_for_injection_format(self):
+        """Test memories are formatted correctly for injection."""
+        session = ConversationSession(conversation_id="conv-123")
+
+        memory = MemoryEntry(
+            id="mem-1",
+            conversation_id="old-conv",
+            role="assistant",
+            content="Test content",
+            created_at="2024-01-01",
+            times_retrieved=5,
+            score=0.9,
+        )
+        session.add_memory(memory)
+
+        memories = session.get_memories_for_injection()
+
+        assert len(memories) == 1
+        assert memories[0]["id"] == "mem-1"
+        assert memories[0]["content"] == "Test content"
+        assert memories[0]["created_at"] == "2024-01-01"
+        assert memories[0]["times_retrieved"] == 5
+        assert memories[0]["role"] == "assistant"
+
+    def test_add_exchange(self):
+        """Test adding a conversation exchange."""
+        session = ConversationSession(conversation_id="conv-123")
+
+        session.add_exchange("Hello!", "Hi there!")
+
+        assert len(session.conversation_context) == 2
+        assert session.conversation_context[0] == {"role": "user", "content": "Hello!"}
+        assert session.conversation_context[1] == {"role": "assistant", "content": "Hi there!"}
+
+
+class TestSessionManager:
+    """Tests for SessionManager class."""
+
+    def test_create_session(self):
+        """Test creating a new session."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.settings") as mock_settings:
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session("conv-123")
+
+        assert session.conversation_id == "conv-123"
+        assert "conv-123" in manager._sessions
+
+    def test_create_session_with_custom_params(self):
+        """Test creating a session with custom parameters."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.settings") as mock_settings:
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session(
+                conversation_id="conv-123",
+                model="claude-3-opus-20240229",
+                temperature=0.5,
+                max_tokens=2000,
+                system_prompt="Be helpful",
+                entity_id="custom-entity",
+            )
+
+        assert session.model == "claude-3-opus-20240229"
+        assert session.temperature == 0.5
+        assert session.max_tokens == 2000
+        assert session.system_prompt == "Be helpful"
+        assert session.entity_id == "custom-entity"
+
+    def test_create_session_uses_entity_default_model(self):
+        """Test session uses entity's default model."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.settings") as mock_settings:
+            mock_entity = MagicMock()
+            mock_entity.default_model = "gpt-4o"
+            mock_entity.model_provider = "openai"
+            mock_settings.get_entity_by_index.return_value = mock_entity
+            mock_settings.get_default_model_for_provider.return_value = "gpt-4o"
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session(
+                conversation_id="conv-123",
+                entity_id="gpt-entity",
+            )
+
+        assert session.model == "gpt-4o"
+
+    def test_get_session_exists(self):
+        """Test getting an existing session."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.settings") as mock_settings:
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            created = manager.create_session("conv-123")
+            retrieved = manager.get_session("conv-123")
+
+        assert retrieved is created
+
+    def test_get_session_not_exists(self):
+        """Test getting a non-existent session."""
+        manager = SessionManager()
+
+        result = manager.get_session("nonexistent")
+
+        assert result is None
+
+    def test_close_session(self):
+        """Test closing a session."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.settings") as mock_settings:
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            manager.create_session("conv-123")
+            assert "conv-123" in manager._sessions
+
+            manager.close_session("conv-123")
+            assert "conv-123" not in manager._sessions
+
+    def test_close_session_not_exists(self):
+        """Test closing a non-existent session doesn't error."""
+        manager = SessionManager()
+
+        # Should not raise
+        manager.close_session("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_load_session_from_db(self, db_session, sample_conversation, sample_messages):
+        """Test loading a session from the database."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+            mock_settings.get_entity_by_index.return_value = None
+
+            session = await manager.load_session_from_db(
+                sample_conversation.id,
+                db_session
+            )
+
+        assert session is not None
+        assert session.conversation_id == sample_conversation.id
+        assert session.model == sample_conversation.model_used
+        assert len(session.conversation_context) == 2  # Two sample messages
+
+    @pytest.mark.asyncio
+    async def test_load_session_from_db_not_found(self, db_session):
+        """Test loading a non-existent conversation returns None."""
+        manager = SessionManager()
+
+        session = await manager.load_session_from_db("nonexistent-id", db_session)
+
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_load_session_from_db_with_retrieved_memories(
+        self, db_session, sample_conversation, sample_messages
+    ):
+        """Test loading session includes previously retrieved memories."""
+        manager = SessionManager()
+
+        retrieved_id = sample_messages[0].id
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(
+                return_value={retrieved_id}
+            )
+            mock_memory.get_full_memory_content = AsyncMock(return_value={
+                "id": retrieved_id,
+                "conversation_id": "other-conv",
+                "role": "assistant",
+                "content": "Retrieved memory content",
+                "created_at": "2024-01-01T12:00:00",
+                "times_retrieved": 3,
+            })
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+            mock_settings.get_entity_by_index.return_value = None
+
+            session = await manager.load_session_from_db(
+                sample_conversation.id,
+                db_session
+            )
+
+        assert retrieved_id in session.retrieved_ids
+        assert retrieved_id in session.session_memories
+
+    @pytest.mark.asyncio
+    async def test_process_message_basic(self, db_session, sample_conversation):
+        """Test basic message processing."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.llm_service") as mock_llm, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.is_configured.return_value = False  # No memory retrieval
+            mock_llm.build_messages_with_memories.return_value = [
+                {"role": "user", "content": "Hello"}
+            ]
+            mock_llm.send_message = AsyncMock(return_value={
+                "content": "Hi there!",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+                "stop_reason": "end_turn",
+            })
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session(sample_conversation.id)
+            result = await manager.process_message(session, "Hello", db_session)
+
+        assert result["content"] == "Hi there!"
+        assert len(session.conversation_context) == 2  # User + assistant
+        assert session.conversation_context[0]["content"] == "Hello"
+        assert session.conversation_context[1]["content"] == "Hi there!"
+
+    @pytest.mark.asyncio
+    async def test_process_message_with_memory_retrieval(self, db_session, sample_conversation):
+        """Test message processing with memory retrieval."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.llm_service") as mock_llm, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            # Configure memory retrieval
+            mock_memory.is_configured.return_value = True
+            mock_memory.search_memories = AsyncMock(return_value=[
+                {
+                    "id": "mem-1",
+                    "score": 0.9,
+                    "conversation_id": "old-conv",
+                    "created_at": "2024-01-01",
+                    "role": "assistant",
+                }
+            ])
+            mock_memory.get_full_memory_content = AsyncMock(return_value={
+                "id": "mem-1",
+                "conversation_id": "old-conv",
+                "role": "assistant",
+                "content": "Previous memory content",
+                "created_at": "2024-01-01",
+                "times_retrieved": 2,
+            })
+            mock_memory.update_retrieval_count = AsyncMock()
+
+            mock_llm.build_messages_with_memories.return_value = [
+                {"role": "user", "content": "With memory context"}
+            ]
+            mock_llm.send_message = AsyncMock(return_value={
+                "content": "Response with memory",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 50, "output_tokens": 20},
+                "stop_reason": "end_turn",
+            })
+
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session(sample_conversation.id)
+            result = await manager.process_message(session, "Hello", db_session)
+
+        # Should have retrieved memories
+        assert len(result["new_memories_retrieved"]) == 1
+        assert result["new_memories_retrieved"][0]["id"] == "mem-1"
+        assert result["total_memories_in_context"] == 1
+
+        # Memory should be in session
+        assert "mem-1" in session.session_memories
+
+        # Update count should have been called
+        mock_memory.update_retrieval_count.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_message_deduplicates_memories(self, db_session, sample_conversation):
+        """Test that already-retrieved memories are not retrieved again."""
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.llm_service") as mock_llm, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.is_configured.return_value = True
+            mock_memory.search_memories = AsyncMock(return_value=[
+                {"id": "mem-1", "score": 0.9, "conversation_id": "old-conv"}
+            ])
+            mock_memory.get_full_memory_content = AsyncMock(return_value={
+                "id": "mem-1",
+                "conversation_id": "old-conv",
+                "role": "assistant",
+                "content": "Memory",
+                "created_at": "2024-01-01",
+                "times_retrieved": 1,
+            })
+            mock_memory.update_retrieval_count = AsyncMock()
+
+            mock_llm.build_messages_with_memories.return_value = []
+            mock_llm.send_message = AsyncMock(return_value={
+                "content": "Response",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+                "stop_reason": "end_turn",
+            })
+
+            mock_settings.default_model = "claude-sonnet-4-20250514"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 4096
+
+            session = manager.create_session(sample_conversation.id)
+
+            # First message should retrieve memory
+            await manager.process_message(session, "First", db_session)
+            assert mock_memory.update_retrieval_count.call_count == 1
+
+            # Second message - memory should be excluded
+            mock_memory.search_memories.reset_mock()
+            mock_memory.update_retrieval_count.reset_mock()
+
+            await manager.process_message(session, "Second", db_session)
+
+            # Search should have been called with exclude_ids
+            call_kwargs = mock_memory.search_memories.call_args.kwargs
+            assert "mem-1" in call_kwargs["exclude_ids"]
+
+            # Update count should NOT be called again for same memory
+            mock_memory.update_retrieval_count.assert_not_called()


### PR DESCRIPTION
- Set up pytest infrastructure with pytest.ini and conftest.py
- Add test fixtures for database, mock clients, and sample data
- Create 122 unit tests covering:
  - Models: Conversation, Message, ConversationMemoryLink
  - Config: Settings, EntityConfig
  - Services: AnthropicService, OpenAIService, LLMService, MemoryService, SessionManager
- Add testing dependencies (pytest, pytest-asyncio, pytest-cov) to requirements.txt
- All tests pass with proper mocking of external services (Anthropic, OpenAI, Pinecone)