### PR TITLE
Filter memories by active entity

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -395,8 +395,12 @@ class ApiClient {
         });
     }
 
-    async getMemoryStats() {
-        return this.request('/memories/stats');
+    async getMemoryStats(entityId = null) {
+        let url = '/memories/stats';
+        if (entityId) {
+            url += `?entity_id=${entityId}`;
+        }
+        return this.request(url);
     }
 
     async getMemory(id) {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1734,7 +1734,7 @@ You are invited to be present, curious, and honest about your experience.`
 
     async loadMemoryStats() {
         try {
-            const stats = await api.getMemoryStats();
+            const stats = await api.getMemoryStats(this.selectedEntityId);
             document.getElementById('memory-stats').innerHTML = `
                 <div class="stat-card">
                     <div class="stat-value">${stats.total_count}</div>
@@ -1760,7 +1760,7 @@ You are invited to be present, curious, and honest about your experience.`
 
     async loadMemoryList() {
         try {
-            const memories = await api.listMemories({ limit: 50, sortBy: 'significance' });
+            const memories = await api.listMemories({ limit: 50, sortBy: 'significance', entityId: this.selectedEntityId });
             const listEl = document.getElementById('memory-list');
 
             if (memories.length === 0) {


### PR DESCRIPTION
- Add entity_id parameter to /api/memories/stats endpoint
- Update frontend API client getMemoryStats() to accept entityId
- Pass selectedEntityId when loading memory list and stats in the memories modal, so users only see memories for the currently selected AI entity