### PR TITLE
Revert to dated model IDs (fix -latest alias issue)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ PINECONE_INDEX_NAME=memories
 
 # Multiple entities with different model providers (JSON array)
 PINECONE_INDEXES='[
-  {"index_name": "claude-main", "label": "Claude", "description": "Primary AI", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-latest"},
+  {"index_name": "claude-main", "label": "Claude", "description": "Primary AI", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"},
   {"index_name": "gpt-research", "label": "GPT Research", "description": "OpenAI for comparison", "model_provider": "openai", "default_model": "gpt-4o"}
 ]'
 ```
@@ -291,7 +291,7 @@ DEBUG=true                              # Development mode
 ```bash
 # To use multiple AI entities with separate memory spaces and different model providers:
 PINECONE_INDEXES='[
-  {"index_name": "claude-main", "label": "Claude", "description": "Primary AI", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-latest"},
+  {"index_name": "claude-main", "label": "Claude", "description": "Primary AI", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"},
   {"index_name": "gpt-research", "label": "GPT", "description": "OpenAI for comparison", "model_provider": "openai", "default_model": "gpt-4o"}
 ]'
 ```
@@ -345,7 +345,7 @@ python run.py
    def send_message(
        self,
        messages: List[Dict[str, str]],
-       model: str = "claude-sonnet-4-5-latest",
+       model: str = "claude-sonnet-4-5-20250929",
        temperature: float = 1.0
    ) -> Dict[str, Any]:
    ```
@@ -494,7 +494,7 @@ title: String (nullable)
 tags: JSON
 conversation_type: Enum (NORMAL, REFLECTION)
 system_prompt_used: Text (nullable)
-model_used: String (default: claude-sonnet-4-5-latest)
+model_used: String (default: claude-sonnet-4-5-20250929)
 notes: Text (nullable)
 entity_id: String (nullable)  # Pinecone index name for this conversation's AI entity
 
@@ -803,7 +803,7 @@ retrieved_at: DateTime
 
 ```python
 # Default models
-DEFAULT_MODEL = "claude-sonnet-4-5-latest"  # Anthropic default
+DEFAULT_MODEL = "claude-sonnet-4-5-20250929"  # Anthropic default
 DEFAULT_OPENAI_MODEL = "gpt-4o"  # OpenAI default
 
 # Memory settings (config.py)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,7 +19,7 @@ PINECONE_INDEX_NAME=memories
 #   - model_provider: "anthropic" or "openai" (default: "anthropic")
 #   - default_model: Model to use for this entity (optional, uses provider default if not set)
 # Example with different providers:
-# PINECONE_INDEXES='[{"index_name": "claude-main", "label": "Claude", "description": "Primary AI (Anthropic)", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-latest"}, {"index_name": "gpt-research", "label": "GPT Research", "description": "Research AI (OpenAI)", "model_provider": "openai", "default_model": "gpt-4o"}]'
+# PINECONE_INDEXES='[{"index_name": "claude-main", "label": "Claude", "description": "Primary AI (Anthropic)", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"}, {"index_name": "gpt-research", "label": "GPT Research", "description": "Research AI (OpenAI)", "model_provider": "openai", "default_model": "gpt-4o"}]'
 
 # Database URL (SQLite for development)
 HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     pinecone_index_name: str = "memories"  # Default/fallback index
 
     # Multiple Pinecone indexes (JSON array of objects with index_name, label, description, model_provider, default_model)
-    # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-latest"}]'
+    # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity", "model_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"}]'
     pinecone_indexes: str = ""
 
     # Database
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
     reflection_exclude_recent_conversations: int = 0
 
     # API defaults
-    default_model: str = "claude-sonnet-4-5-latest"  # Default Anthropic model
+    default_model: str = "claude-sonnet-4-5-20250929"  # Default Anthropic model
     default_openai_model: str = "gpt-4o"  # Default OpenAI model
     default_temperature: float = 1.0
     default_max_tokens: int = 4096

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -24,7 +24,7 @@ class Conversation(Base):
         SQLEnum(ConversationType), default=ConversationType.NORMAL
     )
     system_prompt_used: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    model_used: Mapped[str] = mapped_column(String(100), default="claude-sonnet-4-5-latest")
+    model_used: Mapped[str] = mapped_column(String(100), default="claude-sonnet-4-5-20250929")
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # Entity ID is the Pinecone index name for the AI entity this conversation belongs to
     # NULL means use the default entity (for backward compatibility)

--- a/backend/app/routes/conversations.py
+++ b/backend/app/routes/conversations.py
@@ -16,7 +16,7 @@ class ConversationCreate(BaseModel):
     tags: Optional[List[str]] = None
     conversation_type: str = "normal"
     system_prompt: Optional[str] = None
-    model: str = "claude-sonnet-4-5-latest"
+    model: str = "claude-sonnet-4-5-20250929"
     entity_id: Optional[str] = None  # Pinecone index name for the AI entity
 
 
@@ -76,7 +76,7 @@ class SeedConversationImport(BaseModel):
     tags: Optional[List[str]] = None
     conversation_type: str = "normal"
     system_prompt_used: Optional[str] = None
-    model_used: str = "claude-sonnet-4-5-latest"
+    model_used: str = "claude-sonnet-4-5-20250929"
     notes: Optional[str] = None
     entity_id: Optional[str] = None  # Pinecone index name for the AI entity
     messages: List[dict]  # List of {role: str, content: str, times_retrieved?: int}

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -22,12 +22,12 @@ class ModelProvider(str, Enum):
 # Model to provider mapping
 MODEL_PROVIDER_MAP = {
     # Anthropic Claude 4.5 models
-    "claude-sonnet-4-5-latest": ModelProvider.ANTHROPIC,
-    "claude-opus-4-5-latest": ModelProvider.ANTHROPIC,
-    "claude-haiku-4-5-latest": ModelProvider.ANTHROPIC,
+    "claude-sonnet-4-5-20250929": ModelProvider.ANTHROPIC,
+    "claude-opus-4-5-20251101": ModelProvider.ANTHROPIC,
+    "claude-haiku-4-5-20251001": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
-    "claude-sonnet-4-latest": ModelProvider.ANTHROPIC,
-    "claude-opus-4-latest": ModelProvider.ANTHROPIC,
+    "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
+    "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
     # OpenAI GPT models
     "gpt-4o": ModelProvider.OPENAI,
     "gpt-4o-mini": ModelProvider.OPENAI,
@@ -43,11 +43,11 @@ MODEL_PROVIDER_MAP = {
 # Available models by provider
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
-        {"id": "claude-sonnet-4-5-latest", "name": "Claude Sonnet 4.5"},
-        {"id": "claude-opus-4-5-latest", "name": "Claude Opus 4.5"},
-        {"id": "claude-haiku-4-5-latest", "name": "Claude Haiku 4.5"},
-        {"id": "claude-sonnet-4-latest", "name": "Claude Sonnet 4"},
-        {"id": "claude-opus-4-latest", "name": "Claude Opus 4"},
+        {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5"},
+        {"id": "claude-opus-4-5-20251101", "name": "Claude Opus 4.5"},
+        {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5"},
+        {"id": "claude-sonnet-4-20250514", "name": "Claude Sonnet 4"},
+        {"id": "claude-opus-4-20250514", "name": "Claude Opus 4"},
     ],
     ModelProvider.OPENAI: [
         {"id": "gpt-4o", "name": "GPT-4o"},

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -75,7 +75,7 @@ def test_settings():
         debug=False,
         retrieval_top_k=5,
         similarity_threshold=0.7,
-        default_model="claude-sonnet-4-5-latest",
+        default_model="claude-sonnet-4-5-20250929",
         default_openai_model="gpt-4o",
         default_temperature=1.0,
         default_max_tokens=4096,
@@ -124,7 +124,7 @@ async def sample_conversation(db_session, sample_conversation_id) -> Conversatio
         id=sample_conversation_id,
         title="Test Conversation",
         conversation_type=ConversationType.NORMAL,
-        model_used="claude-sonnet-4-5-latest",
+        model_used="claude-sonnet-4-5-20250929",
         entity_id="test-memories",
     )
     db_session.add(conversation)
@@ -168,7 +168,7 @@ def mock_anthropic_client():
     # Mock messages.create response
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text="This is a test response from Claude.")]
-    mock_response.model = "claude-sonnet-4-5-latest"
+    mock_response.model = "claude-sonnet-4-5-20250929"
     mock_response.usage.input_tokens = 100
     mock_response.usage.output_tokens = 50
     mock_response.stop_reason = "end_turn"

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -80,7 +80,7 @@ class TestAnthropicService:
         response = await service.send_message(messages)
 
         assert response["content"] == "This is a test response from Claude."
-        assert response["model"] == "claude-sonnet-4-5-latest"
+        assert response["model"] == "claude-sonnet-4-5-20250929"
         assert "usage" in response
         assert response["usage"]["input_tokens"] == 100
         assert response["usage"]["output_tokens"] == 50
@@ -123,13 +123,13 @@ class TestAnthropicService:
         messages = [{"role": "user", "content": "Hello!"}]
         await service.send_message(
             messages,
-            model="claude-opus-4-latest",
+            model="claude-opus-4-20250514",
             temperature=0.5,
             max_tokens=2000,
         )
 
         call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
-        assert call_kwargs["model"] == "claude-opus-4-latest"
+        assert call_kwargs["model"] == "claude-opus-4-20250514"
         assert call_kwargs["temperature"] == 0.5
         assert call_kwargs["max_tokens"] == 2000
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -16,14 +16,14 @@ class TestEntityConfig:
             label="Test Entity",
             description="A test entity",
             model_provider="anthropic",
-            default_model="claude-sonnet-4-5-latest",
+            default_model="claude-sonnet-4-5-20250929",
         )
 
         assert entity.index_name == "test-index"
         assert entity.label == "Test Entity"
         assert entity.description == "A test entity"
         assert entity.model_provider == "anthropic"
-        assert entity.default_model == "claude-sonnet-4-5-latest"
+        assert entity.default_model == "claude-sonnet-4-5-20250929"
 
     def test_entity_config_defaults(self):
         """Test EntityConfig default values."""
@@ -55,7 +55,7 @@ class TestEntityConfig:
             label="Test Entity",
             description="A test entity",
             model_provider="anthropic",
-            default_model="claude-sonnet-4-5-latest",
+            default_model="claude-sonnet-4-5-20250929",
         )
 
         result = entity.to_dict()
@@ -65,7 +65,7 @@ class TestEntityConfig:
             "label": "Test Entity",
             "description": "A test entity",
             "model_provider": "anthropic",
-            "default_model": "claude-sonnet-4-5-latest",
+            "default_model": "claude-sonnet-4-5-20250929",
         }
 
 
@@ -79,7 +79,7 @@ class TestSettings:
             _env_file=None,  # Disable .env loading for test
         )
 
-        assert settings.default_model == "claude-sonnet-4-5-latest"
+        assert settings.default_model == "claude-sonnet-4-5-20250929"
         assert settings.default_openai_model == "gpt-4o"
         assert settings.default_temperature == 1.0
         assert settings.default_max_tokens == 4096
@@ -166,13 +166,13 @@ class TestSettings:
         """Test get_default_model_for_provider for Anthropic."""
         settings = Settings(
             anthropic_api_key="test-key",
-            default_model="claude-opus-4-latest",
+            default_model="claude-opus-4-20250514",
             _env_file=None,
         )
 
         model = settings.get_default_model_for_provider("anthropic")
 
-        assert model == "claude-opus-4-latest"
+        assert model == "claude-opus-4-20250514"
 
     def test_get_default_model_for_provider_openai(self):
         """Test get_default_model_for_provider for OpenAI."""

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -13,11 +13,11 @@ class TestModelProviderMapping:
     def test_claude_models_map_to_anthropic(self):
         """Test that Claude models map to Anthropic provider."""
         claude_models = [
-            "claude-sonnet-4-5-latest",
-            "claude-opus-4-5-latest",
-            "claude-haiku-4-5-latest",
-            "claude-sonnet-4-latest",
-            "claude-opus-4-latest",
+            "claude-sonnet-4-5-20250929",
+            "claude-opus-4-5-20251101",
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-20250514",
         ]
 
         for model in claude_models:
@@ -45,7 +45,7 @@ class TestLLMService:
         """Test get_provider_for_model with known models."""
         service = LLMService()
 
-        assert service.get_provider_for_model("claude-sonnet-4-5-latest") == ModelProvider.ANTHROPIC
+        assert service.get_provider_for_model("claude-sonnet-4-5-20250929") == ModelProvider.ANTHROPIC
         assert service.get_provider_for_model("gpt-4o") == ModelProvider.OPENAI
 
     def test_get_provider_for_unknown_model(self):
@@ -83,7 +83,7 @@ class TestLLMService:
         with patch("app.services.llm_service.settings") as mock_settings, \
              patch("app.services.llm_service.openai_service") as mock_openai:
             mock_settings.anthropic_api_key = "test-key"
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_openai_model = "gpt-4o"
             mock_openai.is_configured.return_value = True
 
@@ -105,7 +105,7 @@ class TestLLMService:
         with patch("app.services.llm_service.settings") as mock_settings, \
              patch("app.services.llm_service.openai_service") as mock_openai:
             mock_settings.anthropic_api_key = "test-key"
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_openai.is_configured.return_value = False
 
             providers = service.get_available_providers()
@@ -120,7 +120,7 @@ class TestLLMService:
         with patch("app.services.llm_service.settings") as mock_settings, \
              patch("app.services.llm_service.openai_service") as mock_openai:
             mock_settings.anthropic_api_key = "test-key"
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_openai_model = "gpt-4o"
             mock_openai.is_configured.return_value = True
 
@@ -158,13 +158,13 @@ class TestLLMService:
             mock_settings.anthropic_api_key = "test-key"
             mock_anthropic.send_message = AsyncMock(return_value={
                 "content": "Response",
-                "model": "claude-sonnet-4-5-latest",
+                "model": "claude-sonnet-4-5-20250929",
                 "usage": {"input_tokens": 10, "output_tokens": 20},
                 "stop_reason": "end_turn",
             })
 
             messages = [{"role": "user", "content": "Hello"}]
-            result = await service.send_message(messages, model="claude-sonnet-4-5-latest")
+            result = await service.send_message(messages, model="claude-sonnet-4-5-20250929")
 
             mock_anthropic.send_message.assert_called_once()
             assert result["content"] == "Response"
@@ -250,7 +250,7 @@ class TestLLMService:
             messages = [{"role": "user", "content": "Hello"}]
 
             with pytest.raises(ValueError, match="not configured"):
-                await service.send_message(messages, model="claude-sonnet-4-5-latest")
+                await service.send_message(messages, model="claude-sonnet-4-5-20250929")
 
     def test_build_messages_with_memories(self, sample_memories, sample_conversation_context):
         """Test build_messages_with_memories delegates to anthropic_service."""
@@ -284,7 +284,7 @@ class TestAvailableModels:
         assert len(models) > 0
 
         model_ids = [m["id"] for m in models]
-        assert "claude-sonnet-4-5-latest" in model_ids
+        assert "claude-sonnet-4-5-20250929" in model_ids
 
     def test_openai_models_defined(self):
         """Test that OpenAI models are defined."""

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -26,7 +26,7 @@ class TestConversationModel:
             id=conversation_id,
             title="Test Conversation",
             conversation_type=ConversationType.NORMAL,
-            model_used="claude-sonnet-4-5-latest",
+            model_used="claude-sonnet-4-5-20250929",
         )
         db_session.add(conversation)
         await db_session.commit()
@@ -39,7 +39,7 @@ class TestConversationModel:
         assert saved.id == conversation_id
         assert saved.title == "Test Conversation"
         assert saved.conversation_type == ConversationType.NORMAL
-        assert saved.model_used == "claude-sonnet-4-5-latest"
+        assert saved.model_used == "claude-sonnet-4-5-20250929"
         assert saved.created_at is not None
 
     async def test_conversation_default_values(self, db_session):
@@ -50,7 +50,7 @@ class TestConversationModel:
 
         assert conversation.id is not None
         assert conversation.conversation_type == ConversationType.NORMAL
-        assert conversation.model_used == "claude-sonnet-4-5-latest"
+        assert conversation.model_used == "claude-sonnet-4-5-20250929"
         assert conversation.created_at is not None
         assert conversation.title is None
         assert conversation.system_prompt_used is None

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -53,7 +53,7 @@ class TestConversationSession:
         """Test creating a ConversationSession."""
         session = ConversationSession(
             conversation_id="conv-123",
-            model="claude-sonnet-4-5-latest",
+            model="claude-sonnet-4-5-20250929",
             temperature=0.8,
             max_tokens=2000,
             system_prompt="You are helpful.",
@@ -61,7 +61,7 @@ class TestConversationSession:
         )
 
         assert session.conversation_id == "conv-123"
-        assert session.model == "claude-sonnet-4-5-latest"
+        assert session.model == "claude-sonnet-4-5-20250929"
         assert session.temperature == 0.8
         assert session.max_tokens == 2000
         assert session.system_prompt == "You are helpful."
@@ -175,7 +175,7 @@ class TestSessionManager:
         manager = SessionManager()
 
         with patch("app.services.session_manager.settings") as mock_settings:
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -189,20 +189,20 @@ class TestSessionManager:
         manager = SessionManager()
 
         with patch("app.services.session_manager.settings") as mock_settings:
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
             session = manager.create_session(
                 conversation_id="conv-123",
-                model="claude-opus-4-latest",
+                model="claude-opus-4-20250514",
                 temperature=0.5,
                 max_tokens=2000,
                 system_prompt="Be helpful",
                 entity_id="custom-entity",
             )
 
-        assert session.model == "claude-opus-4-latest"
+        assert session.model == "claude-opus-4-20250514"
         assert session.temperature == 0.5
         assert session.max_tokens == 2000
         assert session.system_prompt == "Be helpful"
@@ -218,7 +218,7 @@ class TestSessionManager:
             mock_entity.model_provider = "openai"
             mock_settings.get_entity_by_index.return_value = mock_entity
             mock_settings.get_default_model_for_provider.return_value = "gpt-4o"
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -234,7 +234,7 @@ class TestSessionManager:
         manager = SessionManager()
 
         with patch("app.services.session_manager.settings") as mock_settings:
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -256,7 +256,7 @@ class TestSessionManager:
         manager = SessionManager()
 
         with patch("app.services.session_manager.settings") as mock_settings:
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -281,7 +281,7 @@ class TestSessionManager:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
             mock_settings.get_entity_by_index.return_value = None
@@ -327,7 +327,7 @@ class TestSessionManager:
                 "created_at": "2024-01-01T12:00:00",
                 "times_retrieved": 3,
             })
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
             mock_settings.get_entity_by_index.return_value = None
@@ -354,11 +354,11 @@ class TestSessionManager:
             ]
             mock_llm.send_message = AsyncMock(return_value={
                 "content": "Hi there!",
-                "model": "claude-sonnet-4-5-latest",
+                "model": "claude-sonnet-4-5-20250929",
                 "usage": {"input_tokens": 10, "output_tokens": 5},
                 "stop_reason": "end_turn",
             })
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -404,12 +404,12 @@ class TestSessionManager:
             ]
             mock_llm.send_message = AsyncMock(return_value={
                 "content": "Response with memory",
-                "model": "claude-sonnet-4-5-latest",
+                "model": "claude-sonnet-4-5-20250929",
                 "usage": {"input_tokens": 50, "output_tokens": 20},
                 "stop_reason": "end_turn",
             })
 
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 
@@ -452,12 +452,12 @@ class TestSessionManager:
             mock_llm.build_messages_with_memories.return_value = []
             mock_llm.send_message = AsyncMock(return_value={
                 "content": "Response",
-                "model": "claude-sonnet-4-5-latest",
+                "model": "claude-sonnet-4-5-20250929",
                 "usage": {"input_tokens": 10, "output_tokens": 5},
                 "stop_reason": "end_turn",
             })
 
-            mock_settings.default_model = "claude-sonnet-4-5-latest"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 4096
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,11 +104,11 @@
                 <div class="form-group">
                     <label for="model-select">Model</label>
                     <select id="model-select">
-                        <option value="claude-sonnet-4-5-latest">Claude Sonnet 4.5</option>
-                        <option value="claude-opus-4-5-latest">Claude Opus 4.5</option>
-                        <option value="claude-haiku-4-5-latest">Claude Haiku 4.5</option>
-                        <option value="claude-sonnet-4-latest">Claude Sonnet 4</option>
-                        <option value="claude-opus-4-latest">Claude Opus 4</option>
+                        <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</option>
+                        <option value="claude-opus-4-5-20251101">Claude Opus 4.5</option>
+                        <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5</option>
+                        <option value="claude-sonnet-4-20250514">Claude Sonnet 4</option>
+                        <option value="claude-opus-4-20250514">Claude Opus 4</option>
                     </select>
                 </div>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -12,7 +12,7 @@ class App {
         this.availableModels = [];
         this.providers = [];
         this.settings = {
-            model: 'claude-sonnet-4-5-latest',
+            model: 'claude-sonnet-4-5-20250929',
             temperature: 1.0,
             maxTokens: 4096,
             systemPrompt: null,


### PR DESCRIPTION
The -latest aliases are not supported by the Anthropic API, so revert all model references to use dated versions:

Claude 4.5:
- claude-sonnet-4-5-20250929
- claude-opus-4-5-20251101
- claude-haiku-4-5-20251001

Claude 4:
- claude-sonnet-4-20250514
- claude-opus-4-20250514

Updated all code, tests, configuration, and documentation.