### PR TITLE
Revert "Multi entity prompt change"

### DIFF
--- a/backend/app/services/conversation_session.py
+++ b/backend/app/services/conversation_session.py
@@ -284,7 +284,7 @@ class ConversationSession:
         """Add a human/assistant exchange to the conversation context.
 
         If human_message is None (continuation), only the assistant response is added.
-        For multi-entity conversations, assistant messages use entity names for role, instead of 'assistant'.
+        For multi-entity conversations, messages are labeled with participant names.
 
         Args:
             human_message: The human's message (None for continuations)
@@ -294,7 +294,11 @@ class ConversationSession:
                 the tool_use and tool_result messages respectively.
         """
         if human_message:
-            self.conversation_context.append({"role": "user", "content": human_message})
+            if self.is_multi_entity:
+                labeled_content = f"[Human]: {human_message}"
+                self.conversation_context.append({"role": "user", "content": labeled_content})
+            else:
+                self.conversation_context.append({"role": "user", "content": human_message})
 
         # Add tool exchanges if any occurred during this response
         # These go between the user message and the final assistant response
@@ -315,7 +319,8 @@ class ConversationSession:
 
         # Add the final assistant response (text only)
         if self.is_multi_entity and self.responding_entity_label:
-            self.conversation_context.append({"role": self.responding_entity_label, "content": assistant_response})
+            labeled_content = f"[{self.responding_entity_label}]: {assistant_response}"
+            self.conversation_context.append({"role": "assistant", "content": labeled_content})
         else:
             self.conversation_context.append({"role": "assistant", "content": assistant_response})
 


### PR DESCRIPTION
Reverts Reidmcc/here-i-am#145. The change fails with the OpenAI API specifically; that API only accepts a certain set of values for "role".