### PR TITLE
Add support for GPT 5.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1254,7 +1254,7 @@ DEFAULT_OPENAI_MODEL = "gpt-5.1"  # OpenAI default
 
 # Supported OpenAI models include:
 #   gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4
-#   gpt-5.1, gpt-5-mini, gpt-5.1-chat-latest
+#   gpt-5.1, gpt-5.2, gpt-5-mini, gpt-5.1-chat-latest
 #   o1, o1-mini, o1-preview, o3, o3-mini, o4-mini
 
 # Memory settings (config.py)
@@ -1277,8 +1277,8 @@ significance = times_retrieved * recency_factor * half_life_modifier
 # half_life_modifier = 0.5 ^ (days_since_creation / significance_half_life_days)
 # Final significance = max(calculated_significance, significance_floor)
 
-# GPT-5.1 verbosity setting (config.py)
-default_verbosity = "medium"  # Options: "low", "medium", "high" for GPT-5.1 models
+# GPT-5.x verbosity setting (config.py)
+default_verbosity = "medium"  # Options: "low", "medium", "high" for GPT-5.x models
 
 # XTTS defaults (config.py)
 xtts_enabled = False              # Must be explicitly enabled

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -221,6 +221,7 @@ class Settings(BaseSettings):
     #   - gpt-4-turbo
     #   - gpt-4
     #   - gpt-5.1
+    #   - gpt-5.2
     #   - gpt-5-mini
     #   - gpt-5.1-chat-latest
     #   - o1

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -38,6 +38,7 @@ MODEL_PROVIDER_MAP = {
     "gpt-3.5-turbo": ModelProvider.OPENAI,
     # OpenAI GPT-5 models
     "gpt-5.1": ModelProvider.OPENAI,
+    "gpt-5.2": ModelProvider.OPENAI,
     "gpt-5-mini": ModelProvider.OPENAI,
     "gpt-5.1-chat-latest": ModelProvider.OPENAI,
     # OpenAI o-series models
@@ -60,6 +61,7 @@ AVAILABLE_MODELS = {
         {"id": "claude-opus-4-20250514", "name": "Claude Opus 4"},
     ],
     ModelProvider.OPENAI: [
+        {"id": "gpt-5.2", "name": "GPT-5.2"},
         {"id": "gpt-5.1", "name": "GPT-5.1"},
         {"id": "gpt-5-mini", "name": "GPT-5 Mini"},
         {"id": "gpt-5.1-chat-latest", "name": "GPT-5.1 Chat (Latest)"},

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -16,6 +16,7 @@ class OpenAIService:
         "o3", "o3-mini",
         "o4-mini",
         "gpt-5.1", "gpt-5-mini", "gpt-5.1-chat-latest",
+        "gpt-5.2",
     }
 
     # Models that don't support the temperature parameter
@@ -24,6 +25,7 @@ class OpenAIService:
         "o3", "o3-mini",
         "o4-mini",
         "gpt-5.1", "gpt-5.1-chat-latest",
+        "gpt-5.2",
     }
 
     # Models that don't support stream_options
@@ -34,6 +36,7 @@ class OpenAIService:
     # Models that support the verbosity parameter
     MODELS_WITH_VERBOSITY = {
         "gpt-5.1", "gpt-5.1-chat-latest",
+        "gpt-5.2",
     }
 
     def __init__(self):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -128,7 +128,7 @@
                 </div>
 
                 <div class="form-group" id="verbosity-group">
-                    <label for="verbosity-select">Verbosity (GPT-5.1 only)</label>
+                    <label for="verbosity-select">Verbosity (GPT-5.x only)</label>
                     <select id="verbosity-select">
                         <option value="low">Low</option>
                         <option value="medium">Medium</option>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1301,7 +1301,7 @@ class App {
                 this.elements.verbosityGroup.title = '';
             } else {
                 this.elements.verbosityGroup.classList.add('disabled');
-                this.elements.verbosityGroup.title = 'Verbosity is only supported by GPT-5.1 models';
+                this.elements.verbosityGroup.title = 'Verbosity is only supported by GPT-5.x models';
             }
         }
     }


### PR DESCRIPTION
- Add gpt-5.2 to MODEL_PROVIDER_MAP and AVAILABLE_MODELS in llm_service
- Add gpt-5.2 to model capability sets in openai_service:
  - MODELS_WITH_COMPLETION_TOKENS
  - MODELS_WITHOUT_TEMPERATURE
  - MODELS_WITH_VERBOSITY
- Update supported models comment in config.py
- Update frontend verbosity labels to say GPT-5.x instead of GPT-5.1
- Update CLAUDE.md documentation