### PR TITLE
Implement feature from issue #152

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,56 @@ Beyond separate entity workspaces, the application supports **multi-entity conve
 - Actual participating entities stored in `ConversationEntities` junction table
 - Messages track speaker via `speaker_entity_id` field
 
+### Image and File Attachments (Vision/Multimodal Support)
+
+The application supports **image and file attachments** for multimodal conversations with AI entities.
+
+**Supported Attachment Types:**
+- **Images**: JPEG, PNG, GIF, WebP (analyzed by vision-capable models)
+- **Text Files**: .txt, .md, .py, .js, .ts, .json, .yaml, .yml, .html, .css, .xml, .csv, .log
+- **Documents**: PDF (requires PyPDF2), DOCX (requires python-docx)
+
+**Key Features:**
+- **Ephemeral Attachments**: Images and files are NOT stored in conversation history or memories - they are analyzed in the current turn, and the AI's textual response becomes the persisted context
+- **5MB Size Limit**: Per-file maximum size
+- **Drag & Drop**: Drop files directly onto the input area
+- **File Picker**: Click the attachment button (📎) to select files
+- **Preview**: See attached files before sending
+- **Provider Support**: Works with Anthropic (Claude) and OpenAI (GPT) models; Google models receive extracted text only (no image support)
+
+**How Attachments Work:**
+
+1. **Images**: Encoded as base64 and sent to vision-capable models using their native multimodal format
+2. **Text Files**: Content is extracted and injected into the message context with a labeled block
+3. **PDF/DOCX**: Server-side extraction converts documents to text before sending to the AI
+
+**Configuration:**
+```bash
+# Enable/disable attachments (default: true)
+ATTACHMENTS_ENABLED=true
+
+# Maximum file size in bytes (default: 5MB)
+ATTACHMENT_MAX_SIZE_BYTES=5242880
+
+# Allowed image MIME types
+ATTACHMENT_ALLOWED_IMAGE_TYPES=image/jpeg,image/png,image/gif,image/webp
+
+# Allowed text file extensions
+ATTACHMENT_ALLOWED_TEXT_EXTENSIONS=.txt,.md,.py,.js,.ts,.json,.yaml,.yml,.html,.css,.xml,.csv,.log
+
+# Enable PDF text extraction (requires PyPDF2)
+ATTACHMENT_PDF_ENABLED=true
+
+# Enable DOCX text extraction (requires python-docx)
+ATTACHMENT_DOCX_ENABLED=true
+```
+
+**Technical Notes:**
+- Attachments are validated on both frontend (file type, size) and backend
+- File context is labeled with `[ATTACHED FILE: filename (type)]` blocks
+- Image-only messages (no text) are supported
+- Multi-entity conversations support attachments - all participating entities can see the content
+
 ### Tool Use System (Web Search & Fetch)
 
 The application supports **agentic tool use** for Anthropic (Claude) and OpenAI (GPT) models, allowing the AI to search the web and fetch content from URLs during conversations.
@@ -1594,6 +1644,8 @@ conversation: Conversation
 21. **Stop Generation** - Cancel AI response mid-stream
 22. **GitHub Settings** - View configured repositories and rate limits in settings modal
 23. **Conversation Archiving** - Archive conversations to hide from list (accessible via archived view)
+24. **Image/File Attachments** - Attach images and text files for multimodal conversations (drag-drop or picker)
+25. **Attachment Preview** - See attached files before sending with remove capability
 
 ---
 
@@ -1757,6 +1809,15 @@ conversation: Conversation
     - Memories are inserted directly into conversation history instead of separate block
     - Improves cacheability (memories paid for once per conversation)
     - Trade-off: Less clear separation between memories and conversation
+
+26. **Image and File Attachments**
+    - Attachments are **ephemeral** - NOT stored in conversation history or memories
+    - The AI analyzes attachments and its response becomes the persisted context
+    - Images require vision-capable models (Claude Sonnet/Opus, GPT-4o, etc.)
+    - For Google models, only text files are supported (images are skipped with a warning)
+    - PDF extraction requires PyPDF2, DOCX requires python-docx
+    - Frontend validates file types and sizes before upload
+    - Backend re-validates attachments for security
 
 ### Common Pitfalls
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -260,6 +260,20 @@ class Settings(BaseSettings):
     # Shared notes accessible to all entities: {notes_base_dir}/shared/
     notes_base_dir: str = "./notes"
 
