### PR TITLE
Allow renaming of conversations

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -389,6 +389,26 @@
         </div>
     </div>
 
+    <!-- Rename Conversation Modal -->
+    <div class="modal" id="rename-modal">
+        <div class="modal-content small">
+            <div class="modal-header">
+                <h3>Rename Conversation</h3>
+                <button class="close-btn" id="close-rename">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="rename-input">Title</label>
+                    <input type="text" id="rename-input" maxlength="255" placeholder="Enter conversation title">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-rename" class="secondary-btn">Cancel</button>
+                <button id="confirm-rename" class="primary-btn">Save</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Delete Confirmation Modal -->
     <div class="modal" id="delete-modal">
         <div class="modal-content small">


### PR DESCRIPTION
Add the ability to rename conversations via a new "Rename" option in the conversation dropdown menu. Features:
- Rename modal with title input field
- Support for Enter key to submit
- Auto-focus on input when modal opens
- Updates both local state and header when current conversation is renamed