### PR TITLE
Restore logging for memory retrieval

### DIFF
--- a/backend/app/services/memory_service.py
+++ b/backend/app/services/memory_service.py
@@ -211,7 +211,7 @@ class MemoryService:
                 exclude_conversation_id=exclude_conversation_id,
             )
             if cached_results is not None:
-                logger.debug("search_memories: CACHE HIT")
+                logger.info(f"[MEMORY] Cache HIT for entity={entity_id}")
                 # Apply exclude_ids filter to cached results
                 filtered = []
                 for mem in cached_results:
@@ -228,7 +228,7 @@ class MemoryService:
             # Query more than we need to allow for filtering by exclude_ids
             fetch_k = top_k * 2
 
-            logger.debug(f"search_memories: threshold={settings.similarity_threshold}, exclude_conv={exclude_conversation_id}")
+            logger.info(f"[MEMORY] Searching memories: threshold={settings.similarity_threshold}, top_k={top_k}, entity={entity_id}")
 
             # Build search query with optional metadata filter
             search_query = {
@@ -253,7 +253,7 @@ class MemoryService:
             # Pinecone inference search returns: results.result.hits
             # Each hit has: _id, _score, fields (metadata dict)
             hits = results.result.hits if hasattr(results, 'result') and hasattr(results.result, 'hits') else []
-            logger.debug(f"search_memories: got {len(hits)} hits from Pinecone")
+            logger.info(f"[MEMORY] Pinecone returned {len(hits)} candidate memories")
 
             for hit in hits:
                 # Get hit properties via to_dict()
@@ -305,7 +305,7 @@ class MemoryService:
                 if len(memories) >= top_k:
                     break
 
-            logger.debug(f"search_memories: returning {len(memories)} memories")
+            logger.info(f"[MEMORY] Search complete: returning {len(memories)} memories (filtered from {len(hits)} candidates)")
             return memories
         except Exception as e:
             logger.error(f"Error searching memories: {e}")

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -531,6 +531,8 @@ class SessionManager:
         new_memories = []
         truly_new_memory_ids = set()  # Only memories never seen before (for cache stability)
 
+        logger.info(f"[MEMORY] Processing message for conversation {session.conversation_id[:8]}...")
+
         # Step 1-2: Retrieve and deduplicate memories
         if memory_service.is_configured():
             # Get archived conversation IDs to exclude from retrieval
@@ -588,6 +590,16 @@ class SessionManager:
                                 db,
                                 entity_id=session.entity_id,
                             )
+
+            # Log memory retrieval summary
+            if new_memories:
+                logger.info(f"[MEMORY] Retrieved {len(new_memories)} new memories ({len(truly_new_memory_ids)} first-time retrievals)")
+                for mem in new_memories:
+                    preview = mem.content[:100].replace('\n', ' ')
+                    retrieval_type = "NEW" if mem.id in truly_new_memory_ids else "RESTORED"
+                    logger.info(f"[MEMORY]   [{retrieval_type}] score={mem.score:.3f} id={mem.id[:8]}... \"{preview}...\"")
+            else:
+                logger.info(f"[MEMORY] No new memories retrieved (total in context: {len(session.in_context_ids)})")
 
         # Step 4: Apply token limits before building API messages
         # Trim memories if over limit (FIFO - oldest retrieved first)
@@ -702,6 +714,8 @@ class SessionManager:
         new_memories = []
         truly_new_memory_ids = set()  # Only memories never seen before (for cache stability)
 
+        logger.info(f"[MEMORY] Processing message (stream) for conversation {session.conversation_id[:8]}...")
+
         # Step 1-2: Retrieve and deduplicate memories
         if memory_service.is_configured():
             # Get archived conversation IDs to exclude from retrieval
@@ -758,6 +772,16 @@ class SessionManager:
                                 db,
                                 entity_id=session.entity_id,
                             )
+
+            # Log memory retrieval summary
+            if new_memories:
+                logger.info(f"[MEMORY] Retrieved {len(new_memories)} new memories ({len(truly_new_memory_ids)} first-time retrievals)")
+                for mem in new_memories:
+                    preview = mem.content[:100].replace('\n', ' ')
+                    retrieval_type = "NEW" if mem.id in truly_new_memory_ids else "RESTORED"
+                    logger.info(f"[MEMORY]   [{retrieval_type}] score={mem.score:.3f} id={mem.id[:8]}... \"{preview}...\"")
+            else:
+                logger.info(f"[MEMORY] No new memories retrieved (total in context: {len(session.in_context_ids)})")
 
         # Step 3: Apply token limits before building API messages
         # Trim memories if over limit (FIFO - oldest retrieved first)


### PR DESCRIPTION
Add visible logging throughout the memory retrieval pipeline:
- Log when processing messages with memory system
- Log Pinecone search parameters and results
- Log cache hits
- Log retrieved memories with score, type (NEW/RESTORED), and preview
- Log when no new memories are retrieved

This makes memory retrieval visible in normal operation without requiring debug mode, helping track what memories are being used.