### PR TITLE
Add adjustable parameters for voice cloning

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,11 +35,20 @@ class XTTSVoiceConfig:
         label: str,
         description: str = "",
         sample_path: str = "",
+        temperature: float = 0.75,
+        length_penalty: float = 1.0,
+        repetition_penalty: float = 5.0,
+        speed: float = 1.0,
     ):
         self.voice_id = voice_id
         self.label = label
         self.description = description
         self.sample_path = sample_path
+        # XTTS synthesis parameters
+        self.temperature = temperature
+        self.length_penalty = length_penalty
+        self.repetition_penalty = repetition_penalty
+        self.speed = speed
 
     def to_dict(self):
         return {
@@ -48,6 +57,10 @@ class XTTSVoiceConfig:
             "description": self.description,
             "sample_path": self.sample_path,
             "provider": "xtts",
+            "temperature": self.temperature,
+            "length_penalty": self.length_penalty,
+            "repetition_penalty": self.repetition_penalty,
+            "speed": self.speed,
         }
 
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1941,6 +1941,13 @@ h4.md-header {
     color: var(--text-muted);
 }
 
+.voice-item-params {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: monospace;
+    opacity: 0.8;
+}
+
 .voice-item-actions {
     display: flex;
     gap: 4px;
@@ -2018,6 +2025,68 @@ h4.md-header {
 #voice-clone-modal .form-group input[type="text"]:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+/* Voice parameters section */
+.voice-params-section {
+    margin-top: 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0;
+}
+
+.voice-params-section summary {
+    padding: 12px 16px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    background-color: var(--bg-secondary);
+    border-radius: 6px;
+}
+
+.voice-params-section[open] summary {
+    border-bottom: 1px solid var(--border-color);
+    border-radius: 6px 6px 0 0;
+}
+
+.voice-params-section summary:hover {
+    color: var(--text-primary);
+}
+
+.voice-params-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    padding: 16px;
+}
+
+.voice-params-grid .form-group {
+    margin-bottom: 0;
+}
+
+.voice-params-grid input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.voice-params-grid input[type="number"]:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* Voice item settings button */
+.voice-item-btn.settings {
+    color: var(--text-secondary);
+}
+
+.voice-item-btn.settings:hover {
+    color: var(--accent);
+    background-color: var(--accent-subtle);
 }
 
 /* Empty voice list state */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -386,11 +386,91 @@
                     <input type="text" id="voice-clone-description" placeholder="e.g., Deep male voice" maxlength="200">
                 </div>
 
+                <details class="voice-params-section">
+                    <summary>Voice Synthesis Parameters</summary>
+                    <div class="voice-params-grid">
+                        <div class="form-group">
+                            <label for="voice-clone-temperature">Temperature</label>
+                            <input type="number" id="voice-clone-temperature" value="0.75" min="0" max="1" step="0.05">
+                            <p class="form-help">Randomness (0-1, lower = more consistent)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-clone-speed">Speed</label>
+                            <input type="number" id="voice-clone-speed" value="1.0" min="0.1" max="3" step="0.1">
+                            <p class="form-help">Speech speed multiplier (0.1-3)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-clone-length-penalty">Length Penalty</label>
+                            <input type="number" id="voice-clone-length-penalty" value="1.0" min="0.1" max="10" step="0.1">
+                            <p class="form-help">Affects output length (0.1-10)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-clone-repetition-penalty">Repetition Penalty</label>
+                            <input type="number" id="voice-clone-repetition-penalty" value="5.0" min="0.1" max="20" step="0.5">
+                            <p class="form-help">Prevents repetition (0.1-20)</p>
+                        </div>
+                    </div>
+                </details>
+
                 <div id="voice-clone-status" class="voice-clone-status" style="display: none;"></div>
             </div>
             <div class="modal-footer">
                 <button id="cancel-voice-clone" class="secondary-btn">Cancel</button>
                 <button id="create-voice-clone" class="primary-btn" disabled>Create Voice</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Voice Edit Modal -->
+    <div class="modal" id="voice-edit-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Edit Voice Settings</h3>
+                <button class="close-btn" id="close-voice-edit">&times;</button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="voice-edit-id">
+
+                <div class="form-group">
+                    <label for="voice-edit-name">Voice Name</label>
+                    <input type="text" id="voice-edit-name" maxlength="50">
+                </div>
+
+                <div class="form-group">
+                    <label for="voice-edit-description">Description</label>
+                    <input type="text" id="voice-edit-description" maxlength="200">
+                </div>
+
+                <div class="voice-params-section" style="border: none; margin-top: 0;">
+                    <div class="voice-params-grid" style="padding: 0;">
+                        <div class="form-group">
+                            <label for="voice-edit-temperature">Temperature</label>
+                            <input type="number" id="voice-edit-temperature" min="0" max="1" step="0.05">
+                            <p class="form-help">Randomness (0-1)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-edit-speed">Speed</label>
+                            <input type="number" id="voice-edit-speed" min="0.1" max="3" step="0.1">
+                            <p class="form-help">Speech speed (0.1-3)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-edit-length-penalty">Length Penalty</label>
+                            <input type="number" id="voice-edit-length-penalty" min="0.1" max="10" step="0.1">
+                            <p class="form-help">Output length (0.1-10)</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="voice-edit-repetition-penalty">Repetition Penalty</label>
+                            <input type="number" id="voice-edit-repetition-penalty" min="0.1" max="20" step="0.5">
+                            <p class="form-help">Prevents repetition (0.1-20)</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="voice-edit-status" class="voice-clone-status" style="display: none;"></div>
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-voice-edit" class="secondary-btn">Cancel</button>
+                <button id="save-voice-edit" class="primary-btn">Save Changes</button>
             </div>
         </div>
     </div>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -475,12 +475,18 @@ class ApiClient {
         return this.request('/tts/voices');
     }
 
-    async cloneVoice(audioFile, label, description = '') {
+    async cloneVoice(audioFile, label, description = '', options = {}) {
         const url = `${API_BASE}/tts/voices/clone`;
         const formData = new FormData();
         formData.append('audio_file', audioFile);
         formData.append('label', label);
         formData.append('description', description);
+
+        // Add voice synthesis parameters with defaults
+        formData.append('temperature', options.temperature ?? 0.75);
+        formData.append('length_penalty', options.length_penalty ?? 1.0);
+        formData.append('repetition_penalty', options.repetition_penalty ?? 5.0);
+        formData.append('speed', options.speed ?? 1.0);
 
         const response = await fetch(url, {
             method: 'POST',
@@ -493,6 +499,13 @@ class ApiClient {
         }
 
         return response.json();
+    }
+
+    async updateVoice(voiceId, updates) {
+        return this.request(`/tts/voices/${voiceId}`, {
+            method: 'PUT',
+            body: updates,
+        });
     }
 
     async deleteTTSVoice(voiceId) {


### PR DESCRIPTION
Allow adjusting temperature, length_penalty, repetition_penalty, and speed parameters when cloning XTTS voices. Parameters are stored per-voice and used when synthesizing speech.

- Add parameters to XTTSVoiceConfig in config.py
- Update xtts_service.py to load/save/use voice parameters in TTS calls
- Add update_voice method for modifying voice settings
- Update tts.py routes with parameter validation for clone and update
- Add PUT /tts/voices/{voice_id} endpoint for updating voice settings
- Update frontend with parameter inputs in clone modal
- Add voice edit modal for modifying existing voice parameters
- Show current parameter values in voice list