### PR TITLE
Fix bullet point margins in chat history

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -772,12 +772,15 @@ h4.md-header {
 
 .md-list {
     margin: 4px 0;
-    padding-left: 24px;
+    padding-left: 0;
+    margin-left: 24px;
+    list-style-position: outside;
 }
 
 .md-list-item,
 .md-list-item-ordered {
     margin: 0;
+    padding-left: 4px;
     line-height: 1.4;
 }
 


### PR DESCRIPTION
Changed list styling to use margin-left instead of padding-left so bullets render in the margin area rather than being clipped. Added explicit list-style-position and padding to ensure consistent alignment with other message text.