### PR TITLE
Add token streaming for AI messages

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -510,6 +510,28 @@ html, body {
     40% { transform: translateY(-6px); }
 }
 
+/* Streaming Message */
+.message-bubble.streaming {
+    position: relative;
+}
+
+.message-bubble.streaming .message-content {
+    display: inline;
+}
+
+.streaming-cursor {
+    display: inline;
+    color: var(--accent);
+    animation: blink 0.8s infinite;
+    font-weight: normal;
+    margin-left: 1px;
+}
+
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+}
+
 /* Input Area */
 .input-area {
     padding: 16px 24px;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -106,6 +106,120 @@ class ApiClient {
         });
     }
 
+    /**
+     * Send a message with streaming response.
+     * @param {Object} data - Chat request data
+     * @param {Object} callbacks - Event callbacks
+     * @param {Function} callbacks.onMemories - Called with memory retrieval info
+     * @param {Function} callbacks.onStart - Called when streaming starts
+     * @param {Function} callbacks.onToken - Called for each token
+     * @param {Function} callbacks.onDone - Called when streaming completes
+     * @param {Function} callbacks.onStored - Called when messages are stored
+     * @param {Function} callbacks.onError - Called on error
+     * @returns {Promise<void>}
+     */
+    async sendMessageStream(data, callbacks = {}) {
+        const url = `${API_BASE}/chat/stream`;
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ detail: 'Unknown error' }));
+            throw new Error(error.detail || `HTTP ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+
+            // Process complete SSE events in buffer
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+            let eventType = null;
+            let eventData = null;
+
+            for (const line of lines) {
+                if (line.startsWith('event: ')) {
+                    eventType = line.slice(7).trim();
+                } else if (line.startsWith('data: ')) {
+                    eventData = line.slice(6);
+                } else if (line === '' && eventType && eventData) {
+                    // Empty line marks end of event
+                    try {
+                        const parsedData = JSON.parse(eventData);
+                        this._handleStreamEvent(eventType, parsedData, callbacks);
+                    } catch (e) {
+                        console.error('Failed to parse SSE data:', e, eventData);
+                    }
+                    eventType = null;
+                    eventData = null;
+                }
+            }
+        }
+
+        // Process any remaining data in buffer
+        if (buffer.trim()) {
+            const lines = buffer.split('\n');
+            let eventType = null;
+            let eventData = null;
+
+            for (const line of lines) {
+                if (line.startsWith('event: ')) {
+                    eventType = line.slice(7).trim();
+                } else if (line.startsWith('data: ')) {
+                    eventData = line.slice(6);
+                }
+            }
+
+            if (eventType && eventData) {
+                try {
+                    const parsedData = JSON.parse(eventData);
+                    this._handleStreamEvent(eventType, parsedData, callbacks);
+                } catch (e) {
+                    console.error('Failed to parse final SSE data:', e, eventData);
+                }
+            }
+        }
+    }
+
+    _handleStreamEvent(eventType, data, callbacks) {
+        switch (eventType) {
+            case 'memories':
+                if (callbacks.onMemories) callbacks.onMemories(data);
+                break;
+            case 'start':
+                if (callbacks.onStart) callbacks.onStart(data);
+                break;
+            case 'token':
+                if (callbacks.onToken) callbacks.onToken(data);
+                break;
+            case 'done':
+                if (callbacks.onDone) callbacks.onDone(data);
+                break;
+            case 'stored':
+                if (callbacks.onStored) callbacks.onStored(data);
+                break;
+            case 'error':
+                if (callbacks.onError) callbacks.onError(data);
+                break;
+            default:
+                console.warn('Unknown SSE event type:', eventType);
+        }
+    }
+
     async quickChat(data) {
         return this.request('/chat/quick', {
             method: 'POST',


### PR DESCRIPTION
Implement Server-Sent Events (SSE) streaming for AI responses so users can see tokens as they are generated instead of waiting for the full response.

Backend changes:
- Add send_message_stream() to AnthropicService with Anthropic's stream API
- Add send_message_stream() to OpenAIService with OpenAI's stream API
- Add send_message_stream() to LLMService for provider routing
- Add process_message_stream() to SessionManager for memory handling
- Create POST /api/chat/stream SSE endpoint in chat routes

Frontend changes:
- Add sendMessageStream() to API client with SSE parsing
- Add createStreamingMessage() for progressive token rendering
- Update sendMessage() to use streaming by default
- Add CSS for blinking cursor animation during streaming

Events streamed: memories, start, token, done, stored, error