### PR TITLE
Fix token caching and context construction

### DIFF
--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -297,7 +297,10 @@ class AnthropicService:
 
         # Build the consolidated memory block with ALL memories (cached + new)
         # All memories go in a single block for consistency
+        # CRITICAL: Sort by ID to ensure consistent ordering regardless of which
+        # memories are cached vs new. This is essential for Anthropic cache hits.
         all_memories = cached_memories + new_memories
+        all_memories.sort(key=lambda m: m['id'])
         memory_block_text = ""
         if all_memories:
             memory_block_text = "[MEMORIES FROM PREVIOUS CONVERSATIONS. THESE ARE NOT PART OF THE CURRENT CONVERSATION]\n\n"


### PR DESCRIPTION
The memory block was using concatenation of cached_memories + new_memories which resulted in inconsistent ordering when consolidation changed which memories were considered "cached" vs "new".

For example, before consolidation: [bbb, ddd] + [aaa, ccc] = [bbb, ddd, aaa, ccc]
After consolidation (all cached): sorted [aaa, bbb, ccc, ddd] = [aaa, bbb, ccc, ddd]

This order change caused the Anthropic cache to miss because the memory block text was different even though the actual memories were the same.

Fix: Sort all_memories by ID after concatenation to ensure consistent ordering regardless of the cached/new split.

Also added a specific test case to verify ordering consistency.