### PR TITLE
Fix navigator tools to use GITHUB_REPOS config instead of current dir…

### DIFF
--- a/backend/app/services/codebase_navigator_tools.py
+++ b/backend/app/services/codebase_navigator_tools.py
@@ -6,9 +6,9 @@ explore codebases efficiently using the Devstral model.
 """
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, List
 
-from app.config import settings
+from app.config import settings, GitHubRepoConfig
 from app.services.tool_service import ToolCategory
 
 if TYPE_CHECKING:
@@ -17,9 +17,53 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_repos_with_local_path() -> List[GitHubRepoConfig]:
+    """Get all configured GitHub repos that have a local_clone_path."""
+    return [repo for repo in settings.get_github_repos() if repo.local_clone_path]
+
+
+def _resolve_repo_path(repo: Optional[str] = None) -> tuple[str, Optional[str]]:
+    """
+    Resolve a repo parameter to an actual filesystem path.
+
+    Args:
+        repo: Either a GitHub repo label (from GITHUB_REPOS config) or None.
+              If None, uses the single configured repo if only one exists.
+
+    Returns:
+        Tuple of (resolved_path, error_message).
+        If error_message is not None, resolved_path should be ignored.
+    """
+    repos_with_path = _get_repos_with_local_path()
+
+    if repo:
+        # Look up by label
+        repo_config = settings.get_github_repo_by_label(repo)
+        if not repo_config:
+            available = [r.label for r in repos_with_path]
+            if available:
+                return "", f"Repository '{repo}' not found. Available repositories: {', '.join(available)}"
+            else:
+                return "", f"Repository '{repo}' not found and no repositories with local_clone_path configured."
+
+        if not repo_config.local_clone_path:
+            return "", f"Repository '{repo}' does not have a local_clone_path configured. Add 'local_clone_path' to the GITHUB_REPOS configuration."
+
+        return repo_config.local_clone_path, None
+
+    # No repo specified - check if there's exactly one repo with local_clone_path
+    if len(repos_with_path) == 1:
+        return repos_with_path[0].local_clone_path, None
+    elif len(repos_with_path) == 0:
+        return "", "No repositories with local_clone_path configured. Add 'local_clone_path' to a repository in GITHUB_REPOS."
+    else:
+        available = [r.label for r in repos_with_path]
+        return "", f"Multiple repositories configured. Please specify which one to use: {', '.join(available)}"
+
+
 async def navigate_codebase(
     task: str,
-    repo_path: str = ".",
+    repo: Optional[str] = None,
     query_type: str = "relevance",
 ) -> str:
     """
