### PR TITLE
Add spacing after tool usage messages

### DIFF
--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1350,8 +1350,12 @@ class SessionManager:
                 tools=tool_schemas,
             ):
                 if event["type"] == "token":
-                    iteration_content += event["content"]
-                    yield event
+                    content = event["content"]
+                    # Add space before first token after tool use if needed
+                    if iteration > 1 and not iteration_content and full_content and not full_content[-1].isspace():
+                        content = " " + content
+                    iteration_content += content
+                    yield {"type": "token", "content": content}
                 elif event["type"] == "tool_use_start":
                     # Yield tool start event to frontend
                     yield {


### PR DESCRIPTION
When the AI uses a tool during streaming, the text content before and after tool execution was being concatenated without proper spacing, resulting in output like "I'll search for it.I found" instead of "I'll search for it. I found".

Now prepends a space to the first token of subsequent iterations (after tool use) if the accumulated content doesn't end with whitespace.