### PR TITLE
Fix gitignore for entity notes directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,4 +215,5 @@ __marimo__/
 
 # App generated files
 voices.json
-backend/app/notes/*
+backend/app/notes/
+notes/


### PR DESCRIPTION
## Problem

The pattern `backend/app/notes/*` wasn't properly ignoring notes files. The `/*` glob pattern can behave inconsistently.

## Solution

Use the trailing slash pattern instead:
- `backend/app/notes/` - tells git to ignore the directory and everything in it
- Also added `notes/` for flexibility if `notes_base_dir` is configured elsewhere

## Why this matters

Entity notes can contain private information that shouldn't be committed to the repo. Proper gitignore ensures notes stay local even if someone isn't paying close attention.