+    # Attachment settings
+    # Enable image attachments in conversations
+    attachments_enabled: bool = True
+    # Maximum file size for attachments in bytes (5MB default)
+    attachment_max_size_bytes: int = 5 * 1024 * 1024
+    # Allowed image MIME types
+    attachment_allowed_image_types: str = "image/jpeg,image/png,image/gif,image/webp"
+    # Allowed text file extensions (for text extraction)
+    attachment_allowed_text_extensions: str = ".txt,.md,.py,.js,.ts,.json,.yaml,.yml,.html,.css,.xml,.csv,.log"
+    # Enable PDF text extraction (requires PyPDF2)
+    attachment_pdf_enabled: bool = True
+    # Enable DOCX text extraction (requires python-docx)
+    attachment_docx_enabled: bool = True
+
     # Memory System settings
     # When True, memories are inserted directly into conversation context as user messages
     # (better cacheability - memories only paid for once per conversation)
@@ -506,6 +520,23 @@ class Settings(BaseSettings):
         elif self.elevenlabs_api_key:
             return "elevenlabs"
         return "none"
+
+    def get_allowed_image_types(self) -> List[str]:
+        """Get list of allowed image MIME types."""
+        return [t.strip() for t in self.attachment_allowed_image_types.split(",") if t.strip()]
+
+    def get_allowed_text_extensions(self) -> List[str]:
+        """Get list of allowed text file extensions (including leading dot)."""
+        return [e.strip() for e in self.attachment_allowed_text_extensions.split(",") if e.strip()]
+
+    def is_allowed_image_type(self, mime_type: str) -> bool:
+        """Check if a MIME type is an allowed image type."""
+        return mime_type in self.get_allowed_image_types()
+
+    def is_allowed_text_file(self, filename: str) -> bool:
+        """Check if a filename has an allowed text extension."""
+        filename_lower = filename.lower()
+        return any(filename_lower.endswith(ext) for ext in self.get_allowed_text_extensions())
 
 
 settings = Settings()

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -14,6 +14,7 @@ from app.services.github_tools import register_github_tools
 from app.services.notes_service import NotesService, notes_service
 from app.services.notes_tools import register_notes_tools, set_current_entity_label
 from app.services.memory_tools import register_memory_tools, set_memory_tool_context
+from app.services.attachment_service import AttachmentService, attachment_service
 
 # Register tools at module load time
 register_web_tools(tool_service)
