### PR TITLE
Add OpenAI support for web search tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Beyond separate entity workspaces, the application supports **multi-entity conve
 
 ### Tool Use System (Web Search & Fetch)
 
-The application supports **agentic tool use** for Anthropic/Claude models, allowing the AI to search the web and fetch content from URLs during conversations.
+The application supports **agentic tool use** for Anthropic (Claude) and OpenAI (GPT) models, allowing the AI to search the web and fetch content from URLs during conversations.
 
 **Available Tools:**
 - **web_search** - Search the web using Brave Search API (returns up to 20 results)
@@ -121,9 +121,9 @@ The application supports **agentic tool use** for Anthropic/Claude models, allow
 
 **How Tool Use Works:**
 
-1. **Agentic Loop**: When Claude responds with a tool request, the system executes the tool and feeds results back to Claude in a loop (max 10 iterations)
+1. **Agentic Loop**: When the AI responds with a tool request, the system executes the tool and feeds results back in a loop (max 10 iterations)
 2. **Streaming**: Tool execution is streamed in real-time with visual indicators in the UI
-3. **Provider Gating**: Tool use is **only available for Anthropic models** (Claude) - OpenAI and Google models do not currently support tool use in this application
+3. **Provider Support**: Tool use is available for **Anthropic (Claude) and OpenAI (GPT)** models - Google models do not currently support tool use in this application
 
 **Configuration:**
 ```bash
@@ -144,7 +144,7 @@ TOOL_USE_MAX_ITERATIONS=10
 
 **Technical Notes:**
 - Tools are registered at module load time via `register_web_tools()`
-- Tool schemas are converted to Anthropic API format automatically
+- Tool schemas are defined in Anthropic format and automatically converted for OpenAI
 - Tool execution is async with proper error handling
 - web_search uses 10-second timeout; web_fetch uses 15-second timeout
 
@@ -924,8 +924,8 @@ PRESETS = {
 3. **Handle errors gracefully** - Return error messages as strings, don't raise exceptions
 
 **Notes:**
-- Tools are only available for Anthropic models
-- Tool schemas are auto-converted to Anthropic API format
+- Tools are available for Anthropic (Claude) and OpenAI (GPT) models
+- Tool schemas are defined in Anthropic format, auto-converted for OpenAI
 - Tools execute in the agentic loop (max 10 iterations by default)
 
 ---
@@ -1266,10 +1266,10 @@ conversation: Conversation
     - A special header is injected to identify participants to each entity
     - Continuation mode (no human message) supported for entity-to-entity flow
 
-16. **Tool Use is Provider-Gated**
-    - Tools (web_search, web_fetch) only work with Anthropic/Claude models
-    - OpenAI and Google models do not receive tool schemas
-    - This is an architectural decision, not a limitation of those APIs
+16. **Tool Use Provider Support**
+    - Tools (web_search, web_fetch) work with Anthropic (Claude) and OpenAI (GPT) models
+    - Google models do not currently receive tool schemas
+    - Tool schemas are defined in Anthropic format, auto-converted for OpenAI
     - Tool results are not persisted to database (visible in conversation but not stored separately)
 
 17. **Web Tools Require External API**

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -435,12 +435,12 @@ async def stream_message(data: ChatRequest):
                 usage_data = {}
                 stop_reason = None
 
-                # Get tool schemas if tools are enabled and using Anthropic
+                # Get tool schemas if tools are enabled and using a supported provider
                 tool_schemas = None
                 if settings.tools_enabled:
-                    # Check if the model is an Anthropic model (tool use only supported for Anthropic)
+                    # Tool use is supported for Anthropic and OpenAI models
                     provider = llm_service.get_provider_for_model(session.model)
-                    if provider == ModelProvider.ANTHROPIC:
+                    if provider in (ModelProvider.ANTHROPIC, ModelProvider.OPENAI):
                         tool_schemas = tool_service.get_tool_schemas()
 
                 async for event in session_manager.process_message_stream(
@@ -831,11 +831,12 @@ async def regenerate_response(data: RegenerateRequest):
                 usage_data = {}
                 stop_reason = None
 
-                # Get tool schemas if tools are enabled and using Anthropic
+                # Get tool schemas if tools are enabled and using a supported provider
                 tool_schemas = None
                 if settings.tools_enabled:
+                    # Tool use is supported for Anthropic and OpenAI models
                     provider = llm_service.get_provider_for_model(session.model)
-                    if provider == ModelProvider.ANTHROPIC:
+                    if provider in (ModelProvider.ANTHROPIC, ModelProvider.OPENAI):
                         tool_schemas = tool_service.get_tool_schemas()
 
                 # Stream the new response

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -198,7 +198,7 @@ class LLMService:
             max_tokens: Max tokens in response
             enable_caching: Enable Anthropic prompt caching (default True, ignored for OpenAI)
             verbosity: Verbosity level for gpt-5.1 models (low, medium, high)
-            tools: Optional list of tool definitions (Anthropic format, only used for Anthropic)
+            tools: Optional list of tool definitions (Anthropic format, converted for OpenAI)
 
         Returns:
             Dict with 'content', 'model', 'usage', 'stop_reason' keys.
@@ -236,7 +236,6 @@ class LLMService:
                 tools=tools,
             )
         elif provider == ModelProvider.OPENAI:
-            # Tool use not currently supported for OpenAI in this implementation
             return await openai_service.send_message(
                 messages=messages,
                 system_prompt=system_prompt,
@@ -244,6 +243,7 @@ class LLMService:
                 temperature=temperature,
                 max_tokens=max_tokens,
                 verbosity=verbosity,
+                tools=tools,
             )
         elif provider == ModelProvider.GOOGLE:
             # Tool use not currently supported for Google in this implementation
@@ -311,7 +311,6 @@ class LLMService:
             ):
                 yield event
         elif provider == ModelProvider.OPENAI:
-            # Tool use not currently supported for OpenAI in this implementation
             async for event in openai_service.send_message_stream(
                 messages=messages,
                 system_prompt=system_prompt,
@@ -319,6 +318,7 @@ class LLMService:
                 temperature=temperature,
                 max_tokens=max_tokens,
                 verbosity=verbosity,
+                tools=tools,
             ):
                 yield event
         elif provider == ModelProvider.GOOGLE:

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -3,6 +3,7 @@ from openai import AsyncOpenAI
 from app.config import settings
 import tiktoken
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,43 @@ class OpenAIService:
         """Check if model supports the verbosity parameter."""
         return model in self.MODELS_WITH_VERBOSITY
 
+    def _convert_tools_to_openai_format(
+        self,
+        tools: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Convert Anthropic-style tool schemas to OpenAI format.
+
+        Anthropic format:
+        {
+            "name": "web_search",
+            "description": "...",
+            "input_schema": {"type": "object", "properties": {...}, "required": [...]}
+        }
+
+        OpenAI format:
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "...",
+                "parameters": {"type": "object", "properties": {...}, "required": [...]}
+            }
+        }
+        """
+        openai_tools = []
+        for tool in tools:
+            openai_tool = {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {"type": "object", "properties": {}}),
+                }
+            }
+            openai_tools.append(openai_tool)
+        return openai_tools
+
     def _ensure_client(self):
         """Lazily initialize the OpenAI client."""
         if self.client is None:
@@ -91,6 +129,7 @@ class OpenAIService:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         verbosity: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """
         Send a message to OpenAI API.
@@ -102,9 +141,11 @@ class OpenAIService:
             temperature: Temperature setting (defaults to 1.0)
             max_tokens: Max tokens in response (defaults to 4096)
             verbosity: Verbosity level for gpt-5.1 models (low, medium, high)
+            tools: Optional list of tool definitions (Anthropic format, will be converted)
 
         Returns:
-            Dict with 'content', 'model', 'usage' keys
+            Dict with 'content', 'model', 'usage', 'stop_reason' keys.
+            If tools are used, also includes 'content_blocks' and 'tool_use'.
         """
         client = self._ensure_client()
 
@@ -117,14 +158,55 @@ class OpenAIService:
         if system_prompt:
             api_messages.append({"role": "system", "content": system_prompt})
 
-        # Map message roles (OpenAI uses 'user' and 'assistant')
+        # Map message roles and handle different content formats
         for msg in messages:
             role = msg["role"]
             content = msg["content"]
+
+            # Handle tool result messages (from agentic loop)
+            if role == "user" and isinstance(content, list):
+                # Check if this is a tool_result message from Anthropic format
+                if content and isinstance(content[0], dict) and content[0].get("type") == "tool_result":
+                    # Convert Anthropic tool_result to OpenAI format
+                    for result in content:
+                        api_messages.append({
+                            "role": "tool",
+                            "tool_call_id": result["tool_use_id"],
+                            "content": result.get("content", ""),
+                        })
+                    continue
+
+            # Handle assistant messages with tool_use blocks
+            if role == "assistant" and isinstance(content, list):
+                # Check if this contains tool_use blocks
+                text_content = ""
+                tool_calls = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "text":
+                            text_content += block.get("text", "")
+                        elif block.get("type") == "tool_use":
+                            tool_calls.append({
+                                "id": block["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": block["name"],
+                                    "arguments": json.dumps(block.get("input", {})),
+                                }
+                            })
+                if tool_calls:
+                    msg_dict = {"role": "assistant", "content": text_content or None}
+                    msg_dict["tool_calls"] = tool_calls
+                    api_messages.append(msg_dict)
+                    continue
+                else:
+                    content = text_content
+
             # Handle Anthropic array format (with cache_control) - extract text
             if isinstance(content, list):
                 content = content[0]["text"] if content else ""
                 logger.warning(f"[OPENAI] Converted array content to string for role={role} (len={len(content)})")
+
             api_messages.append({"role": role, "content": content})
 
         # Build API parameters based on model capabilities
@@ -147,10 +229,42 @@ class OpenAIService:
         if self._supports_verbosity(model):
             api_params["verbosity"] = verbosity or settings.default_verbosity
 
+        # Add tools if provided
+        if tools:
+            api_params["tools"] = self._convert_tools_to_openai_format(tools)
+            logger.info(f"[TOOLS] OpenAI: Sending request with {len(tools)} tools")
+
         response = await client.chat.completions.create(**api_params)
 
-        # Extract content
-        content = response.choices[0].message.content or ""
+        # Extract content and handle tool calls
+        message = response.choices[0].message
+        content = message.content or ""
+        content_blocks = []
+        tool_use_blocks = []
+
+        # Add text content block if present
+        if content:
+            content_blocks.append({"type": "text", "text": content})
+
+        # Check for tool calls
+        if message.tool_calls:
+            for tool_call in message.tool_calls:
+                # Parse arguments from JSON string
+                try:
+                    arguments = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    arguments = {}
+                    logger.error(f"[TOOLS] Failed to parse tool arguments: {tool_call.function.arguments}")
+
+                tool_use_block = {
+                    "type": "tool_use",
+                    "id": tool_call.id,
+                    "name": tool_call.function.name,
+                    "input": arguments,
+                }
+                content_blocks.append(tool_use_block)
+                tool_use_blocks.append(tool_use_block)
+                logger.info(f"[TOOLS] OpenAI tool use detected: {tool_call.function.name} (id={tool_call.id})")
 
         # Build usage dict with cache information when available
         usage = {
@@ -169,12 +283,25 @@ class OpenAIService:
         logger.info(f"[CACHE] OpenAI API Response - input: {usage.get('input_tokens')}, output: {usage.get('output_tokens')}")
         logger.info(f"[CACHE] OpenAI cached tokens: {usage.get('cached_tokens', 0)}")
 
-        return {
+        # Map OpenAI finish_reason to match Anthropic's stop_reason for tool use
+        finish_reason = response.choices[0].finish_reason
+        if finish_reason == "tool_calls":
+            finish_reason = "tool_use"  # Normalize for agentic loop
+
+        result = {
             "content": content,
             "model": response.model,
             "usage": usage,
-            "stop_reason": response.choices[0].finish_reason,
+            "stop_reason": finish_reason,
         }
+
+        # Include content_blocks and tool_use for tool calling support
+        if content_blocks:
+            result["content_blocks"] = content_blocks
+        if tool_use_blocks:
+            result["tool_use"] = tool_use_blocks
+
+        return result
 
     async def send_message_stream(
         self,
@@ -184,6 +311,7 @@ class OpenAIService:
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         verbosity: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """
         Send a message to OpenAI API with streaming response.
@@ -191,7 +319,8 @@ class OpenAIService:
         Yields events with type and data:
         - {"type": "start", "model": str}
         - {"type": "token", "content": str}
-        - {"type": "done", "content": str, "model": str, "usage": dict, "stop_reason": str}
+        - {"type": "tool_use_start", "tool_use": dict} - Start of a tool use block
+        - {"type": "done", "content": str, "content_blocks": list, "tool_use": list|None, "model": str, "usage": dict, "stop_reason": str}
         - {"type": "error", "error": str}
         """
         client = self._ensure_client()
@@ -206,13 +335,54 @@ class OpenAIService:
             api_messages.append({"role": "system", "content": system_prompt})
 
         for msg in messages:
+            role = msg["role"]
             content = msg["content"]
+
+            # Handle tool result messages (from agentic loop)
+            if role == "user" and isinstance(content, list):
+                # Check if this is a tool_result message from Anthropic format
+                if content and isinstance(content[0], dict) and content[0].get("type") == "tool_result":
+                    # Convert Anthropic tool_result to OpenAI format
+                    for result in content:
+                        api_messages.append({
+                            "role": "tool",
+                            "tool_call_id": result["tool_use_id"],
+                            "content": result.get("content", ""),
+                        })
+                    continue
+
+            # Handle assistant messages with tool_use blocks
+            if role == "assistant" and isinstance(content, list):
+                # Check if this contains tool_use blocks
+                text_content = ""
+                tool_calls = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "text":
+                            text_content += block.get("text", "")
+                        elif block.get("type") == "tool_use":
+                            tool_calls.append({
+                                "id": block["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": block["name"],
+                                    "arguments": json.dumps(block.get("input", {})),
+                                }
+                            })
+                if tool_calls:
+                    msg_dict = {"role": "assistant", "content": text_content or None}
+                    msg_dict["tool_calls"] = tool_calls
+                    api_messages.append(msg_dict)
+                    continue
+                else:
+                    content = text_content
+
             # Handle Anthropic array format (with cache_control) - extract text
             if isinstance(content, list):
                 # Array format: [{"type": "text", "text": "...", ...}]
                 content = content[0]["text"] if content else ""
-                logger.warning(f"[OPENAI] Converted array content to string for role={msg['role']} (len={len(content)})")
-            api_messages.append({"role": msg["role"], "content": content})
+                logger.warning(f"[OPENAI] Converted array content to string for role={role} (len={len(content)})")
+            api_messages.append({"role": role, "content": content})
 
         logger.info(f"[OPENAI] Sending {len(api_messages)} messages to API")
 
@@ -222,6 +392,8 @@ class OpenAIService:
 
             full_content = ""
             stop_reason = None
+            content_blocks = []
+            tool_use_blocks = []
 
             # Build API parameters based on model capabilities
             api_params = {
@@ -248,18 +420,64 @@ class OpenAIService:
             if self._supports_verbosity(model):
                 api_params["verbosity"] = verbosity or settings.default_verbosity
 
+            # Add tools if provided
+            if tools:
+                api_params["tools"] = self._convert_tools_to_openai_format(tools)
+                logger.info(f"[TOOLS] OpenAI: Streaming request with {len(tools)} tools")
+
             stream = await client.chat.completions.create(**api_params)
 
             input_tokens = 0
             output_tokens = 0
             cached_tokens = 0
 
+            # Track tool calls as they stream in
+            # OpenAI streams tool calls as deltas with index
+            current_tool_calls: Dict[int, Dict[str, Any]] = {}
+
             async for chunk in stream:
                 if chunk.choices and len(chunk.choices) > 0:
                     delta = chunk.choices[0].delta
+
+                    # Handle text content
                     if delta.content:
                         full_content += delta.content
                         yield {"type": "token", "content": delta.content}
+
+                    # Handle tool calls streaming
+                    if delta.tool_calls:
+                        for tool_call_delta in delta.tool_calls:
+                            idx = tool_call_delta.index
+
+                            # Initialize or update the tool call at this index
+                            if idx not in current_tool_calls:
+                                current_tool_calls[idx] = {
+                                    "id": "",
+                                    "name": "",
+                                    "arguments": "",
+                                }
+
+                            tc = current_tool_calls[idx]
+
+                            # Update tool call ID
+                            if tool_call_delta.id:
+                                tc["id"] = tool_call_delta.id
+
+                            # Update function name and arguments
+                            if tool_call_delta.function:
+                                if tool_call_delta.function.name:
+                                    tc["name"] = tool_call_delta.function.name
+                                    # Emit tool_use_start when we get the name
+                                    yield {
+                                        "type": "tool_use_start",
+                                        "tool_use": {
+                                            "id": tc["id"],
+                                            "name": tc["name"],
+                                        }
+                                    }
+                                if tool_call_delta.function.arguments:
+                                    tc["arguments"] += tool_call_delta.function.arguments
+
                     if chunk.choices[0].finish_reason:
                         stop_reason = chunk.choices[0].finish_reason
 
@@ -270,6 +488,30 @@ class OpenAIService:
                     # Extract cached_tokens from prompt_tokens_details if available
                     if hasattr(chunk.usage, "prompt_tokens_details") and chunk.usage.prompt_tokens_details:
                         cached_tokens = getattr(chunk.usage.prompt_tokens_details, "cached_tokens", 0) or 0
+
+            # Build content blocks for text
+            if full_content:
+                content_blocks.append({"type": "text", "text": full_content})
+
+            # Process accumulated tool calls
+            for idx in sorted(current_tool_calls.keys()):
+                tc = current_tool_calls[idx]
+                if tc["id"] and tc["name"]:
+                    try:
+                        arguments = json.loads(tc["arguments"]) if tc["arguments"] else {}
+                    except json.JSONDecodeError:
+                        arguments = {}
+                        logger.error(f"[TOOLS] Failed to parse tool arguments: {tc['arguments']}")
+
+                    tool_use_block = {
+                        "type": "tool_use",
+                        "id": tc["id"],
+                        "name": tc["name"],
+                        "input": arguments,
+                    }
+                    content_blocks.append(tool_use_block)
+                    tool_use_blocks.append(tool_use_block)
+                    logger.info(f"[TOOLS] OpenAI tool use complete: {tc['name']} (id={tc['id']})")
 
             # Build usage dict with cache information when available
             usage = {
@@ -283,14 +525,26 @@ class OpenAIService:
             logger.info(f"[CACHE] OpenAI Stream API Response - input: {input_tokens}, output: {output_tokens}")
             logger.info(f"[CACHE] OpenAI cached tokens: {cached_tokens}")
 
+            # Map OpenAI finish_reason to match Anthropic's stop_reason for tool use
+            if stop_reason == "tool_calls":
+                stop_reason = "tool_use"  # Normalize for agentic loop
+
             # Yield final done event
-            yield {
+            done_event = {
                 "type": "done",
                 "content": full_content,
                 "model": model,
                 "usage": usage,
                 "stop_reason": stop_reason,
             }
+
+            # Include content_blocks and tool_use for tool calling support
+            if content_blocks:
+                done_event["content_blocks"] = content_blocks
+            if tool_use_blocks:
+                done_event["tool_use"] = tool_use_blocks
+
+            yield done_event
 
         except Exception as e:
             yield {"type": "error", "error": str(e)}


### PR DESCRIPTION
- Add tools parameter to OpenAI service send_message and send_message_stream
- Convert Anthropic tool schema format to OpenAI function calling format
- Handle OpenAI tool call responses and convert back to unified format
- Parse streaming tool calls with argument accumulation
- Map OpenAI finish_reason "tool_calls" to "tool_use" for agentic loop
- Handle tool result messages by converting from Anthropic to OpenAI format
- Update LLM service to pass tools to OpenAI provider
- Update chat routes to enable tools for both Anthropic and OpenAI models
- Update documentation to reflect OpenAI tool support