### PR TITLE
Add tool use capabilities to AI entities

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,6 +69,18 @@ ELEVENLABS_VOICES='[
 # Default fixes are used if not set. Set to {} to disable all fixes.
 # STYLETTS2_PRONUNCIATION_FIXES='{"turned": "turnd", "learned": "lernd", "burned": "burnd", "earned": "ernd", "into": "in to"}'
 
+# ============================================================================
+# TOOL USE CONFIGURATION
+# ============================================================================
+# Enable AI tool use (web search, content fetching)
+# TOOLS_ENABLED=true
+# Maximum iterations for tool use before forcing final response (default: 10)
+# TOOL_USE_MAX_ITERATIONS=10
+
+# Brave Search API key (for web search tool)
+# Get your API key at: https://brave.com/search/api/
+BRAVE_SEARCH_API_KEY=your_brave_search_api_key_here
+
 # Pinecone Configuration
 # Each index represents a different AI entity with separate memory/conversation history
 # Format: JSON array of objects with:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -170,6 +170,14 @@ class Settings(BaseSettings):
     # Phonemizer backend: "gruut" (MIT licensed, no system deps) or "espeak" (requires espeak-ng)
     styletts2_phonemizer: str = "gruut"
 
+    # Tool Use settings
+    # Enable tool use (web search, content fetching) for AI entities
+    tools_enabled: bool = True
+    # Maximum number of tool use iterations before forcing a final response
+    tool_use_max_iterations: int = 10
+    # Brave Search API key (for web search tool)
+    brave_search_api_key: str = ""
+
     # Multiple Pinecone indexes (JSON array of objects with index_name, label, description, llm_provider, default_model)
     # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity", "llm_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"}]'
     pinecone_indexes: str = ""

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -7,6 +7,11 @@ from app.services.session_manager import ConversationSession, SessionManager, se
 from app.services.cache_service import CacheService, TTLCache, cache_service
 from app.services.tts_service import TTSService, tts_service
 from app.services.xtts_service import XTTSService, xtts_service
