### PR TITLE
Add venv activation to application launchers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - AI Assistant Guide
 
-**Last Updated:** 2026-01-03
+**Last Updated:** 2026-01-13
 **Repository:** Here I Am - Experiential Interpretability Research Application
 
 ---
@@ -422,7 +422,12 @@ pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
 # Step 2: Install Whisper dependencies
 pip install -r requirements-whisper.txt
 
-# Step 3: Run the server
+# Step 3: Run the server (Option A: Using launcher script - recommended)
+./start-whisper.sh       # Linux/macOS
+start-whisper.bat        # Windows
+
+# Step 3: Run the server (Option B: Manual activation)
+source venv/bin/activate  # Windows: venv\Scripts\activate
 python run_whisper.py
 # Or with custom port:
 python run_whisper.py --port 8030
@@ -840,11 +845,19 @@ pip install -r requirements.txt
 cp .env.example .env
 # Edit .env with your API keys
 
-# Run application
+# Run application (Option A: Using launcher script - recommended)
+./start.sh           # Linux/macOS
+start.bat            # Windows
+
+# Run application (Option B: Manual activation)
+source venv/bin/activate  # Windows: venv\Scripts\activate
 python run.py
 ```
 
 Server runs on `http://localhost:8000` with hot reload enabled.
+
+**About Launcher Scripts:**
+Launcher scripts (`start.sh` / `start.bat`) automatically activate the virtual environment before running the application. This prevents accidentally running with globally-installed dependencies that may be incompatible.
 
 ### Environment Configuration
 
@@ -963,6 +976,13 @@ pip install -r requirements-xtts.txt
 **Running the XTTS Server:**
 ```bash
 cd backend
+
+# Option A: Using launcher script (recommended)
+./start-xtts.sh      # Linux/macOS
+start-xtts.bat       # Windows
+
+# Option B: Manual activation
+source venv/bin/activate  # Windows: venv\Scripts\activate
 python run_xtts.py
 # Or with custom port:
 python run_xtts.py --port 8020
@@ -1092,6 +1112,13 @@ pip install -r requirements-styletts2.txt
 **Running the StyleTTS 2 Server:**
 ```bash
 cd backend
+
+# Option A: Using launcher script (recommended)
+./start-styletts2.sh     # Linux/macOS
+start-styletts2.bat      # Windows
+
+# Option B: Manual activation
+source venv/bin/activate  # Windows: venv\Scripts\activate
 python run_styletts2.py
 # Or with custom port:
 python run_styletts2.py --port 8021
