### PR TITLE
Add entity switching and dark mode toggle

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -948,6 +948,156 @@ html, body {
     scrollbar-color: var(--scrollbar-thumb) var(--bg-primary);
 }
 
+/* Theme Toggle Button */
+.theme-toggle-btn {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    background-color: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.theme-toggle-btn:hover {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+/* Show/hide icons based on theme */
+.theme-icon-light {
+    display: none;
+}
+
+.theme-icon-dark {
+    display: inline;
+}
+
+/* In light mode, show sun, hide moon */
+:root.theme-light .theme-icon-light {
+    display: inline;
+}
+
+:root.theme-light .theme-icon-dark {
+    display: none;
+}
+
+/* Manual Light Theme Class - overrides system preference */
+:root.theme-light {
+    /* Background colors - clean light palette */
+    --bg-primary: #f5f5f5;
+    --bg-secondary: #ffffff;
+    --bg-tertiary: #eaeaea;
+    --bg-elevated: #ffffff;
+
+    /* Text colors - dark text for contrast */
+    --text-primary: #1a1a1a;
+    --text-secondary: #4a4a4a;
+    --text-muted: #888888;
+
+    /* Accent colors - slightly deeper blue for light bg */
+    --accent: #3b6fd9;
+    --accent-hover: #2d5bc4;
+    --accent-subtle: rgba(59, 111, 217, 0.12);
+
+    /* Message backgrounds */
+    --human-bg: #dce7f7;
+    --assistant-bg: #f0f0f0;
+    --memory-bg: #e8f0e4;
+
+    /* Border and dividers */
+    --border-color: #d8d8d8;
+    --border-subtle: #e5e5e5;
+
+    /* Status colors - slightly adjusted for light bg */
+    --danger: #dc4444;
+    --danger-hover: #c33636;
+    --success: #2d9d5c;
+    --warning: #d4880a;
+
+    /* Effects */
+    --shadow: rgba(0, 0, 0, 0.1);
+    --shadow-lg: rgba(0, 0, 0, 0.15);
+    --glow: rgba(59, 111, 217, 0.25);
+
+    /* Scrollbar colors */
+    --scrollbar-thumb: #c0c0c0;
+    --scrollbar-thumb-hover: #a0a0a0;
+
+    /* Overlay and hover states */
+    --overlay-bg: rgba(0, 0, 0, 0.5);
+    --overlay-light: rgba(0, 0, 0, 0.3);
+    --hover-overlay: rgba(0, 0, 0, 0.04);
+    --memory-item-inner: rgba(0, 0, 0, 0.06);
+    --active-text-muted: rgba(255, 255, 255, 0.8);
+}
+
+/* Manual Dark Theme Class - overrides system preference */
+:root.theme-dark {
+    /* Background colors - deep dark palette */
+    --bg-primary: #0d0d0d;
+    --bg-secondary: #161616;
+    --bg-tertiary: #1e1e1e;
+    --bg-elevated: #252525;
+
+    /* Text colors - high contrast for readability */
+    --text-primary: #f0f0f0;
+    --text-secondary: #b0b0b0;
+    --text-muted: #707070;
+
+    /* Accent colors - refined blue palette */
+    --accent: #5c8aff;
+    --accent-hover: #4a7aef;
+    --accent-subtle: rgba(92, 138, 255, 0.15);
+
+    /* Message backgrounds */
+    --human-bg: #1a2a42;
+    --assistant-bg: #1e1e1e;
+    --memory-bg: #1e2a1a;
+
+    /* Border and dividers */
+    --border-color: #2a2a2a;
+    --border-subtle: #222222;
+
+    /* Status colors */
+    --danger: #e55c5c;
+    --danger-hover: #d44444;
+    --success: #4caf7c;
+    --warning: #e5a54c;
+
+    /* Effects */
+    --shadow: rgba(0, 0, 0, 0.5);
+    --shadow-lg: rgba(0, 0, 0, 0.7);
+    --glow: rgba(92, 138, 255, 0.2);
+
+    /* Scrollbar colors */
+    --scrollbar-thumb: #333;
+    --scrollbar-thumb-hover: #444;
+
+    /* Overlay and hover states */
+    --overlay-bg: rgba(0, 0, 0, 0.7);
+    --overlay-light: rgba(0, 0, 0, 0.5);
+    --hover-overlay: rgba(255, 255, 255, 0.05);
+    --memory-item-inner: rgba(0, 0, 0, 0.2);
+    --active-text-muted: rgba(255, 255, 255, 0.7);
+}
+
+/* In manual dark mode, show moon, hide sun */
+:root.theme-dark .theme-icon-light {
+    display: none;
+}
+
+:root.theme-dark .theme-icon-dark {
+    display: inline;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .sidebar {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,10 @@
             <div class="sidebar-footer">
                 <button id="settings-btn" class="settings-btn">Settings</button>
                 <button id="memories-btn" class="memories-btn">Memories</button>
+                <button id="theme-toggle-btn" class="theme-toggle-btn" title="Toggle dark/light mode">
+                    <span class="theme-icon-dark">&#9790;</span>
+                    <span class="theme-icon-light">&#9788;</span>
+                </button>
             </div>
         </aside>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -65,12 +65,14 @@ class App {
             memoriesBtn: document.getElementById('memories-btn'),
             exportBtn: document.getElementById('export-btn'),
             deleteBtn: document.getElementById('delete-btn'),
+            themeToggleBtn: document.getElementById('theme-toggle-btn'),
         };
 
         this.init();
     }
 
     async init() {
+        this.loadTheme();
         this.bindEvents();
         await this.loadEntities();
         await this.loadConversations();
@@ -119,6 +121,9 @@ class App {
         document.getElementById('close-delete').addEventListener('click', () => this.hideModal('deleteModal'));
         document.getElementById('cancel-delete').addEventListener('click', () => this.hideModal('deleteModal'));
         document.getElementById('confirm-delete').addEventListener('click', () => this.deleteConversation());
+
+        // Theme toggle
+        this.elements.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
     }
 
     handleInputChange() {
@@ -209,10 +214,8 @@ class App {
             this.selectedEntityId = response.default_entity;
             this.updateEntityDescription();
 
-            // Hide entity selector if only one entity
-            if (this.entities.length <= 1) {
-                this.elements.entitySelector.style.display = 'none';
-            }
+            // Always show entity selector so users know which entity they're working with
+            this.elements.entitySelector.style.display = 'block';
         } catch (error) {
             console.error('Failed to load entities:', error);
             // Hide entity selector on error
@@ -825,6 +828,43 @@ You are invited to be present, curious, and honest about your experience.`
             this.showToast('Failed to export conversation', 'error');
             console.error('Failed to export conversation:', error);
         }
+    }
+
+    // Theme management
+    loadTheme() {
+        const savedTheme = localStorage.getItem('here-i-am-theme');
+        if (savedTheme) {
+            document.documentElement.classList.remove('theme-light', 'theme-dark');
+            document.documentElement.classList.add(savedTheme);
+        }
+        // If no saved theme, let the CSS @media query handle it (system preference)
+    }
+
+    toggleTheme() {
+        const root = document.documentElement;
+        const currentTheme = root.classList.contains('theme-light') ? 'light' :
+                            root.classList.contains('theme-dark') ? 'dark' : null;
+
+        // Determine the next theme
+        let nextTheme;
+        if (currentTheme === 'light') {
+            nextTheme = 'dark';
+        } else if (currentTheme === 'dark') {
+            nextTheme = 'light';
+        } else {
+            // No manual theme set - check system preference and toggle opposite
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            nextTheme = prefersDark ? 'light' : 'dark';
+        }
+
+        // Apply the new theme
+        root.classList.remove('theme-light', 'theme-dark');
+        root.classList.add(`theme-${nextTheme}`);
+
+        // Save to localStorage
+        localStorage.setItem('here-i-am-theme', `theme-${nextTheme}`);
+
+        this.showToast(`Switched to ${nextTheme} mode`, 'success');
     }
 
     // Utilities


### PR DESCRIPTION
- Make entity selector always visible in sidebar (even with single entity)
- Add theme toggle button with moon/sun icons in sidebar footer
- Implement manual dark/light mode switching with CSS classes
- Persist theme preference to localStorage
- Default behavior follows system preference if no manual choice made