### PR TITLE
Fix memory count mismatch in UI

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -343,6 +343,13 @@ async def get_session_info(
     if not session:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    # Get memories currently in context (not all retrieved, just those in context)
+    in_context_memories = [
+        session.session_memories[mid]
+        for mid in session.in_context_ids
+        if mid in session.session_memories
+    ]
+
     return {
         "conversation_id": session.conversation_id,
         "model": session.model,
@@ -351,7 +358,7 @@ async def get_session_info(
         "system_prompt": session.system_prompt,
         "entity_id": session.entity_id,
         "message_count": len(session.conversation_context),
-        "memories_in_context": len(session.session_memories),
+        "memories_in_context": len(in_context_memories),
         "memories": [
             {
                 "id": m.id,
@@ -359,8 +366,9 @@ async def get_session_info(
                 "created_at": m.created_at,
                 "times_retrieved": m.times_retrieved,
                 "role": m.role,
+                "score": m.score,
             }
-            for m in session.session_memories.values()
+            for m in in_context_memories
         ],
     }
 

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -434,11 +434,12 @@ class SessionManager:
                     "created_at": m.created_at,
                     "times_retrieved": m.times_retrieved + 1,  # Account for this retrieval
                     "score": m.score,
+                    "role": m.role,
                 }
                 for m in new_memories
             ],
             "total_memories_in_context": len(session.in_context_ids),
-            "trimmed_memories": len(trimmed_memory_ids),
+            "trimmed_memory_ids": trimmed_memory_ids,
             "trimmed_context_messages": trimmed_context_count,
         }
 
@@ -529,11 +530,12 @@ class SessionManager:
                     "created_at": m.created_at,
                     "times_retrieved": m.times_retrieved + 1,
                     "score": m.score,
+                    "role": m.role,
                 }
                 for m in new_memories
             ],
             "total_in_context": len(session.in_context_ids),
-            "trimmed_memories": len(trimmed_memory_ids),
+            "trimmed_memory_ids": trimmed_memory_ids,
             "trimmed_context_messages": trimmed_context_count,
         }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -444,11 +444,29 @@ class App {
                 },
                 {
                     onMemories: (data) => {
-                        // Update memories when retrieved
+                        let hasChanges = false;
+
+                        // Remove trimmed memories (FIFO trimming for token limits)
+                        if (data.trimmed_memory_ids && data.trimmed_memory_ids.length > 0) {
+                            const trimmedSet = new Set(data.trimmed_memory_ids);
+                            this.retrievedMemories = this.retrievedMemories.filter(
+                                mem => !trimmedSet.has(mem.id)
+                            );
+                            hasChanges = true;
+                        }
+
+                        // Add new memories (with deduplication for restored memories)
                         if (data.new_memories && data.new_memories.length > 0) {
+                            const existingIds = new Set(this.retrievedMemories.map(m => m.id));
                             data.new_memories.forEach(mem => {
-                                this.retrievedMemories.push(mem);
+                                if (!existingIds.has(mem.id)) {
+                                    this.retrievedMemories.push(mem);
+                                }
                             });
+                            hasChanges = true;
+                        }
+
+                        if (hasChanges) {
                             this.updateMemoriesPanel();
                         }
                     },


### PR DESCRIPTION
The UI was not properly synced with the backend's memory tracking:
- Added role field to streaming new_memories (was missing)
- Changed trimmed_memories count to trimmed_memory_ids list so frontend can remove trimmed memories from its local tracking
- Updated frontend to handle trimmed memories and deduplicate restored ones
- Fixed get_session_info to return only in-context memories (not all retrieved memories) for consistency with streaming behavior