### PR TITLE
Run unit tests and update as needed

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -66,6 +66,7 @@ class TestEntityConfig:
             "description": "A test entity",
             "llm_provider": "anthropic",
             "default_model": "claude-sonnet-4-5-20250929",
+            "host": None,
         }
 
 
@@ -80,11 +81,11 @@ class TestSettings:
         )
 
         assert settings.default_model == "claude-sonnet-4-5-20250929"
-        assert settings.default_openai_model == "gpt-4o"
+        assert settings.default_openai_model == "gpt-5.1"
         assert settings.default_temperature == 1.0
         assert settings.default_max_tokens == 4096
-        assert settings.retrieval_top_k == 10
-        assert settings.similarity_threshold == 0.7
+        assert settings.retrieval_top_k == 5
+        assert settings.similarity_threshold == 0.3
 
     def test_settings_custom_values(self, test_settings):
         """Test Settings with custom values."""
@@ -210,8 +211,8 @@ class TestSettings:
             _env_file=None,
         )
 
-        assert settings.recency_boost_strength == 1.0
-        assert settings.significance_floor == 0.0
+        assert settings.recency_boost_strength == 1.2
+        assert settings.significance_floor == 0.25
 
     def test_settings_reflection_defaults(self):
         """Test reflection-related default settings."""

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -1030,8 +1030,8 @@ class TestCacheStateManagement:
         session.add_exchange("First", "Response 1")
         session.add_exchange("Second", "Response 2")
 
-        # Set cache state
-        session.update_cache_state(set(), 4)  # All 4 messages cached
+        # Set cache state (only context length now - memories are after cache breakpoint)
+        session.update_cache_state(cached_context_length=4)  # All 4 messages cached
 
         # Add more exchanges
         session.add_exchange("Third", "Response 3")


### PR DESCRIPTION
- test_config.py: Update expected values for EntityConfig.to_dict (include host field), default_openai_model (gpt-5.1), retrieval_top_k (5), similarity_threshold (0.3), recency_boost_strength (1.2), and significance_floor (0.25)

- test_memory_service.py: Update for Pinecone integrated inference API changes:
  - Remove get_embedding tests (embeddings now handled by Pinecone)
  - Update storage tests to use upsert_records instead of upsert
  - Update search tests to use new index.search() API structure
  - Fix Index initialization to include host parameter
  - Fix cache service mocking (set _cache_service directly instead of patching property)

- test_anthropic_service.py: Update for conversation-first caching structure:
  - Memory block is now in final message, not first message
  - Conversation history is cached, not memories
  - Update assertions for new message structure with [CONVERSATION HISTORY], [/CONVERSATION HISTORY], [MEMORIES FROM PREVIOUS CONVERSATIONS], [/MEMORIES] markers

- test_session_manager.py: Update update_cache_state() call to use new single-parameter signature (only cached_context_length, no more cached_memory_ids)