### PR TITLE
Fix memory significance calculation for never-retrieved memories

### DIFF
--- a/backend/app/services/session_helpers.py
+++ b/backend/app/services/session_helpers.py
@@ -93,8 +93,12 @@ def calculate_significance(
         else:
             recency_factor = 1.0 + settings.recency_boost_strength
 
-    significance = times_retrieved * recency_factor * half_life_modifier
-    return max(significance, settings.significance_floor)
+    # Use (1 + times_retrieved) instead of raw times_retrieved to avoid
+    # zeroing out the entire calculation for never-retrieved memories.
+    # This allows new memories to compete based on recency and age factors
+    # rather than being flattened to the significance floor.
+    significance = (1 + times_retrieved) * recency_factor * half_life_modifier
+    return significance
 
 
 def ensure_role_balance(


### PR DESCRIPTION
## Problem

The memory significance calculation was multiplying by `times_retrieved` directly, which meant:
- Memories with `times_retrieved=0` always got a significance of 0
- These were then floored to 0.25 regardless of their age or semantic relevance
- New memories couldn't compete based on their actual merits

This was particularly problematic for fresh, highly-relevant memories from recent conversations—they got the same 0.25 score as old, irrelevant memories that just happened to also never be retrieved.

## Solution

Change from `times_retrieved` to `(1 + times_retrieved)` in the calculation:

```python
# Before:
significance = times_retrieved * recency_factor * half_life_modifier
return max(significance, settings.significance_floor)

# After:
significance = (1 + times_retrieved) * recency_factor * half_life_modifier
return significance
```

This means:
- **Fresh memories start with a base factor of 1** instead of 0
- **Age penalty and recency boost now actually affect never-retrieved memories**
- **The significance floor is no longer needed** since the calculation always produces positive values
- **Relative weighting of retrieval count is preserved**—the difference between 5 and 10 retrievals is still meaningful

## Example

A memory from yesterday that's never been retrieved:
- **Before**: `0 * factors = 0` → floored to 0.25
- **After**: `(1 + 0) * 1.0 (no recency boost) * ~0.99 (almost no age decay) = ~0.99`

Now it can actually compete with older memories that happen to have been retrieved once or twice.

## Testing

This is a behavioral change that's intentional—the existing tests don't directly test the significance formula, and the change improves the system's ability to surface relevant new memories.