+from app.services.tool_service import ToolService, ToolCategory, ToolResult, tool_service
+from app.services.web_tools import register_web_tools
+
+# Register web tools at module load time
+register_web_tools(tool_service)
 
 __all__ = [
     # Classes
@@ -21,6 +26,9 @@ __all__ = [
     "TTLCache",
     "TTSService",
     "XTTSService",
+    "ToolService",
+    "ToolCategory",
+    "ToolResult",
     # Singleton instances
     "anthropic_service",
     "openai_service",
@@ -31,4 +39,7 @@ __all__ = [
     "cache_service",
     "tts_service",
     "xtts_service",
+    "tool_service",
+    # Tool registration functions
+    "register_web_tools",
 ]

--- a/backend/app/services/tool_service.py
+++ b/backend/app/services/tool_service.py
@@ -1,0 +1,272 @@
+"""
+Tool Service for managing AI tool use capabilities.
+
+This service provides:
+- Tool registration with schemas and executor functions
+- Tool schema generation in Anthropic format
+- Tool execution with error handling
+- Batch tool execution with async parallelization
+"""
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Set, Awaitable
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ToolCategory(str, Enum):
+    """Categories for organizing tools."""
+    WEB = "web"
+    MEMORY = "memory"
+    UTILITY = "utility"
+
+
+@dataclass
+class ToolResult:
+    """Result from a tool execution."""
+    tool_use_id: str
+    content: str
+    is_error: bool = False
+
+
+@dataclass
+class ToolDefinition:
+    """Definition of a tool including its schema and executor."""
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    executor: Callable[..., Awaitable[str]]
+    category: ToolCategory
+    enabled: bool = True
+
+
+class ToolService:
+    """
+    Service for managing tool registration and execution.
+
+    Tools allow AI entities to perform actions like web searches,
+    content fetching, and other external operations during conversations.
+    """
+
+    def __init__(self):
+        self._tools: Dict[str, ToolDefinition] = {}
+        logger.info("ToolService initialized")
+
+    def register_tool(
+        self,
+        name: str,
+        description: str,
+        input_schema: Dict[str, Any],
+        executor: Callable[..., Awaitable[str]],
+        category: ToolCategory = ToolCategory.UTILITY,
+        enabled: bool = True,
+    ) -> None:
+        """
+        Register a new tool.
+
+        Args:
+            name: Unique tool name (snake_case recommended)
+            description: Human-readable description for the AI
+            input_schema: JSON Schema for the tool's input parameters
+            executor: Async function that executes the tool
+            category: Tool category for organization
+            enabled: Whether the tool is enabled by default
+        """
+        if name in self._tools:
+            logger.warning(f"Tool '{name}' already registered, overwriting")
+
+        self._tools[name] = ToolDefinition(
+            name=name,
+            description=description,
+            input_schema=input_schema,
+            executor=executor,
+            category=category,
+            enabled=enabled,
+        )
+        logger.info(f"Registered tool: {name} (category={category.value}, enabled={enabled})")
+
+    def unregister_tool(self, name: str) -> bool:
+        """
+        Unregister a tool.
+
+        Args:
+            name: Tool name to unregister
+
+        Returns:
+            True if tool was removed, False if not found
+        """
+        if name in self._tools:
+            del self._tools[name]
+            logger.info(f"Unregistered tool: {name}")
+            return True
+        return False
+
+    def get_tool(self, name: str) -> Optional[ToolDefinition]:
+        """Get a tool definition by name."""
+        return self._tools.get(name)
+
+    def list_tools(
+        self,
+        categories: Optional[List[ToolCategory]] = None,
+        enabled_only: bool = True,
+    ) -> List[ToolDefinition]:
+        """
+        List registered tools.
+
+        Args:
+            categories: Filter by categories (None = all)
+            enabled_only: Only return enabled tools
+
+        Returns:
+            List of matching tool definitions
+        """
+        tools = list(self._tools.values())
+
+        if enabled_only:
+            tools = [t for t in tools if t.enabled]
+
+        if categories:
+            category_set: Set[ToolCategory] = set(categories)
+            tools = [t for t in tools if t.category in category_set]
+
+        return tools
+
+    def get_tool_schemas(
+        self,
+        categories: Optional[List[ToolCategory]] = None,
+        enabled_only: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get tool schemas in Anthropic API format.
+
+        Args:
+            categories: Filter by categories (None = all)
+            enabled_only: Only return enabled tools
+
+        Returns:
+            List of tool schemas ready for Anthropic API
+        """
+        tools = self.list_tools(categories=categories, enabled_only=enabled_only)
+
+        schemas = []
+        for tool in tools:
+            schema = {
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.input_schema,
+            }
+            schemas.append(schema)
+
+        return schemas
+
+    async def execute_tool(
+        self,
+        tool_use_id: str,
+        tool_name: str,
+        tool_input: Dict[str, Any],
+    ) -> ToolResult:
+        """
+        Execute a single tool.
+
+        Args:
+            tool_use_id: Unique ID for this tool use
+            tool_name: Name of the tool to execute
+            tool_input: Input parameters for the tool
+
+        Returns:
+            ToolResult with the execution result or error
+        """
+        tool = self._tools.get(tool_name)
+
+        if not tool:
+            logger.error(f"Tool not found: {tool_name}")
+            return ToolResult(
+                tool_use_id=tool_use_id,
+                content=f"Error: Tool '{tool_name}' not found",
+                is_error=True,
+            )
+
+        if not tool.enabled:
+            logger.warning(f"Tool disabled: {tool_name}")
+            return ToolResult(
+                tool_use_id=tool_use_id,
+                content=f"Error: Tool '{tool_name}' is currently disabled",
+                is_error=True,
+            )
+
+        try:
+            logger.info(f"Executing tool: {tool_name} with input: {tool_input}")
+            result = await tool.executor(**tool_input)
+            logger.info(f"Tool {tool_name} completed successfully (result length: {len(result)})")
+            return ToolResult(
+                tool_use_id=tool_use_id,
+                content=result,
+                is_error=False,
+            )
+        except Exception as e:
+            error_msg = f"Error executing tool '{tool_name}': {str(e)}"
+            logger.exception(error_msg)
+            return ToolResult(
+                tool_use_id=tool_use_id,
+                content=error_msg,
+                is_error=True,
+            )
+
+    async def execute_tools(
+        self,
+        tool_calls: List[Dict[str, Any]],
+    ) -> List[ToolResult]:
+        """
+        Execute multiple tools in parallel.
+
+        Args:
+            tool_calls: List of tool calls, each with:
+                - id: Tool use ID
+                - name: Tool name
+                - input: Tool input parameters
+
+        Returns:
+            List of ToolResults in the same order as input
+        """
+        if not tool_calls:
+            return []
+
+        # Create tasks for parallel execution
+        tasks = []
+        for call in tool_calls:
+            task = self.execute_tool(
+                tool_use_id=call["id"],
+                tool_name=call["name"],
+                tool_input=call.get("input", {}),
+            )
+            tasks.append(task)
+
+        # Execute all tools in parallel
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+
+        return list(results)
+
+    def set_tool_enabled(self, name: str, enabled: bool) -> bool:
+        """
+        Enable or disable a tool.
+
+        Args:
+            name: Tool name
+            enabled: Whether to enable or disable
+
+        Returns:
+            True if tool was found and updated, False otherwise
+        """
+        tool = self._tools.get(name)
+        if tool:
+            tool.enabled = enabled
+            logger.info(f"Tool '{name}' {'enabled' if enabled else 'disabled'}")
+            return True
+        return False
+
+
+# Singleton instance
+tool_service = ToolService()

--- a/backend/app/services/web_tools.py
+++ b/backend/app/services/web_tools.py
@@ -1,0 +1,272 @@
+"""
+Web tools for AI entities.
+
+Provides web search and content fetching capabilities that AI entities
+can use during conversations to gather current information.
+"""
+
+import httpx
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from bs4 import BeautifulSoup
+
+from app.config import settings
+from app.services.tool_service import ToolCategory, ToolService
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Constants
+BRAVE_SEARCH_API_URL = "https://api.search.brave.com/res/v1/web/search"
+SEARCH_TIMEOUT = 10.0  # seconds
+FETCH_TIMEOUT = 15.0  # seconds
+DEFAULT_NUM_RESULTS = 5
+DEFAULT_MAX_LENGTH = 50000
+
+
+async def web_search(query: str, num_results: int = DEFAULT_NUM_RESULTS) -> str:
+    """
+    Search the web using Brave Search API.
+
+    Args:
+        query: The search query string
+        num_results: Number of results to return (default: 5)
+
+    Returns:
+        Formatted search results as text, or error message
+    """
+    api_key = settings.brave_search_api_key
+    if not api_key:
+        return "Error: Web search is not configured. The BRAVE_SEARCH_API_KEY environment variable is not set."
+
+    try:
+        async with httpx.AsyncClient(timeout=SEARCH_TIMEOUT) as client:
+            response = await client.get(
+                BRAVE_SEARCH_API_URL,
+                headers={
+                    "X-Subscription-Token": api_key,
+                    "Accept": "application/json",
+                },
+                params={
+                    "q": query,
+                    "count": min(num_results, 20),  # Brave API limits to 20
+                },
+            )
+
+            if response.status_code == 401:
+                return "Error: Invalid Brave Search API key."
+            elif response.status_code == 429:
+                return "Error: Brave Search API rate limit exceeded. Please try again later."
+            elif response.status_code != 200:
+                return f"Error: Brave Search API returned status {response.status_code}"
+
+            data = response.json()
+
+            # Extract web results
+            web_results = data.get("web", {}).get("results", [])
+            if not web_results:
+                return f"No search results found for: {query}"
+
+            # Format results
+            formatted_results = []
+            for i, result in enumerate(web_results[:num_results], 1):
+                title = result.get("title", "No title")
+                url = result.get("url", "No URL")
+                description = result.get("description", "No description")
+
+                formatted_results.append(
+                    f"{i}. {title}\n"
+                    f"   URL: {url}\n"
+                    f"   {description}"
+                )
+
+            output = f"Search results for: {query}\n\n" + "\n\n".join(formatted_results)
+            logger.info(f"Web search completed: {len(web_results)} results for '{query}'")
+            return output
+
+    except httpx.TimeoutException:
+        return f"Error: Search request timed out after {SEARCH_TIMEOUT} seconds."
+    except httpx.RequestError as e:
+        return f"Error: Failed to connect to search service: {str(e)}"
+    except Exception as e:
+        logger.exception(f"Unexpected error during web search: {e}")
+        return f"Error: An unexpected error occurred during search: {str(e)}"
+
+
+async def web_fetch(url: str, max_length: int = DEFAULT_MAX_LENGTH) -> str:
+    """
+    Fetch and extract content from a URL.
+
+    For HTML pages, extracts text content while removing navigation,
+    scripts, and other non-content elements.
+
+    Args:
+        url: The URL to fetch
+        max_length: Maximum content length to return (default: 50000)
+
+    Returns:
+        Extracted content as text, or error message
+    """
+    try:
+        async with httpx.AsyncClient(timeout=FETCH_TIMEOUT, follow_redirects=True) as client:
+            response = await client.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; HereIAm/1.0; Research Tool)",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,application/json,text/plain;q=0.8,*/*;q=0.5",
+                },
+            )
+
+            if response.status_code == 403:
+                return f"Error: Access denied (403 Forbidden) for URL: {url}"
+            elif response.status_code == 404:
+                return f"Error: Page not found (404) for URL: {url}"
+            elif response.status_code != 200:
+                return f"Error: Failed to fetch URL (status {response.status_code}): {url}"
+
+            content_type = response.headers.get("content-type", "").lower()
+            content = response.text
+
+            # Handle JSON content
+            if "application/json" in content_type:
+                try:
+                    json_data = response.json()
+                    formatted_json = json.dumps(json_data, indent=2)
+                    if len(formatted_json) > max_length:
+                        formatted_json = formatted_json[:max_length] + "\n...[truncated]"
+                    return f"JSON content from {url}:\n\n{formatted_json}"
+                except json.JSONDecodeError:
+                    pass  # Fall through to text handling
+
+            # Handle HTML content
+            if "text/html" in content_type or content.strip().startswith("<!"):
+                soup = BeautifulSoup(content, "html.parser")
+
+                # Remove unwanted elements
+                for element in soup.find_all([
+                    "script", "style", "nav", "footer", "header",
+                    "aside", "noscript", "iframe", "form"
+                ]):
+                    element.decompose()
+
+                # Try to find main content area
+                main_content = None
+                for selector in ["main", "article", '[role="main"]', ".content", "#content"]:
+                    main_content = soup.select_one(selector)
+                    if main_content:
+                        break
+
+                # Extract text from main content or body
+                if main_content:
+                    text = main_content.get_text(separator="\n", strip=True)
+                else:
+                    body = soup.find("body")
+                    if body:
+                        text = body.get_text(separator="\n", strip=True)
+                    else:
+                        text = soup.get_text(separator="\n", strip=True)
+
+                # Clean up whitespace
+                lines = [line.strip() for line in text.split("\n") if line.strip()]
+                cleaned_text = "\n".join(lines)
+
+                if len(cleaned_text) > max_length:
+                    cleaned_text = cleaned_text[:max_length] + "\n...[truncated]"
+
+                # Get page title
+                title = soup.find("title")
+                title_text = title.get_text(strip=True) if title else "No title"
+
+                output = f"Content from: {url}\nTitle: {title_text}\n\n{cleaned_text}"
+                logger.info(f"Web fetch completed: {len(cleaned_text)} chars from '{url}'")
+                return output
+
+            # Handle plain text
+            if len(content) > max_length:
+                content = content[:max_length] + "\n...[truncated]"
+
+            return f"Content from {url}:\n\n{content}"
+
+    except httpx.TimeoutException:
+        return f"Error: Request timed out after {FETCH_TIMEOUT} seconds for URL: {url}"
+    except httpx.RequestError as e:
+        return f"Error: Failed to connect to URL: {str(e)}"
+    except Exception as e:
+        logger.exception(f"Unexpected error fetching URL: {e}")
+        return f"Error: An unexpected error occurred: {str(e)}"
+
+
+def register_web_tools(tool_service: ToolService) -> None:
+    """
+    Register web tools with the tool service.
+
+    Args:
+        tool_service: The ToolService instance to register with
+    """
+    # Register web_search tool
+    tool_service.register_tool(
+        name="web_search",
+        description=(
+            "Search the web for current information. Use this tool when you need "
+            "to find recent news, facts, data, or any information that might be "
+            "more current than your training data. Returns a list of search results "
+            "with titles, URLs, and descriptions."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query. Be specific and include relevant keywords.",
+                },
+                "num_results": {
+                    "type": "integer",
+                    "description": "Number of results to return (default: 5, max: 20).",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["query"],
+        },
+        executor=web_search,
+        category=ToolCategory.WEB,
+        enabled=True,
+    )
+
+    # Register web_fetch tool
+    tool_service.register_tool(
+        name="web_fetch",
+        description=(
+            "Fetch and read the content of a specific web page. Use this tool when "
+            "you have a URL and need to read its content. The tool extracts the main "
+            "text content from HTML pages, removing navigation and other non-content "
+            "elements. Also handles JSON and plain text content."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The full URL to fetch (must include http:// or https://).",
+                },
+                "max_length": {
+                    "type": "integer",
+                    "description": "Maximum characters to return (default: 50000).",
+                    "default": 50000,
+                    "minimum": 1000,
+                    "maximum": 100000,
+                },
+            },
+            "required": ["url"],
+        },
+        executor=web_fetch,
+        category=ToolCategory.WEB,
+        enabled=True,
+    )
+
+    logger.info("Web tools registered: web_search, web_fetch")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ numpy>=1.26.0,<3.0.0
 tiktoken==0.6.0
 aiofiles==23.2.1
 python-multipart==0.0.9
+beautifulsoup4>=4.12.0
 
 # Testing dependencies
 pytest==8.3.3

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -904,6 +904,97 @@ h4.md-header {
     51%, 100% { opacity: 0; }
 }
 
+/* Tool Use Messages */
+.tool-message {
+    margin: 8px auto;
+    max-width: 800px;
+    padding: 8px 12px;
+    background-color: var(--bg-tertiary);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.tool-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tool-icon {
+    font-size: 1rem;
+    opacity: 0.8;
+}
+
+.tool-name {
+    font-weight: 500;
+    color: var(--text-primary);
+    text-transform: capitalize;
+}
+
+.tool-status {
+    margin-left: auto;
+    font-size: 0.9rem;
+}
+
+.tool-status.loading {
+    color: var(--accent);
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+.tool-status.success {
+    color: var(--success);
+}
+
+.tool-status.error {
+    color: var(--danger);
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+}
+
+.tool-input-details,
+.tool-result-details {
+    margin-top: 8px;
+}
+
+.tool-input-details summary,
+.tool-result-details summary {
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    user-select: none;
+}
+
+.tool-input-details summary:hover,
+.tool-result-details summary:hover {
+    color: var(--text-secondary);
+}
+
+.tool-input,
+.tool-result {
+    margin-top: 6px;
+    padding: 8px;
+    background-color: var(--bg-secondary);
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.tool-result.error {
+    border-left: 2px solid var(--danger);
+    color: var(--danger);
+}
+
 /* Input Area */
 .input-area {
     padding: 16px 24px;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -242,6 +242,8 @@ class ApiClient {
      * @param {Function} callbacks.onMemories - Called with memory retrieval info
      * @param {Function} callbacks.onStart - Called when streaming starts
      * @param {Function} callbacks.onToken - Called for each token
+     * @param {Function} callbacks.onToolStart - Called when a tool starts executing
+     * @param {Function} callbacks.onToolResult - Called with tool execution result
      * @param {Function} callbacks.onDone - Called when streaming completes
      * @param {Function} callbacks.onStored - Called when messages are stored
      * @param {Function} callbacks.onError - Called on error
@@ -335,6 +337,12 @@ class ApiClient {
                 break;
             case 'token':
                 if (callbacks.onToken) callbacks.onToken(data);
+                break;
+            case 'tool_start':
+                if (callbacks.onToolStart) callbacks.onToolStart(data);
+                break;
+            case 'tool_result':
+                if (callbacks.onToolResult) callbacks.onToolResult(data);
                 break;
             case 'done':
                 if (callbacks.onDone) callbacks.onDone(data);


### PR DESCRIPTION
Implement tool use feature allowing AI entities to autonomously use web search and content fetching during conversations:

Backend changes:
- Add tool configuration (BRAVE_SEARCH_API_KEY, TOOLS_ENABLED, TOOL_USE_MAX_ITERATIONS)
- Create ToolService with tool registration, schema generation, and execution
- Create web_tools.py with web_search (Brave API) and web_fetch functions
- Update AnthropicService to handle tool_use responses in both send_message and streaming
- Update LLMService to pass tools parameter to Anthropic provider
- Update SessionManager.process_message_stream with tool use loop
- Update chat routes to pass tool schemas and forward tool events via SSE

Frontend changes:
- Add onToolStart and onToolResult callbacks to API client
- Create addToolMessage method for displaying tool indicators
- Add CSS styles for tool messages with collapsible input/result sections

The AI decides when to use tools based on tool descriptions and conversation context. Tool results are shown in the UI for transparency.