### PR TITLE
Fix type error in OpenAI export import

### DIFF
--- a/backend/app/routes/conversations.py
+++ b/backend/app/routes/conversations.py
@@ -643,7 +643,7 @@ def _parse_openai_export(data: list, include_ids: bool = False) -> List[dict]:
                     text += part["text"]
 
             if text.strip():
-                create_time = message.get("create_time", 0)
+                create_time = message.get("create_time") or 0
                 msg_entry = {
                     "role": "human" if role == "user" else "assistant",
                     "content": text.strip(),


### PR DESCRIPTION
The `message.get("create_time", 0)` only returns the default when the key is missing, but OpenAI exports can have `create_time: null`. Using `or 0` handles both missing keys and null values.