### PR TITLE
Add configurable role balance for memory retrieval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -855,6 +855,7 @@ ELEVENLABS_MODEL_ID=eleven_multilingual_v2  # TTS model
 
 # Memory System Enhancement
 # USE_MEMORY_IN_CONTEXT=false           # Insert memories directly into conversation context (experimental)
+# MEMORY_ROLE_BALANCE_ENABLED=true      # Ensure memories include both human and assistant messages (default: true)
 ```
 
 **Entity Configuration (PINECONE_INDEXES):**
@@ -1952,6 +1953,9 @@ significance = times_retrieved * recency_factor * half_life_modifier
 #   Note: days_since_retrieval capped at 1-day minimum to prevent very recent retrievals from dominating
 # half_life_modifier = 0.5 ^ (days_since_creation / significance_half_life_days)
 # Final significance = max(calculated_significance, significance_floor)
+
+# Role balance in memory retrieval
+memory_role_balance_enabled = True  # When True, ensures at least one human and one assistant memory
 
 # GPT-5.x verbosity setting (config.py)
 default_verbosity = "medium"  # Options: "low", "medium", "high" for GPT-5.x models

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -161,6 +161,14 @@ PINECONE_INDEXES='[
     {"index_name": "gpt-research", "label": "GPT", "llm_provider": "openai", "host": "[Your Pincone index host url]", "default_model": "GPT-5.1"}
 ]'
 
+# ============================================================================
+# MEMORY RETRIEVAL CONFIGURATION
+# ============================================================================
+# Role balance ensures retrieved memories include both human and assistant messages
+# when possible. This provides more balanced context by preventing memory sets
+# that are entirely from one role. Set to false to select purely by relevance score.
+# MEMORY_ROLE_BALANCE_ENABLED=true
+
 # Database URL (SQLite for development)
 HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -290,6 +290,11 @@ class Settings(BaseSettings):
     significance_floor: float = 0.25
     significance_half_life_days: int = 60  # Significance halves every N days since memory creation
 
+    # Role balance in memory retrieval
+    # When True, ensures selected memories include at least one human and one assistant message
+    # When False, memories are selected purely by combined score (similarity × significance)
+    memory_role_balance_enabled: bool = True
+
     # Reflection mode
     reflection_seed_count: int = 7
     reflection_exclude_recent_conversations: int = 0

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -430,11 +430,16 @@ class SessionManager:
                     logger.error(f"[MEMORY] Error processing candidate {candidate.get('id', 'unknown')}: {e}")
                     continue
 
-            # Re-rank by combined score and keep top_k with role balance
+            # Re-rank by combined score and keep top_k
             enriched_candidates.sort(key=lambda x: x["combined_score"], reverse=True)
-            top_candidates = _ensure_role_balance(enriched_candidates, top_k)
 
-            logger.info(f"[MEMORY] Re-ranked {len(enriched_candidates)} candidates by significance, keeping top {len(top_candidates)}")
+            # Apply role balance if enabled (ensures at least one human and one assistant message)
+            if settings.memory_role_balance_enabled:
+                top_candidates = _ensure_role_balance(enriched_candidates, top_k)
+            else:
+                top_candidates = enriched_candidates[:top_k]
+
+            logger.info(f"[MEMORY] Re-ranked {len(enriched_candidates)} candidates by significance, keeping top {len(top_candidates)} (role_balance={'on' if settings.memory_role_balance_enabled else 'off'})")
 
             # Step 3: Process top candidates
             for item in top_candidates:
@@ -771,11 +776,16 @@ class SessionManager:
                     logger.error(f"[MEMORY] Error processing candidate {candidate.get('id', 'unknown')}: {e}")
                     continue
 
-            # Re-rank by combined score and keep top_k with role balance
+            # Re-rank by combined score and keep top_k
             enriched_candidates.sort(key=lambda x: x["combined_score"], reverse=True)
-            top_candidates = _ensure_role_balance(enriched_candidates, top_k)
 
-            logger.info(f"[MEMORY] Re-ranked {len(enriched_candidates)} candidates by significance, keeping top {len(top_candidates)}")
+            # Apply role balance if enabled (ensures at least one human and one assistant message)
+            if settings.memory_role_balance_enabled:
+                top_candidates = _ensure_role_balance(enriched_candidates, top_k)
+            else:
+                top_candidates = enriched_candidates[:top_k]
+
+            logger.info(f"[MEMORY] Re-ranked {len(enriched_candidates)} candidates by significance, keeping top {len(top_candidates)} (role_balance={'on' if settings.memory_role_balance_enabled else 'off'})")
 
             # Step 3: Process top candidates
             for item in top_candidates:


### PR DESCRIPTION
Add MEMORY_ROLE_BALANCE_ENABLED config option (default: true) to allow users to disable role balance in memory retrieval. When disabled, memories are selected purely by combined score (similarity × significance) without ensuring at least one human and one assistant message.