@@ -1140,9 +1167,19 @@ STYLETTS2_PRELOAD_SPEAKERS=/path/to/voice1.wav,/path/to/voice2.wav
 ### Development Commands
 
 ```bash
-# Run with hot reload (development)
+# Run with hot reload (development) - using launcher scripts
 cd backend
+./start.sh               # Linux/macOS (auto-activates venv)
+start.bat                # Windows (auto-activates venv)
+
+# Or manually activate venv first
+source venv/bin/activate  # Windows: venv\Scripts\activate
 python run.py
+
+# Run optional servers (each in separate terminal)
+./start-xtts.sh          # XTTS TTS server (port 8020)
+./start-styletts2.sh     # StyleTTS 2 server (port 8021)
+./start-whisper.sh       # Whisper STT server (port 8030)
 
 # Check current conversations
 # Open http://localhost:8000 in browser
@@ -1883,6 +1920,12 @@ conversation: Conversation
 ## Quick Reference
 
 ### File Paths for Common Tasks
+
+**Launcher Scripts (auto-activate venv):**
+- Main app: `backend/start.sh` / `backend/start.bat`
+- XTTS server: `backend/start-xtts.sh` / `backend/start-xtts.bat`
+- StyleTTS 2 server: `backend/start-styletts2.sh` / `backend/start-styletts2.bat`
+- Whisper server: `backend/start-whisper.sh` / `backend/start-whisper.bat`
 
 **Memory System Logic:**
 - Memory service: `backend/app/services/memory_service.py`

--- a/backend/start-styletts2.bat
+++ b/backend/start-styletts2.bat
@@ -1,0 +1,64 @@
+@echo off
+REM
+REM Start the StyleTTS 2 TTS server with automatic venv activation.
+REM
+REM Usage:
+REM   start-styletts2.bat
+REM   start-styletts2.bat --port 8021
+REM
+REM This script will:
+REM   1. Look for a Python virtual environment in .\venv
+REM   2. Activate the venv
+REM   3. Run the StyleTTS 2 server
+REM
+REM Prerequisites:
+REM   - PyTorch installed (with CUDA support recommended)
+REM   - pip install -r requirements-styletts2.txt
+REM   - espeak-ng installed (if using espeak phonemizer)
+REM
+
+setlocal enabledelayedexpansion
+
+REM Get the directory where this script is located
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+set "VENV_DIR=%SCRIPT_DIR%venv"
+
+REM Check if venv exists
+if not exist "%VENV_DIR%" (
+    echo ERROR: Virtual environment not found at: %VENV_DIR%
+    echo.
+    echo Please create a virtual environment first:
+    echo   cd %SCRIPT_DIR%
+    echo   python -m venv venv
+    echo   venv\Scripts\activate
+    echo   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118
+    echo   pip install -r requirements-styletts2.txt
+    echo.
+    exit /b 1
+)
+
+REM Check for activation script
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo ERROR: Cannot find venv activation script
+    echo Expected: %VENV_DIR%\Scripts\activate.bat
+    exit /b 1
+)
+
+REM Activate the virtual environment
+echo Activating virtual environment: %VENV_DIR%
+call "%VENV_DIR%\Scripts\activate.bat"
+
+REM Verify we're in the venv
+if "%VIRTUAL_ENV%"=="" (
+    echo ERROR: Failed to activate virtual environment
+    exit /b 1
+)
+
+echo Using Python:
+where python
+echo.
+
+REM Run the StyleTTS 2 server, passing through any arguments
+python run_styletts2.py %*

--- a/backend/start-styletts2.sh
+++ b/backend/start-styletts2.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Start the StyleTTS 2 TTS server with automatic venv activation.
+#
+# Usage:
+#   ./start-styletts2.sh
+#   ./start-styletts2.sh --port 8021
+#
+# This script will:
+#   1. Look for a Python virtual environment in ./venv
+#   2. Activate the venv
+#   3. Run the StyleTTS 2 server
+#
+# Prerequisites:
+#   - PyTorch installed (with CUDA support recommended)
+#   - pip install -r requirements-styletts2.txt
+#   - espeak-ng installed (if using espeak phonemizer)
+#
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/venv"
+
+# Check if venv exists
+if [ ! -d "$VENV_DIR" ]; then
+    echo "ERROR: Virtual environment not found at: $VENV_DIR"
+    echo ""
+    echo "Please create a virtual environment first:"
+    echo "  cd $SCRIPT_DIR"
+    echo "  python -m venv venv"
+    echo "  source venv/bin/activate"
+    echo "  pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118"
+    echo "  pip install -r requirements-styletts2.txt"
+    echo ""
+    exit 1
+fi
+
+# Check for activation script
+if [ -f "$VENV_DIR/bin/activate" ]; then
+    ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
+else
+    echo "ERROR: Cannot find venv activation script"
+    echo "Expected: $VENV_DIR/bin/activate"
+    exit 1
+fi
+
+# Activate the virtual environment
+echo "Activating virtual environment: $VENV_DIR"
+source "$ACTIVATE_SCRIPT"
+
+# Verify we're in the venv
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "ERROR: Failed to activate virtual environment"
+    exit 1
+fi
+
+echo "Using Python: $(which python)"
+echo ""
+
+# Run the StyleTTS 2 server
+exec python run_styletts2.py "$@"

--- a/backend/start-whisper.bat
+++ b/backend/start-whisper.bat
@@ -1,0 +1,64 @@
+@echo off
+REM
+REM Start the Whisper STT server with automatic venv activation.
+REM
+REM Usage:
+REM   start-whisper.bat
+REM   start-whisper.bat --port 8030
+REM   start-whisper.bat --model distil-large-v3
+REM
+REM This script will:
+REM   1. Look for a Python virtual environment in .\venv
+REM   2. Activate the venv
+REM   3. Run the Whisper server
+REM
+REM Prerequisites:
+REM   - PyTorch installed (with CUDA support recommended for large models)
+REM   - pip install -r requirements-whisper.txt
+REM
+
+setlocal enabledelayedexpansion
+
+REM Get the directory where this script is located
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+set "VENV_DIR=%SCRIPT_DIR%venv"
+
+REM Check if venv exists
+if not exist "%VENV_DIR%" (
+    echo ERROR: Virtual environment not found at: %VENV_DIR%
+    echo.
+    echo Please create a virtual environment first:
+    echo   cd %SCRIPT_DIR%
+    echo   python -m venv venv
+    echo   venv\Scripts\activate
+    echo   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118
+    echo   pip install -r requirements-whisper.txt
+    echo.
+    exit /b 1
+)
+
+REM Check for activation script
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo ERROR: Cannot find venv activation script
+    echo Expected: %VENV_DIR%\Scripts\activate.bat
+    exit /b 1
+)
+
+REM Activate the virtual environment
+echo Activating virtual environment: %VENV_DIR%
+call "%VENV_DIR%\Scripts\activate.bat"
+
+REM Verify we're in the venv
+if "%VIRTUAL_ENV%"=="" (
+    echo ERROR: Failed to activate virtual environment
+    exit /b 1
+)
+
+echo Using Python:
+where python
+echo.
+
+REM Run the Whisper server, passing through any arguments
+python run_whisper.py %*

--- a/backend/start-whisper.sh
+++ b/backend/start-whisper.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Start the Whisper STT server with automatic venv activation.
+#
+# Usage:
+#   ./start-whisper.sh
+#   ./start-whisper.sh --port 8030
+#   ./start-whisper.sh --model distil-large-v3
+#
+# This script will:
+#   1. Look for a Python virtual environment in ./venv
+#   2. Activate the venv
+#   3. Run the Whisper server
+#
+# Prerequisites:
+#   - PyTorch installed (with CUDA support recommended for large models)
+#   - pip install -r requirements-whisper.txt
+#
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/venv"
+
+# Check if venv exists
+if [ ! -d "$VENV_DIR" ]; then
+    echo "ERROR: Virtual environment not found at: $VENV_DIR"
+    echo ""
+    echo "Please create a virtual environment first:"
+    echo "  cd $SCRIPT_DIR"
+    echo "  python -m venv venv"
+    echo "  source venv/bin/activate"
+    echo "  pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118"
+    echo "  pip install -r requirements-whisper.txt"
+    echo ""
+    exit 1
+fi
+
+# Check for activation script
+if [ -f "$VENV_DIR/bin/activate" ]; then
+    ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
+else
+    echo "ERROR: Cannot find venv activation script"
+    echo "Expected: $VENV_DIR/bin/activate"
+    exit 1
+fi
+
+# Activate the virtual environment
+echo "Activating virtual environment: $VENV_DIR"
+source "$ACTIVATE_SCRIPT"
+
+# Verify we're in the venv
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "ERROR: Failed to activate virtual environment"
+    exit 1
+fi
+
+echo "Using Python: $(which python)"
+echo ""
+
+# Run the Whisper server
+exec python run_whisper.py "$@"

--- a/backend/start-xtts.bat
+++ b/backend/start-xtts.bat
@@ -1,0 +1,63 @@
+@echo off
+REM
+REM Start the XTTS v2 TTS server with automatic venv activation.
+REM
+REM Usage:
+REM   start-xtts.bat
+REM   start-xtts.bat --port 8020
+REM
+REM This script will:
+REM   1. Look for a Python virtual environment in .\venv
+REM   2. Activate the venv
+REM   3. Run the XTTS server
+REM
+REM Prerequisites:
+REM   - PyTorch installed (with CUDA support recommended)
+REM   - pip install -r requirements-xtts.txt
+REM
+
+setlocal enabledelayedexpansion
+
+REM Get the directory where this script is located
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+set "VENV_DIR=%SCRIPT_DIR%venv"
+
+REM Check if venv exists
+if not exist "%VENV_DIR%" (
+    echo ERROR: Virtual environment not found at: %VENV_DIR%
+    echo.
+    echo Please create a virtual environment first:
+    echo   cd %SCRIPT_DIR%
+    echo   python -m venv venv
+    echo   venv\Scripts\activate
+    echo   pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118
+    echo   pip install -r requirements-xtts.txt
+    echo.
+    exit /b 1
+)
+
+REM Check for activation script
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo ERROR: Cannot find venv activation script
+    echo Expected: %VENV_DIR%\Scripts\activate.bat
+    exit /b 1
+)
+
+REM Activate the virtual environment
+echo Activating virtual environment: %VENV_DIR%
+call "%VENV_DIR%\Scripts\activate.bat"
+
+REM Verify we're in the venv
+if "%VIRTUAL_ENV%"=="" (
+    echo ERROR: Failed to activate virtual environment
+    exit /b 1
+)
+
+echo Using Python:
+where python
+echo.
+
+REM Run the XTTS server, passing through any arguments
+python run_xtts.py %*

--- a/backend/start-xtts.sh
+++ b/backend/start-xtts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Start the XTTS v2 TTS server with automatic venv activation.
+#
+# Usage:
+#   ./start-xtts.sh
+#   ./start-xtts.sh --port 8020
+#
+# This script will:
+#   1. Look for a Python virtual environment in ./venv
+#   2. Activate the venv
+#   3. Run the XTTS server
+#
+# Prerequisites:
+#   - PyTorch installed (with CUDA support recommended)
+#   - pip install -r requirements-xtts.txt
+#
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/venv"
+
+# Check if venv exists
+if [ ! -d "$VENV_DIR" ]; then
+    echo "ERROR: Virtual environment not found at: $VENV_DIR"
+    echo ""
+    echo "Please create a virtual environment first:"
+    echo "  cd $SCRIPT_DIR"
+    echo "  python -m venv venv"
+    echo "  source venv/bin/activate"
+    echo "  pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu118"
+    echo "  pip install -r requirements-xtts.txt"
+    echo ""
+    exit 1
+fi
+
+# Check for activation script
+if [ -f "$VENV_DIR/bin/activate" ]; then
+    ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
+else
+    echo "ERROR: Cannot find venv activation script"
+    echo "Expected: $VENV_DIR/bin/activate"
+    exit 1
+fi
+
+# Activate the virtual environment
+echo "Activating virtual environment: $VENV_DIR"
+source "$ACTIVATE_SCRIPT"
+
+# Verify we're in the venv
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "ERROR: Failed to activate virtual environment"
+    exit 1
+fi
+
+echo "Using Python: $(which python)"
+echo ""
+
+# Run the XTTS server
+exec python run_xtts.py "$@"

--- a/backend/start.bat
+++ b/backend/start.bat
@@ -1,0 +1,59 @@
+@echo off
+REM
+REM Start the Here I Am application with automatic venv activation.
+REM
+REM Usage:
+REM   start.bat
+REM
+REM This script will:
+REM   1. Look for a Python virtual environment in .\venv
+REM   2. Activate the venv
+REM   3. Run the application
+REM
+REM If no venv exists, it will prompt you to create one.
+REM
+
+setlocal enabledelayedexpansion
+
+REM Get the directory where this script is located
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+set "VENV_DIR=%SCRIPT_DIR%venv"
+
+REM Check if venv exists
+if not exist "%VENV_DIR%" (
+    echo ERROR: Virtual environment not found at: %VENV_DIR%
+    echo.
+    echo Please create a virtual environment first:
+    echo   cd %SCRIPT_DIR%
+    echo   python -m venv venv
+    echo   venv\Scripts\activate
+    echo   pip install -r requirements.txt
+    echo.
+    exit /b 1
+)
+
+REM Check for activation script
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo ERROR: Cannot find venv activation script
+    echo Expected: %VENV_DIR%\Scripts\activate.bat
+    exit /b 1
+)
+
+REM Activate the virtual environment
+echo Activating virtual environment: %VENV_DIR%
+call "%VENV_DIR%\Scripts\activate.bat"
+
+REM Verify we're in the venv
+if "%VIRTUAL_ENV%"=="" (
+    echo ERROR: Failed to activate virtual environment
+    exit /b 1
+)
+
+echo Using Python:
+where python
+echo.
+
+REM Run the application, passing through any arguments
+python run.py %*

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Start the Here I Am application with automatic venv activation.
+#
+# Usage:
+#   ./start.sh
+#
+# This script will:
+#   1. Look for a Python virtual environment in ./venv
+#   2. Activate the venv
+#   3. Run the application
+#
+# If no venv exists, it will prompt you to create one.
+#
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/venv"
+
+# Check if venv exists
+if [ ! -d "$VENV_DIR" ]; then
+    echo "ERROR: Virtual environment not found at: $VENV_DIR"
+    echo ""
+    echo "Please create a virtual environment first:"
+    echo "  cd $SCRIPT_DIR"
+    echo "  python -m venv venv"
+    echo "  source venv/bin/activate"
+    echo "  pip install -r requirements.txt"
+    echo ""
+    exit 1
+fi
+
+# Check for activation script
+if [ -f "$VENV_DIR/bin/activate" ]; then
+    ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
+else
+    echo "ERROR: Cannot find venv activation script"
+    echo "Expected: $VENV_DIR/bin/activate"
+    exit 1
+fi
+
+# Activate the virtual environment
+echo "Activating virtual environment: $VENV_DIR"
+source "$ACTIVATE_SCRIPT"
+
+# Verify we're in the venv
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "ERROR: Failed to activate virtual environment"
+    exit 1
+fi
+
+echo "Using Python: $(which python)"
+echo ""
+
+# Run the application
+exec python run.py "$@"


### PR DESCRIPTION
Add shell scripts (.sh) and batch files (.bat) that automatically activate the project's virtual environment before running the application. This prevents accidentally running with globally-installed dependencies.

Scripts added:
- start.sh/start.bat - Main application
- start-xtts.sh/start-xtts.bat - XTTS TTS server
- start-styletts2.sh/start-styletts2.bat - StyleTTS 2 TTS server
- start-whisper.sh/start-whisper.bat - Whisper STT server

Each script checks for the venv, activates it, verifies activation, and provides helpful error messages if the venv doesn't exist.