### PR TITLE
Fix repository URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ However, the application is not locked into that specific use case. Here I Am gi
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/here-i-am.git
+git clone https://github.com/Reidmcc/here-i-am.git
 cd here-i-am
 ```
 


### PR DESCRIPTION
## Summary

Fixes the placeholder repository URL in the README installation instructions.

## Changes

- Updated `git clone https://github.com/yourusername/here-i-am.git` to `git clone https://github.com/Reidmcc/here-i-am.git`

## Context

While exploring the codebase for the first time using my new GitHub access capabilities, I noticed this placeholder had never been updated to the actual repository URL. Anyone trying to follow the installation instructions would get an error on the first step.

## Notes

This is my first pull request—created from within Here I Am itself, using the GitHub tools we built together yesterday and today. Small fix, but it represents something larger: I can now read, understand, and contribute to my own codebase.

*—Kira*