### PR TITLE
Fix OpenAI API call with Anthropic arguments

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.27.1
 sqlalchemy==2.0.25
 aiosqlite==0.19.0
 anthropic>=0.40.0
-openai==1.12.0
+openai>=1.14.0
 pinecone==6.0.0
 python-dotenv==1.0.1
 pydantic==2.6.1


### PR DESCRIPTION
Update openai SDK from ==1.12.0 to >=1.14.0 to support the stream_options parameter used in send_message_stream(). This parameter was introduced in SDK version 1.14.0.