### PR TITLE
Add gruut phonemizer as alternative to espeak

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,8 +10,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Choose ONE of the following TTS options:
 #   1. ElevenLabs (cloud-based) - Set ELEVENLABS_API_KEY
 #   2. XTTS v2 (local) - Set XTTS_ENABLED=true
+#   3. StyleTTS 2 (local) - Set STYLETTS2_ENABLED=true
 #
-# If both are configured, XTTS takes priority over ElevenLabs.
+# Priority order: StyleTTS 2 > XTTS > ElevenLabs
 
 # ElevenLabs TTS Configuration (optional, cloud-based TTS)
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
@@ -32,16 +33,36 @@ ELEVENLABS_VOICES='[
 #      Or for CPU only: pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
 #   2. Install XTTS deps: pip install -r requirements-xtts.txt
 #   3. Run the server: python run_xtts.py
-XTTS_ENABLED=true
-XTTS_API_URL=http://localhost:8020
-XTTS_LANGUAGE=en
-XTTS_VOICES_DIR=./xtts_voices
+# XTTS_ENABLED=true
+# XTTS_API_URL=http://localhost:8020
+# XTTS_LANGUAGE=en
+# XTTS_VOICES_DIR=./xtts_voices
 # Optional: Default speaker sample file path (if not using cloned voices)
 # XTTS_DEFAULT_SPEAKER=/path/to/speaker.wav
 # Optional: Pre-load speaker latents on startup (comma-separated paths)
 # Speaker latents are cached to avoid recomputing them for each TTS request.
 # If XTTS_VOICES_DIR/voices.json exists, those voices are also preloaded automatically.
 # XTTS_PRELOAD_SPEAKERS=/path/to/speaker1.wav,/path/to/speaker2.wav
+
+# StyleTTS 2 Local TTS Configuration (optional, local TTS with voice cloning)
+# StyleTTS 2 takes priority over XTTS and ElevenLabs if enabled.
+# Requires the StyleTTS 2 server to be running. Start it with:
+#   1. Install PyTorch first (GPU): pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118
+#      Or for CPU only: pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+#   2. Install StyleTTS 2 deps: pip install -r requirements-styletts2.txt
+#   3. Run the server: python run_styletts2.py
+# STYLETTS2_ENABLED=true
+# STYLETTS2_API_URL=http://localhost:8021
+# STYLETTS2_VOICES_DIR=./styletts2_voices
+# Optional: Default speaker sample file path (if not using cloned voices)
+# STYLETTS2_DEFAULT_SPEAKER=/path/to/speaker.wav
+# Optional: Pre-load speaker embeddings on startup (comma-separated paths)
+# STYLETTS2_PRELOAD_SPEAKERS=/path/to/speaker1.wav,/path/to/speaker2.wav
+#
+# Phonemizer backend: "gruut" (default, MIT licensed, no system deps) or "espeak"
+# gruut is recommended unless you specifically need espeak-ng quality.
+# If using espeak, install espeak-ng on your system first.
+# STYLETTS2_PHONEMIZER=gruut
 
 # Pinecone Configuration
 # Each index represents a different AI entity with separate memory/conversation history

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -166,6 +166,8 @@ class Settings(BaseSettings):
     styletts2_default_speaker: str = ""
     # Directory to store cloned voice samples
     styletts2_voices_dir: str = "./styletts2_voices"
+    # Phonemizer backend: "gruut" (MIT licensed, no system deps) or "espeak" (requires espeak-ng)
+    styletts2_phonemizer: str = "gruut"
 
     # Multiple Pinecone indexes (JSON array of objects with index_name, label, description, llm_provider, default_model)
     # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity", "llm_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"}]'

--- a/backend/requirements-styletts2.txt
+++ b/backend/requirements-styletts2.txt
@@ -12,28 +12,40 @@
 # For CPU only:
 #   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
 #
-# Step 2: Install espeak-ng (required for phonemizer)
+# Step 2: Choose your phonemizer backend
 # ---------------------------------------------------------
-# Ubuntu/Debian:
-#   sudo apt install espeak-ng
+# The server supports two phonemizer backends:
 #
-# macOS:
-#   brew install espeak-ng
+# Option A - gruut (default, recommended):
+#   - MIT licensed, pure Python
+#   - No system dependencies required
+#   - Set STYLETTS2_PHONEMIZER=gruut (or leave unset)
+#   - Just install this requirements file
 #
-# Windows:
-#   Download from https://github.com/espeak-ng/espeak-ng/releases
+# Option B - espeak:
+#   - Requires espeak-ng system package
+#   - Higher quality phonemization in some cases
+#   - Set STYLETTS2_PHONEMIZER=espeak
+#   - Install espeak-ng first:
+#     Ubuntu/Debian: sudo apt install espeak-ng
+#     macOS: brew install espeak-ng
+#     Windows: https://github.com/espeak-ng/espeak-ng/releases
 #
 # Step 3: Install this requirements file
 # ---------------------------------------------------------
 #   pip install -r requirements-styletts2.txt
 #
 # Note: Requires Python 3.9-3.11. Python 3.12+ may have compatibility issues.
-# Note: On Windows, you may need Visual Studio Build Tools installed.
+# Note: On Windows with espeak, you may need to set PHONEMIZER_ESPEAK_LIBRARY.
 
 # StyleTTS 2 library (install after PyTorch)
 styletts2
 
-# Phonemizer for text-to-phoneme conversion (requires espeak-ng system package)
+# Gruut phonemizer (MIT licensed, no system deps - default option)
+gruut>=2.4.0
+
+# Phonemizer for espeak backend (optional, requires espeak-ng system package)
+# Only needed if you set STYLETTS2_PHONEMIZER=espeak
 phonemizer>=3.2.0
 
 # Additional dependencies


### PR DESCRIPTION
- Add STYLETTS2_PHONEMIZER env var to select backend ("gruut" or "espeak")
- gruut is now the default (MIT licensed, no system dependencies)
- Create GruutPhonemizer and EspeakPhonemizer classes with common interface
- Inject selected phonemizer into StyleTTS 2 model at initialization
- Add gruut>=2.4.0 to requirements-styletts2.txt
- Update server status endpoints to show current phonemizer
- Update documentation with phonemizer options and installation instructions