### PR TITLE
Increase initial memory retrieval limit to ten

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,7 +54,8 @@ class Settings(BaseSettings):
     debug: bool = True
 
     # Memory retrieval defaults
-    retrieval_top_k: int = 5
+    initial_retrieval_top_k: int = 10  # First retrieval in a conversation
+    retrieval_top_k: int = 5  # Subsequent retrievals
     similarity_threshold: float = 0.3  # Tuned for llama-text-embed-v2
 
     # Significance calculation

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -408,9 +408,14 @@ class SessionManager:
                 user_message,
             )
 
+            # Use higher limit for first retrieval in a conversation
+            is_first_retrieval = len(session.retrieved_ids) == 0
+            top_k = settings.initial_retrieval_top_k if is_first_retrieval else settings.retrieval_top_k
+
             # Exclude memories already in context (not all retrieved - allows trimmed ones to return)
             candidates = await memory_service.search_memories(
                 query=memory_query,
+                top_k=top_k,
                 exclude_conversation_id=session.conversation_id,
                 exclude_ids=session.in_context_ids,
                 entity_id=session.entity_id,
@@ -538,9 +543,14 @@ class SessionManager:
                 user_message,
             )
 
+            # Use higher limit for first retrieval in a conversation
+            is_first_retrieval = len(session.retrieved_ids) == 0
+            top_k = settings.initial_retrieval_top_k if is_first_retrieval else settings.retrieval_top_k
+
             # Exclude memories already in context (not all retrieved - allows trimmed ones to return)
             candidates = await memory_service.search_memories(
                 query=memory_query,
+                top_k=top_k,
                 exclude_conversation_id=session.conversation_id,
                 exclude_ids=session.in_context_ids,
                 entity_id=session.entity_id,


### PR DESCRIPTION
The first memory retrieval in a conversation now pulls up to 10 memories to provide richer context at the start. Subsequent retrievals use the normal limit of 5.