### PR TITLE
Fix Anthropic streaming: remove redundant stream parameter

### DIFF
--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -102,7 +102,6 @@ class AnthropicService:
             "max_tokens": max_tokens,
             "temperature": temperature,
             "messages": messages,
-            "stream": True,
         }
 
         if system_prompt:


### PR DESCRIPTION
The Anthropic SDK's .stream() context manager doesn't accept a 'stream' parameter - that's only used with .create(). Removing it fixes the error: "AsyncMessages.stream() got an unexpected keyword argument 'stream'"