@@ -30,7 +74,8 @@ async def navigate_codebase(
 
     Args:
         task: Description of what you're trying to accomplish
-        repo_path: Path to the repository root (default: current directory)
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
         query_type: One of "relevance", "structure", "dependencies",
                     "entry_points", "impact"
 
@@ -43,6 +88,11 @@ async def navigate_codebase(
     # Check if configured
     if not codebase_navigator_service.is_configured():
         return "Error: Codebase navigator is not configured. Set CODEBASE_NAVIGATOR_ENABLED=true and MISTRAL_API_KEY."
+
+    # Resolve repo to path
+    repo_path, error = _resolve_repo_path(repo)
+    if error:
+        return f"Error: {error}"
 
     try:
         response = await codebase_navigator_service.navigate(
@@ -60,7 +110,7 @@ async def navigate_codebase(
         return f"Error: {str(e)}"
 
 
-async def navigate_codebase_structure(repo_path: str = ".") -> str:
+async def navigate_codebase_structure(repo: Optional[str] = None) -> str:
     """
     Get an overview of the codebase structure and architecture.
 
@@ -68,21 +118,22 @@ async def navigate_codebase_structure(repo_path: str = ".") -> str:
     diving into specific tasks.
 
     Args:
-        repo_path: Path to the repository root (default: current directory)
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
 
     Returns:
         Architecture overview and key entry points
     """
     return await navigate_codebase(
         task="Provide a comprehensive overview of the codebase architecture, main components, and how they interact.",
-        repo_path=repo_path,
+        repo=repo,
         query_type="structure",
     )
 
 
 async def navigate_find_entry_points(
     feature: str,
-    repo_path: str = ".",
+    repo: Optional[str] = None,
 ) -> str:
     """
     Find the entry points for implementing or modifying a feature.
@@ -91,21 +142,22 @@ async def navigate_find_entry_points(
 
     Args:
         feature: Description of the feature to implement or modify
-        repo_path: Path to the repository root
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
 
     Returns:
         List of entry points with explanations
     """
     return await navigate_codebase(
         task=f"Find the entry points and key locations for implementing or modifying: {feature}",
-        repo_path=repo_path,
+        repo=repo,
         query_type="entry_points",
     )
 
 
 async def navigate_assess_impact(
     change: str,
-    repo_path: str = ".",
+    repo: Optional[str] = None,
 ) -> str:
     """
     Assess the potential impact of a code change.
@@ -114,21 +166,22 @@ async def navigate_assess_impact(
 
     Args:
         change: Description of the change being considered
-        repo_path: Path to the repository root
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
 
     Returns:
         Impact assessment including affected files and tests
     """
     return await navigate_codebase(
         task=f"Assess the impact of this change: {change}. What other files, tests, or documentation might be affected?",
-        repo_path=repo_path,
+        repo=repo,
         query_type="impact",
     )
 
 
 async def navigate_trace_dependencies(
     component: str,
-    repo_path: str = ".",
+    repo: Optional[str] = None,
 ) -> str:
     """
     Trace the dependencies of a component.
@@ -137,26 +190,28 @@ async def navigate_trace_dependencies(
 
     Args:
         component: Name or description of the component to trace
-        repo_path: Path to the repository root
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
 
     Returns:
         Dependency information including imports and dependents
     """
     return await navigate_codebase(
         task=f"Trace the dependencies for: {component}. Show what it imports and what other code depends on it.",
-        repo_path=repo_path,
+        repo=repo,
         query_type="dependencies",
     )
 
 
-async def navigator_invalidate_cache(repo_path: str = ".") -> str:
+async def navigator_invalidate_cache(repo: Optional[str] = None) -> str:
     """
     Invalidate the navigator cache for a repository.
 
     Use this after the codebase has been modified to ensure fresh results.
 
     Args:
-        repo_path: Path to the repository root
+        repo: Repository label from GITHUB_REPOS config. If only one repo
+              is configured with local_clone_path, it will be used by default.
 
     Returns:
         Confirmation of cache invalidation
@@ -165,6 +220,11 @@ async def navigator_invalidate_cache(repo_path: str = ".") -> str:
 
     if not codebase_navigator_service.is_configured():
         return "Error: Codebase navigator is not configured."
+
+    # Resolve repo to path
+    repo_path, error = _resolve_repo_path(repo)
+    if error:
+        return f"Error: {error}"
 
     try:
         count = codebase_navigator_service.invalidate_cache(repo_path)
@@ -217,10 +277,9 @@ Example:
                     "type": "string",
                     "description": "Description of what you're trying to accomplish",
                 },
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
                 "query_type": {
                     "type": "string",
@@ -250,10 +309,9 @@ Returns:
         input_schema={
             "type": "object",
             "properties": {
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
             },
             "required": [],
@@ -281,10 +339,9 @@ Returns:
                     "type": "string",
                     "description": "Description of the feature to implement or modify",
                 },
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
             },
             "required": ["feature"],
@@ -313,10 +370,9 @@ Returns:
                     "type": "string",
                     "description": "Description of the change being considered",
                 },
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
             },
             "required": ["change"],
@@ -344,10 +400,9 @@ Returns:
                     "type": "string",
                     "description": "Name or description of the component to trace",
                 },
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
             },
             "required": ["component"],
@@ -368,10 +423,9 @@ force invalidation with this tool.""",
         input_schema={
             "type": "object",
             "properties": {
-                "repo_path": {
+                "repo": {
                     "type": "string",
-                    "description": "Path to the repository root (default: current directory)",
-                    "default": ".",
+                    "description": "Repository label from GITHUB_REPOS config. If only one repo is configured with local_clone_path, it will be used automatically.",
                 },
             },
             "required": [],


### PR DESCRIPTION
…ectory

The codebase navigator tools were indexing the application directory instead of the configured GitHub repositories. This fixes the issue by:

- Adding _resolve_repo_path() to resolve repo labels to local_clone_path
- Changing all tool functions from repo_path parameter to repo parameter
- Tools now require a configured GitHub repo with local_clone_path set
- If only one repo is configured, it's used automatically
- Clear error messages when repo isn't configured or not found