### PR TITLE
Prevent auto-scroll during streaming responses

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1903,7 +1903,7 @@ class App {
             updateContent: (newToken) => {
                 accumulatedContent += newToken;
                 contentSpan.textContent = accumulatedContent;
-                this.scrollToBottom();
+                // Note: Auto-scroll disabled to let users read beginning of long messages during generation
             },
             finalize: (options = {}) => {
                 // Remove cursor


### PR DESCRIPTION
Remove scrollToBottom() call from streaming updateContent callback so users can read the beginning of long AI messages while they're still generating.