@@ -39,6 +40,7 @@ __all__ = [
     "ToolResult",
     "GitHubService",
     "NotesService",
+    "AttachmentService",
     # Singleton instances
     "anthropic_service",
     "openai_service",
@@ -52,6 +54,7 @@ __all__ = [
     "tool_service",
     "github_service",
     "notes_service",
+    "attachment_service",
     # Tool registration functions
     "register_web_tools",
     "register_github_tools",

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -1,0 +1,463 @@
+"""
+Attachment Service
+
+Handles processing of image and file attachments for multimodal conversations.
+- Validates attachment types and sizes
+- Extracts text from PDF and DOCX files
+- Formats attachments for LLM APIs
+"""
+
+import base64
+import io
+import logging
+from typing import List, Dict, Any, Optional, Tuple
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def extract_text_from_pdf(pdf_data: bytes) -> str:
+    """
+    Extract text content from a PDF file.
+
+    Requires PyPDF2 to be installed.
+    Returns extracted text or error message.
+    """
+    if not settings.attachment_pdf_enabled:
+        return "[PDF extraction is disabled]"
+
+    try:
+        from PyPDF2 import PdfReader
+
+        reader = PdfReader(io.BytesIO(pdf_data))
+        text_parts = []
+
+        for page_num, page in enumerate(reader.pages, 1):
+            page_text = page.extract_text()
+            if page_text:
+                text_parts.append(f"--- Page {page_num} ---\n{page_text}")
+
+        if not text_parts:
+            return "[PDF contains no extractable text]"
+
+        return "\n\n".join(text_parts)
+
+    except ImportError:
+        logger.warning("PyPDF2 not installed - PDF extraction unavailable")
+        return "[PDF extraction unavailable - PyPDF2 not installed]"
+    except Exception as e:
+        logger.error(f"Error extracting text from PDF: {e}")
+        return f"[Error extracting PDF text: {str(e)}]"
+
+
+def extract_text_from_docx(docx_data: bytes) -> str:
+    """
+    Extract text content from a DOCX file.
+
+    Requires python-docx to be installed.
+    Returns extracted text or error message.
+    """
+    if not settings.attachment_docx_enabled:
+        return "[DOCX extraction is disabled]"
+
+    try:
+        from docx import Document
+
+        doc = Document(io.BytesIO(docx_data))
+        text_parts = []
+
+        for para in doc.paragraphs:
+            if para.text.strip():
+                text_parts.append(para.text)
+
+        if not text_parts:
+            return "[DOCX contains no extractable text]"
+
+        return "\n\n".join(text_parts)
+
+    except ImportError:
+        logger.warning("python-docx not installed - DOCX extraction unavailable")
+        return "[DOCX extraction unavailable - python-docx not installed]"
+    except Exception as e:
+        logger.error(f"Error extracting text from DOCX: {e}")
+        return f"[Error extracting DOCX text: {str(e)}]"
+
+
+def process_file_attachment(filename: str, content: str, content_type: str) -> Tuple[str, str]:
+    """
+    Process a file attachment and extract its text content.
+
+    Args:
+        filename: Name of the file
+        content: Either raw text or base64-encoded binary data
+        content_type: "text" or "base64"
+
+    Returns:
+        Tuple of (extracted_text, file_type_label)
+    """
+    filename_lower = filename.lower()
+
+    # Already-extracted text
+    if content_type == "text":
+        # Determine label from extension
+        if filename_lower.endswith('.md'):
+            return content, "Markdown"
+        elif filename_lower.endswith('.py'):
+            return content, "Python"
+        elif filename_lower.endswith('.js'):
+            return content, "JavaScript"
+        elif filename_lower.endswith('.ts'):
+            return content, "TypeScript"
+        elif filename_lower.endswith('.json'):
+            return content, "JSON"
+        elif filename_lower.endswith(('.yaml', '.yml')):
+            return content, "YAML"
+        elif filename_lower.endswith('.html'):
+            return content, "HTML"
+        elif filename_lower.endswith('.css'):
+            return content, "CSS"
+        elif filename_lower.endswith('.xml'):
+            return content, "XML"
+        elif filename_lower.endswith('.csv'):
+            return content, "CSV"
+        elif filename_lower.endswith('.log'):
+            return content, "Log"
+        else:
+            return content, "Text"
+
+    # Base64-encoded binary data
+    try:
+        binary_data = base64.b64decode(content)
+    except Exception as e:
+        logger.error(f"Failed to decode base64 content for {filename}: {e}")
+        return f"[Error decoding file: {str(e)}]", "Error"
+
+    # Extract text based on file extension
+    if filename_lower.endswith('.pdf'):
+        return extract_text_from_pdf(binary_data), "PDF"
+    elif filename_lower.endswith('.docx'):
+        return extract_text_from_docx(binary_data), "DOCX"
+    else:
+        # Try to decode as text
+        try:
+            return binary_data.decode('utf-8'), "Text"
+        except UnicodeDecodeError:
+            return "[Binary file - cannot extract text]", "Binary"
+
+
+def build_file_context_block(files: List[Dict[str, Any]]) -> str:
+    """
+    Build a text block containing extracted file contents.
+
+    Files are labeled with their filename and type to distinguish
+    from the primary user message.
+    """
+    if not files:
+        return ""
+
+    blocks = []
+    for file_info in files:
+        filename = file_info.get("filename", "unknown")
+        content = file_info.get("content", "")
+        content_type = file_info.get("content_type", "text")
+
+        extracted_text, file_type = process_file_attachment(filename, content, content_type)
+
+        blocks.append(
+            f"[ATTACHED FILE: {filename} ({file_type})]\n"
+            f"```\n{extracted_text}\n```\n"
+            f"[/ATTACHED FILE]"
+        )
+
+    return "\n\n".join(blocks)
+
+
+def format_image_for_anthropic(image: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Format an image attachment for Anthropic's API.
+
+    Anthropic format:
+    {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "..."
+        }
+    }
+    """
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": image["media_type"],
+            "data": image["data"],
+        }
+    }
+
+
+def format_image_for_openai(image: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Format an image attachment for OpenAI's API.
+
+    OpenAI format:
+    {
+        "type": "image_url",
+        "image_url": {
+            "url": "data:image/jpeg;base64,..."
+        }
+    }
+    """
+    data_uri = f"data:{image['media_type']};base64,{image['data']}"
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": data_uri
+        }
+    }
+
+
+def build_multimodal_content_anthropic(
+    text_content: str,
+    images: List[Dict[str, Any]],
+    files: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Build multimodal content array for Anthropic's API.
+
+    Structure:
+    1. Image blocks (if any)
+    2. File context block (if any files)
+    3. User's text message
+    """
+    content_blocks = []
+
+    # Add images first
+    for image in images:
+        content_blocks.append(format_image_for_anthropic(image))
+
+    # Build text content with file context
+    file_context = build_file_context_block(files)
+    full_text = ""
+
+    if file_context:
+        full_text = f"{file_context}\n\n"
+
+    if text_content:
+        full_text += text_content
+
+    if full_text:
+        content_blocks.append({
+            "type": "text",
+            "text": full_text,
+        })
+
+    return content_blocks
+
+
+def build_multimodal_content_openai(
+    text_content: str,
+    images: List[Dict[str, Any]],
+    files: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Build multimodal content array for OpenAI's API.
+
+    Structure:
+    1. Text block (including file context)
+    2. Image blocks (if any)
+    """
+    content_blocks = []
+
+    # Build text content with file context first
+    file_context = build_file_context_block(files)
+    full_text = ""
+
+    if file_context:
+        full_text = f"{file_context}\n\n"
+
+    if text_content:
+        full_text += text_content
+
+    if full_text:
+        content_blocks.append({
+            "type": "text",
+            "text": full_text,
+        })
+
+    # Add images after text
+    for image in images:
+        content_blocks.append(format_image_for_openai(image))
+
+    return content_blocks
+
+
+def has_attachments(attachments: Optional[Dict[str, Any]]) -> bool:
+    """Check if there are any attachments to process."""
+    if not attachments:
+        return False
+
+    images = attachments.get("images", [])
+    files = attachments.get("files", [])
+
+    return bool(images or files)
+
+
+def get_attachment_summary(attachments: Optional[Dict[str, Any]]) -> str:
+    """Get a human-readable summary of attachments for logging."""
+    if not attachments:
+        return "none"
+
+    images = attachments.get("images", [])
+    files = attachments.get("files", [])
+
+    parts = []
+    if images:
+        parts.append(f"{len(images)} image(s)")
+    if files:
+        parts.append(f"{len(files)} file(s)")
+
+    return ", ".join(parts) if parts else "none"
+
+
+# Singleton-like module functions
+class AttachmentService:
+    """Service for processing message attachments."""
+
+    def is_enabled(self) -> bool:
+        """Check if attachments are enabled."""
+        return settings.attachments_enabled
+
+    def validate_image(self, image: Dict[str, Any]) -> None:
+        """
+        Validate an image attachment.
+
+        Raises ValueError if validation fails.
+        """
+        media_type = image.get("media_type", "")
+        data = image.get("data", "")
+
+        # Check media type
+        if not settings.is_allowed_image_type(media_type):
+            allowed = settings.get_allowed_image_types()
+            raise ValueError(f"Unsupported image type '{media_type}'. Allowed: {', '.join(allowed)}")
+
+        # Check size (approximate from base64 length)
+        # Base64 encoding increases size by ~33%
+        estimated_size = len(data) * 3 // 4
+        max_size = settings.attachment_max_size_bytes
+
+        if estimated_size > max_size:
+            raise ValueError(
+                f"Image size ({estimated_size / (1024*1024):.1f}MB) exceeds "
+                f"maximum ({max_size / (1024*1024):.1f}MB)"
+            )
+
+    def validate_file(self, file: Dict[str, Any]) -> None:
+        """
+        Validate a file attachment.
+
+        Raises ValueError if validation fails.
+        """
+        filename = file.get("filename", "")
+        content = file.get("content", "")
+        content_type = file.get("content_type", "text")
+
+        filename_lower = filename.lower()
+
+        # Check if it's an allowed text file or supported binary format
+        is_text = settings.is_allowed_text_file(filename)
+        is_pdf = filename_lower.endswith('.pdf') and settings.attachment_pdf_enabled
+        is_docx = filename_lower.endswith('.docx') and settings.attachment_docx_enabled
+
+        if not (is_text or is_pdf or is_docx):
+            raise ValueError(f"Unsupported file type: {filename}")
+
+        # Check size
+        if content_type == "text":
+            estimated_size = len(content.encode('utf-8'))
+        else:
+            # Base64
+            estimated_size = len(content) * 3 // 4
+
+        max_size = settings.attachment_max_size_bytes
+        if estimated_size > max_size:
+            raise ValueError(
+                f"File size ({estimated_size / (1024*1024):.1f}MB) exceeds "
+                f"maximum ({max_size / (1024*1024):.1f}MB)"
+            )
+
+    def validate_attachments(self, attachments: Optional[Dict[str, Any]]) -> None:
+        """
+        Validate all attachments.
+
+        Raises ValueError if any validation fails.
+        """
+        if not attachments:
+            return
+
+        if not self.is_enabled():
+            if has_attachments(attachments):
+                raise ValueError("Attachments are disabled")
+            return
+
+        for image in attachments.get("images", []):
+            self.validate_image(image)
+
+        for file in attachments.get("files", []):
+            self.validate_file(file)
+
+    def process_attachments_for_provider(
+        self,
+        text_content: str,
+        attachments: Optional[Dict[str, Any]],
+        provider: str,
+    ) -> Any:
+        """
+        Process attachments and return content formatted for the specified provider.
+
+        Args:
+            text_content: The user's text message
+            attachments: Optional attachments dict with "images" and "files" lists
+            provider: "anthropic", "openai", or "google"
+
+        Returns:
+            For providers with attachment support: List of content blocks
+            For providers without support: String with file content appended
+        """
+        if not attachments or not has_attachments(attachments):
+            return text_content
+
+        images = attachments.get("images", [])
+        files = attachments.get("files", [])
+
+        # Convert Pydantic models to dicts if needed
+        images_list = [
+            img.model_dump() if hasattr(img, 'model_dump') else img
+            for img in images
+        ]
+        files_list = [
+            f.model_dump() if hasattr(f, 'model_dump') else f
+            for f in files
+        ]
+
+        logger.info(f"[ATTACHMENTS] Processing {len(images_list)} images, {len(files_list)} files for {provider}")
+
+        if provider == "anthropic":
+            return build_multimodal_content_anthropic(text_content, images_list, files_list)
+        elif provider == "openai":
+            return build_multimodal_content_openai(text_content, images_list, files_list)
+        else:
+            # Google/other providers - append file context to text, skip images
+            if images_list:
+                logger.warning(f"[ATTACHMENTS] {provider} does not support images - skipping {len(images_list)} images")
+
+            file_context = build_file_context_block(files_list)
+            if file_context:
+                return f"{file_context}\n\n{text_content}"
+            return text_content
+
+
+# Singleton instance
+attachment_service = AttachmentService()

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -351,6 +351,8 @@ class LLMService:
         responding_entity_label: Optional[str] = None,
         # Custom role labels for context formatting
         user_display_name: Optional[str] = None,
+        # Attachments (images and files) - ephemeral, not stored
+        attachments: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Build the message list for API call with memory injection.
@@ -363,12 +365,16 @@ class LLMService:
         1. Cached conversation history (with cache breakpoint at end)
         2. New conversation history (uncached)
         3. Memories (after conversation, so retrievals don't invalidate cache)
-        4. Current user message
+        4. Current user message (with optional attachments for multimodal)
 
         For cache hits, the cached_context must be IDENTICAL to the previous call.
 
         For multi-entity conversations, a header is added explaining the conversation
         structure and participant labels.
+
+        Attachments (images and files) are ephemeral - they are included in the
+        current message for multimodal models but NOT stored in conversation
+        history or memories. The AI's response becomes the persisted context.
 
         Args:
             memories: List of memory dicts to inject
@@ -383,6 +389,7 @@ class LLMService:
             entity_labels: Mapping of entity_id to display label
             responding_entity_label: Label of the entity receiving this context
             user_display_name: Custom display name for the user/researcher
+            attachments: Optional dict with "images" and "files" lists
 
         Returns:
             List of message dicts formatted for the LLM API
@@ -403,6 +410,8 @@ class LLMService:
             entity_labels=entity_labels,
             responding_entity_label=responding_entity_label,
             user_display_name=user_display_name,
+            attachments=attachments,
+            provider=provider,
         )
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,10 @@ aiofiles==23.2.1
 python-multipart==0.0.9
 beautifulsoup4>=4.12.0
 
+# Optional: PDF/DOCX text extraction for attachments
+PyPDF2>=3.0.0
+python-docx>=1.0.0
+
 # Testing dependencies
 pytest==8.3.3
 pytest-asyncio==0.24.0

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1155,6 +1155,124 @@ h4.md-header {
     color: var(--text-muted);
 }
 
+/* Attachment Button */
+.attach-btn {
+    padding: 10px 14px;
+    background-color: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.attach-btn:hover {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    border-color: var(--accent);
+}
+
+/* Attachment Preview */
+.attachment-preview {
+    max-width: 800px;
+    margin: 0 auto 12px;
+    padding: 12px;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+}
+
+.attachment-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.attachment-item {
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.attachment-item.image {
+    width: 80px;
+    height: 80px;
+    background-color: var(--bg-primary);
+}
+
+.attachment-item.image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.attachment-item.file {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    max-width: 200px;
+}
+
+.attachment-file-icon {
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 4px 6px;
+    background-color: var(--accent);
+    color: white;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.attachment-file-name {
+    font-size: 0.8rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+}
+
+.attachment-remove {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: var(--danger);
+    color: white;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.attachment-item:hover .attachment-remove {
+    opacity: 1;
+}
+
+.attachment-remove:hover {
+    background-color: var(--danger-hover);
+}
+
+/* Drag and Drop */
+.input-area.drag-over {
+    background-color: var(--bg-tertiary);
+    border-color: var(--accent);
+    box-shadow: inset 0 0 0 2px var(--accent);
+}
+
 /* Modal */
 .modal {
     display: none;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,7 +77,19 @@
 
             <!-- Input Area -->
             <div class="input-area">
+                <!-- Attachment Preview Area -->
+                <div class="attachment-preview" id="attachment-preview" style="display: none;">
+                    <div class="attachment-list" id="attachment-list">
+                        <!-- Attachment previews will appear here -->
+                    </div>
+                </div>
                 <div class="input-container">
+                    <button id="attach-btn" class="attach-btn" title="Attach images or files">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+                        </svg>
+                    </button>
+                    <input type="file" id="file-input" multiple accept="image/jpeg,image/png,image/gif,image/webp,.txt,.md,.py,.js,.ts,.json,.yaml,.yml,.html,.css,.xml,.csv,.log,.pdf,.docx" style="display: none;">
                     <textarea
                         id="message-input"
                         placeholder="Type your message..."


### PR DESCRIPTION
Implements issue #152 with the following features:

Image Attachments:
- Support for JPEG, PNG, GIF, and WebP images
- Images are sent to vision-capable models (Claude, GPT-4o)
- Base64 encoding for Anthropic API, data URI for OpenAI API

File Attachments:
- Text files: .txt, .md, .py, .js, .ts, .json, .yaml, etc.
- PDF extraction via PyPDF2 (optional)
- DOCX extraction via python-docx (optional)
- File content injected with labeled blocks

Frontend:
- Attachment button (📎) in input area
- Drag-and-drop support for files
- Preview area with thumbnails for images
- File type indicators with remove buttons
- 5MB per-file size limit validation

Backend:
- AttachmentService for processing and validation
- Config settings for enabling/disabling features
- Provider-specific multimodal content formatting
- Ephemeral attachments (not stored in memory)

Documentation updated in CLAUDE.md.