### PR TITLE
Add cancel button for in-progress memory

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1051,6 +1051,44 @@ h4.md-header {
     border: 1px solid var(--danger);
 }
 
+.import-status.warning {
+    background-color: rgba(255, 193, 7, 0.15);
+    color: #ffc107;
+    border: 1px solid #ffc107;
+}
+
+/* Import Progress Bar */
+.import-progress {
+    margin-top: 12px;
+}
+
+.import-progress-bar-container {
+    width: 100%;
+    height: 8px;
+    background-color: var(--bg-tertiary);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.import-progress-bar {
+    height: 100%;
+    background-color: var(--accent);
+    width: 0%;
+    transition: width 0.3s ease;
+}
+
+.import-progress-text {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 8px;
+    text-align: center;
+}
+
+.import-actions {
+    display: flex;
+    gap: 10px;
+}
+
 /* Import Preview Header */
 .import-preview-header {
     display: flex;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -226,8 +226,16 @@
                         <!-- Conversations will be loaded here -->
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group import-actions">
                         <button id="import-btn" class="primary-btn">Import Selected</button>
+                        <button id="import-cancel-btn" class="danger-btn" style="display: none;">Cancel Import</button>
+                    </div>
+
+                    <div id="import-progress" class="import-progress" style="display: none;">
+                        <div class="import-progress-bar-container">
+                            <div id="import-progress-bar" class="import-progress-bar"></div>
+                        </div>
+                        <div id="import-progress-text" class="import-progress-text">Starting import...</div>
                     </div>
                 </div>
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -125,6 +125,101 @@ class ApiClient {
         });
     }
 
+    /**
+     * Import conversations with streaming progress updates.
+     * @param {Object} data - Import request data
+     * @param {Object} callbacks - Event callbacks
+     * @param {Function} callbacks.onStart - Called when import starts with total counts
+     * @param {Function} callbacks.onProgress - Called with progress updates
+     * @param {Function} callbacks.onDone - Called when import completes
+     * @param {Function} callbacks.onError - Called on error
+     * @param {Function} callbacks.onCancelled - Called when import is cancelled
+     * @param {AbortSignal} signal - Optional AbortSignal for cancellation
+     * @returns {Promise<void>}
+     */
+    async importExternalConversationsStream(data, callbacks = {}, signal = null) {
+        const url = `${API_BASE}/conversations/import-external/stream`;
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ detail: 'Unknown error' }));
+            throw new Error(error.detail || `HTTP ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+
+                // Process complete SSE events in buffer
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+
+                let eventType = null;
+                let eventData = null;
+
+                for (const line of lines) {
+                    if (line.startsWith('event: ')) {
+                        eventType = line.slice(7).trim();
+                    } else if (line.startsWith('data: ')) {
+                        eventData = line.slice(6);
+                    } else if (line === '' && eventType && eventData) {
+                        try {
+                            const parsedData = JSON.parse(eventData);
+                            this._handleImportStreamEvent(eventType, parsedData, callbacks);
+                        } catch (e) {
+                            console.error('Failed to parse SSE data:', e, eventData);
+                        }
+                        eventType = null;
+                        eventData = null;
+                    }
+                }
+            }
+        } catch (e) {
+            if (e.name === 'AbortError') {
+                if (callbacks.onCancelled) callbacks.onCancelled({ status: 'cancelled' });
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    _handleImportStreamEvent(eventType, data, callbacks) {
+        switch (eventType) {
+            case 'start':
+                if (callbacks.onStart) callbacks.onStart(data);
+                break;
+            case 'progress':
+                if (callbacks.onProgress) callbacks.onProgress(data);
+                break;
+            case 'done':
+                if (callbacks.onDone) callbacks.onDone(data);
+                break;
+            case 'cancelled':
+                if (callbacks.onCancelled) callbacks.onCancelled(data);
+                break;
+            case 'error':
+                if (callbacks.onError) callbacks.onError(data);
+                break;
+            default:
+                console.warn('Unknown import SSE event type:', eventType);
+        }
+    }
+
     async previewExternalConversations(data) {
         return this.request('/conversations/import-external/preview', {
             method: 'POST',


### PR DESCRIPTION
- Add streaming import endpoint (/import-external/stream) that sends progress updates via SSE and supports cancellation
- Add cancel button and progress bar to import UI
- Show real-time progress during import (messages processed, percentage)
- Allow users to cancel long-running imports by clicking Cancel button
- Use AbortController for clean client-side cancellation
- Add warning status style for cancelled imports