### PR TITLE
Create unit tests for refactored frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,10 @@ __marimo__/
 voices.json
 backend/app/notes/
 notes/
+
+# Frontend (Node.js)
+node_modules/
+frontend/node_modules/
+frontend/coverage/
+package-lock.json
+frontend/package-lock.json

--- a/frontend/js/__tests__/attachments.test.js
+++ b/frontend/js/__tests__/attachments.test.js
@@ -1,0 +1,464 @@
+/**
+ * Unit Tests for Attachments Module
+ * Tests file/image attachment handling
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { state } from '../modules/state.js';
+import {
+    setElements,
+    setCallbacks,
+    handleFileSelect,
+    processFiles,
+    updateAttachmentPreview,
+    removeAttachment,
+    clearAttachments,
+    hasAttachments,
+    getAttachmentsForRequest,
+    buildDisplayContentWithAttachments,
+} from '../modules/attachments.js';
+
+describe('Attachments Module', () => {
+    let mockElements;
+    let mockCallbacks;
+
+    beforeEach(() => {
+        // Reset state attachments
+        state.pendingAttachments = { images: [], files: [] };
+
+        // Create mock elements
+        mockElements = {
+            attachmentPreview: document.createElement('div'),
+            attachmentList: document.createElement('div'),
+        };
+
+        // Create mock callbacks
+        mockCallbacks = {
+            onAttachmentsChanged: vi.fn(),
+        };
+
+        setElements(mockElements);
+        setCallbacks(mockCallbacks);
+    });
+
+    describe('hasAttachments', () => {
+        it('should return false when no attachments', () => {
+            expect(hasAttachments()).toBe(false);
+        });
+
+        it('should return true when images are pending', () => {
+            state.pendingAttachments.images.push({ name: 'test.png' });
+            expect(hasAttachments()).toBe(true);
+        });
+
+        it('should return true when files are pending', () => {
+            state.pendingAttachments.files.push({ name: 'test.txt' });
+            expect(hasAttachments()).toBe(true);
+        });
+
+        it('should return true when both images and files are pending', () => {
+            state.pendingAttachments.images.push({ name: 'test.png' });
+            state.pendingAttachments.files.push({ name: 'test.txt' });
+            expect(hasAttachments()).toBe(true);
+        });
+    });
+
+    describe('processFiles', () => {
+        it('should reject files larger than 5MB', async () => {
+            const largeFile = new File(['x'.repeat(6 * 1024 * 1024)], 'large.txt', { type: 'text/plain' });
+            largeFile.size = 6 * 1024 * 1024; // Override size
+
+            await processFiles([largeFile]);
+
+            expect(state.pendingAttachments.files.length).toBe(0);
+        });
+
+        it('should process valid image files', async () => {
+            const imageFile = new File(['fake image data'], 'test.png', { type: 'image/png' });
+            imageFile._mockBase64 = 'dGVzdA==';
+
+            await processFiles([imageFile]);
+
+            expect(state.pendingAttachments.images.length).toBe(1);
+            expect(state.pendingAttachments.images[0].name).toBe('test.png');
+            expect(state.pendingAttachments.images[0].type).toBe('image/png');
+            expect(mockCallbacks.onAttachmentsChanged).toHaveBeenCalled();
+        });
+
+        it('should process valid text files', async () => {
+            const textFile = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+            textFile._mockContent = 'hello world';
+
+            await processFiles([textFile]);
+
+            expect(state.pendingAttachments.files.length).toBe(1);
+            expect(state.pendingAttachments.files[0].name).toBe('test.txt');
+            expect(state.pendingAttachments.files[0].content).toBe('hello world');
+            expect(mockCallbacks.onAttachmentsChanged).toHaveBeenCalled();
+        });
+
+        it('should handle PDF files for server-side processing', async () => {
+            const pdfFile = new File(['pdf content'], 'document.pdf', { type: 'application/pdf' });
+
+            await processFiles([pdfFile]);
+
+            expect(state.pendingAttachments.files.length).toBe(1);
+            expect(state.pendingAttachments.files[0].name).toBe('document.pdf');
+            expect(state.pendingAttachments.files[0].file).toBe(pdfFile);
+            expect(state.pendingAttachments.files[0].content).toBe(null);
+        });
+
+        it('should handle DOCX files for server-side processing', async () => {
+            const docxFile = new File(['docx content'], 'document.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+
+            await processFiles([docxFile]);
+
+            expect(state.pendingAttachments.files.length).toBe(1);
+            expect(state.pendingAttachments.files[0].name).toBe('document.docx');
+            expect(state.pendingAttachments.files[0].content).toBe(null);
+        });
+
+        it('should reject unsupported file types', async () => {
+            const unsupportedFile = new File(['data'], 'virus.exe', { type: 'application/octet-stream' });
+
+            await processFiles([unsupportedFile]);
+
+            expect(state.pendingAttachments.files.length).toBe(0);
+            expect(state.pendingAttachments.images.length).toBe(0);
+        });
+
+        it('should process multiple files', async () => {
+            const imageFile = new File(['image'], 'test.png', { type: 'image/png' });
+            imageFile._mockBase64 = 'dGVzdA==';
+
+            const textFile = new File(['text'], 'test.txt', { type: 'text/plain' });
+            textFile._mockContent = 'text content';
+
+            await processFiles([imageFile, textFile]);
+
+            expect(state.pendingAttachments.images.length).toBe(1);
+            expect(state.pendingAttachments.files.length).toBe(1);
+        });
+
+        it('should handle supported image types', async () => {
+            const imageTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+            for (const type of imageTypes) {
+                state.pendingAttachments = { images: [], files: [] };
+
+                const ext = type.split('/')[1];
+                const file = new File(['data'], `test.${ext}`, { type });
+                file._mockBase64 = 'dGVzdA==';
+
+                await processFiles([file]);
+
+                expect(state.pendingAttachments.images.length).toBe(1);
+            }
+        });
+
+        it('should handle supported text extensions', async () => {
+            const extensions = ['.txt', '.md', '.py', '.js', '.ts', '.json', '.yaml', '.yml', '.html', '.css', '.xml', '.csv', '.log'];
+
+            for (const ext of extensions) {
+                state.pendingAttachments = { images: [], files: [] };
+
+                const file = new File(['content'], `test${ext}`, { type: 'text/plain' });
+                file._mockContent = 'file content';
+
+                await processFiles([file]);
+
+                expect(state.pendingAttachments.files.length).toBe(1);
+            }
+        });
+    });
+
+    describe('handleFileSelect', () => {
+        it('should process files from file input event', async () => {
+            const mockFile = new File(['test'], 'test.txt', { type: 'text/plain' });
+            mockFile._mockContent = 'test content';
+
+            const mockEvent = {
+                target: {
+                    files: [mockFile],
+                    value: 'C:\\fakepath\\test.txt',
+                },
+            };
+
+            // handleFileSelect doesn't await processFiles, so we need to wait for it
+            handleFileSelect(mockEvent);
+
+            // Wait for async file reading to complete
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(state.pendingAttachments.files.length).toBe(1);
+            expect(mockEvent.target.value).toBe('');
+        });
+
+        it('should reset input value after processing', () => {
+            const mockEvent = {
+                target: {
+                    files: [],
+                    value: 'something',
+                },
+            };
+
+            handleFileSelect(mockEvent);
+
+            expect(mockEvent.target.value).toBe('');
+        });
+    });
+
+    describe('updateAttachmentPreview', () => {
+        it('should hide preview when no attachments', () => {
+            mockElements.attachmentPreview.style.display = 'block';
+
+            updateAttachmentPreview();
+
+            expect(mockElements.attachmentPreview.style.display).toBe('none');
+        });
+
+        it('should show preview when attachments exist', () => {
+            state.pendingAttachments.images.push({
+                name: 'test.png',
+                previewUrl: 'blob:url',
+            });
+
+            updateAttachmentPreview();
+
+            expect(mockElements.attachmentPreview.style.display).toBe('block');
+        });
+
+        it('should render image previews', () => {
+            state.pendingAttachments.images.push({
+                name: 'image.png',
+                previewUrl: 'blob:image-url',
+            });
+
+            updateAttachmentPreview();
+
+            const html = mockElements.attachmentList.innerHTML;
+            expect(html).toContain('attachment-item image');
+            expect(html).toContain('blob:image-url');
+            expect(html).toContain('image.png');
+        });
+
+        it('should render file previews', () => {
+            state.pendingAttachments.files.push({
+                name: 'document.txt',
+                type: 'text/plain',
+            });
+
+            updateAttachmentPreview();
+
+            const html = mockElements.attachmentList.innerHTML;
+            expect(html).toContain('attachment-item file');
+            expect(html).toContain('TXT');
+            expect(html).toContain('document.txt');
+        });
+
+        it('should handle XSS in filenames', () => {
+            state.pendingAttachments.files.push({
+                name: '<script>alert("xss")</script>.txt',
+                type: 'text/plain',
+            });
+
+            updateAttachmentPreview();
+
+            const html = mockElements.attachmentList.innerHTML;
+            expect(html).not.toContain('<script>');
+            expect(html).toContain('&lt;script&gt;');
+        });
+    });
+
+    describe('removeAttachment', () => {
+        beforeEach(() => {
+            state.pendingAttachments = {
+                images: [
+                    { name: 'img1.png', previewUrl: 'blob:url-1' },
+                    { name: 'img2.png', previewUrl: 'blob:url-2' },
+                ],
+                files: [
+                    { name: 'doc1.txt' },
+                    { name: 'doc2.txt' },
+                ],
+            };
+        });
+
+        it('should remove image at specified index', () => {
+            removeAttachment('image', 0);
+
+            expect(state.pendingAttachments.images.length).toBe(1);
+            expect(state.pendingAttachments.images[0].name).toBe('img2.png');
+        });
+
+        it('should revoke blob URL when removing image', () => {
+            removeAttachment('image', 0);
+
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:url-1');
+        });
+
+        it('should remove file at specified index', () => {
+            removeAttachment('file', 1);
+
+            expect(state.pendingAttachments.files.length).toBe(1);
+            expect(state.pendingAttachments.files[0].name).toBe('doc1.txt');
+        });
+
+        it('should call onAttachmentsChanged callback', () => {
+            removeAttachment('image', 0);
+
+            expect(mockCallbacks.onAttachmentsChanged).toHaveBeenCalled();
+        });
+
+        it('should update preview after removal', () => {
+            mockElements.attachmentPreview.style.display = 'block';
+
+            // Remove all attachments
+            removeAttachment('image', 0);
+            removeAttachment('image', 0);
+            removeAttachment('file', 0);
+            removeAttachment('file', 0);
+
+            expect(mockElements.attachmentPreview.style.display).toBe('none');
+        });
+
+        it('should handle image without previewUrl', () => {
+            state.pendingAttachments.images.push({ name: 'no-url.png' });
+
+            expect(() => removeAttachment('image', 2)).not.toThrow();
+        });
+    });
+
+    describe('clearAttachments', () => {
+        beforeEach(() => {
+            state.pendingAttachments = {
+                images: [
+                    { name: 'img1.png', previewUrl: 'blob:url-1' },
+                    { name: 'img2.png', previewUrl: 'blob:url-2' },
+                ],
+                files: [
+                    { name: 'doc.txt' },
+                ],
+            };
+        });
+
+        it('should clear all attachments', () => {
+            clearAttachments();
+
+            expect(state.pendingAttachments.images.length).toBe(0);
+            expect(state.pendingAttachments.files.length).toBe(0);
+        });
+
+        it('should revoke all blob URLs', () => {
+            clearAttachments();
+
+            expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:url-1');
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:url-2');
+        });
+
+        it('should call onAttachmentsChanged callback', () => {
+            clearAttachments();
+
+            expect(mockCallbacks.onAttachmentsChanged).toHaveBeenCalled();
+        });
+
+        it('should update preview to hidden', () => {
+            mockElements.attachmentPreview.style.display = 'block';
+
+            clearAttachments();
+
+            expect(mockElements.attachmentPreview.style.display).toBe('none');
+        });
+    });
+
+    describe('getAttachmentsForRequest', () => {
+        it('should format images for API request', () => {
+            state.pendingAttachments.images.push({
+                name: 'test.png',
+                type: 'image/png',
+                base64: 'base64data',
+            });
+
+            const result = getAttachmentsForRequest();
+
+            expect(result.images.length).toBe(1);
+            expect(result.images[0]).toEqual({
+                name: 'test.png',
+                media_type: 'image/png',
+                data: 'base64data',
+            });
+        });
+
+        it('should format files for API request', () => {
+            state.pendingAttachments.files.push({
+                name: 'document.txt',
+                type: 'text/plain',
+                content: 'file content',
+            });
+
+            const result = getAttachmentsForRequest();
+
+            expect(result.files.length).toBe(1);
+            expect(result.files[0]).toEqual({
+                name: 'document.txt',
+                type: 'text/plain',
+                content: 'file content',
+            });
+        });
+
+        it('should return empty arrays when no attachments', () => {
+            const result = getAttachmentsForRequest();
+
+            expect(result.images).toEqual([]);
+            expect(result.files).toEqual([]);
+        });
+    });
+
+    describe('buildDisplayContentWithAttachments', () => {
+        it('should return text content when no attachments', () => {
+            const result = buildDisplayContentWithAttachments('Hello world', { images: [], files: [] });
+            expect(result).toBe('Hello world');
+        });
+
+        it('should prepend image count indicator', () => {
+            const result = buildDisplayContentWithAttachments('Hello', { images: [{}], files: [] });
+            expect(result).toBe('[1 image attached]\n\nHello');
+        });
+
+        it('should use plural for multiple images', () => {
+            const result = buildDisplayContentWithAttachments('Hello', { images: [{}, {}], files: [] });
+            expect(result).toBe('[2 images attached]\n\nHello');
+        });
+
+        it('should prepend file count indicator', () => {
+            const result = buildDisplayContentWithAttachments('Hello', { images: [], files: [{}] });
+            expect(result).toBe('[1 file attached]\n\nHello');
+        });
+
+        it('should use plural for multiple files', () => {
+            const result = buildDisplayContentWithAttachments('Hello', { images: [], files: [{}, {}, {}] });
+            expect(result).toBe('[3 files attached]\n\nHello');
+        });
+
+        it('should combine image and file indicators', () => {
+            const result = buildDisplayContentWithAttachments('Hello', { images: [{}], files: [{}, {}] });
+            expect(result).toBe('[1 image attached] [2 files attached]\n\nHello');
+        });
+
+        it('should return placeholder for attachments only (no text)', () => {
+            const result = buildDisplayContentWithAttachments('', { images: [{}], files: [] });
+            expect(result).toBe('[1 image attached]\n\n');
+        });
+
+        it('should return placeholder for null/undefined text with attachments', () => {
+            const result = buildDisplayContentWithAttachments(null, { images: [{}], files: [] });
+            expect(result).toBe('[1 image attached]\n\n');
+        });
+
+        it('should handle missing attachment arrays', () => {
+            const result = buildDisplayContentWithAttachments('Hello', {});
+            expect(result).toBe('Hello');
+        });
+    });
+});

--- a/frontend/js/__tests__/messages.test.js
+++ b/frontend/js/__tests__/messages.test.js
@@ -1,0 +1,612 @@
+/**
+ * Unit Tests for Messages Module
+ * Tests message rendering and display functionality
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { state } from '../modules/state.js';
+import {
+    setElements,
+    setCallbacks,
+    addMessage,
+    addToolMessage,
+    createStreamingMessage,
+    addTypingIndicator,
+    clearMessages,
+    removeRegenerateButtons,
+    copyMessage,
+    updateAssistantMessageActions,
+    isNearBottom,
+    scrollToBottom,
+} from '../modules/messages.js';
+
+describe('Messages Module', () => {
+    let mockElements;
+    let mockCallbacks;
+
+    beforeEach(() => {
+        // Reset TTS state
+        state.ttsEnabled = false;
+
+        // Create mock elements
+        mockElements = {
+            messages: document.createElement('div'),
+            messagesContainer: document.createElement('div'),
+            welcomeMessage: document.createElement('div'),
+        };
+
+        mockElements.messages.id = 'messages';
+        mockElements.messagesContainer.id = 'messages-container';
+        mockElements.welcomeMessage.id = 'welcome-message';
+        mockElements.messagesContainer.appendChild(mockElements.messages);
+
+        // Create mock callbacks
+        mockCallbacks = {
+            onCopyMessage: vi.fn(),
+            onEditMessage: vi.fn(),
+            onRegenerateMessage: vi.fn(),
+            onSpeakMessage: vi.fn(),
+            scrollToBottom: vi.fn(),
+        };
+
+        setElements(mockElements);
+        setCallbacks(mockCallbacks);
+    });
+
+    describe('addMessage', () => {
+        it('should create a human message element', () => {
+            const message = addMessage('human', 'Hello world');
+
+            expect(message.classList.contains('message')).toBe(true);
+            expect(message.classList.contains('human')).toBe(true);
+            expect(message.textContent).toContain('Hello world');
+        });
+
+        it('should create an assistant message element', () => {
+            const message = addMessage('assistant', 'Hi there!');
+
+            expect(message.classList.contains('message')).toBe(true);
+            expect(message.classList.contains('assistant')).toBe(true);
+            expect(message.textContent).toContain('Hi there!');
+        });
+
+        it('should hide welcome message', () => {
+            mockElements.welcomeMessage.style.display = 'block';
+
+            addMessage('human', 'Test');
+
+            expect(mockElements.welcomeMessage.style.display).toBe('none');
+        });
+
+        it('should store message ID in data attribute', () => {
+            const message = addMessage('human', 'Test', { messageId: 'msg-123' });
+
+            expect(message.dataset.messageId).toBe('msg-123');
+        });
+
+        it('should store role in data attribute', () => {
+            const message = addMessage('assistant', 'Test');
+
+            expect(message.dataset.role).toBe('assistant');
+        });
+
+        it('should store speaker entity ID for multi-entity', () => {
+            const message = addMessage('assistant', 'Test', { speakerEntityId: 'entity-1' });
+
+            expect(message.dataset.speakerEntityId).toBe('entity-1');
+        });
+
+        it('should add speaker label for assistant messages', () => {
+            const message = addMessage('assistant', 'Test', { speakerLabel: 'Claude' });
+
+            expect(message.innerHTML).toContain('message-speaker-label');
+            expect(message.innerHTML).toContain('Claude');
+        });
+
+        it('should not add speaker label for human messages', () => {
+            const message = addMessage('human', 'Test', { speakerLabel: 'User' });
+
+            expect(message.innerHTML).not.toContain('message-speaker-label');
+        });
+
+        it('should add timestamp by default', () => {
+            const message = addMessage('human', 'Test');
+
+            expect(message.innerHTML).toContain('message-meta');
+        });
+
+        it('should hide timestamp when showTimestamp is false', () => {
+            const message = addMessage('human', 'Test', { showTimestamp: false });
+
+            expect(message.innerHTML).not.toContain('message-meta');
+        });
+
+        it('should use custom timestamp', () => {
+            const customDate = new Date('2024-01-15T10:30:00');
+            const message = addMessage('human', 'Test', { timestamp: customDate.toISOString() });
+
+            expect(message.innerHTML).toContain('10:30');
+        });
+
+        it('should add error class when isError is true', () => {
+            const message = addMessage('assistant', 'Error occurred', { isError: true });
+
+            expect(message.querySelector('.message-bubble.error')).toBeTruthy();
+        });
+
+        describe('action buttons', () => {
+            it('should add copy button for messages with ID', () => {
+                const message = addMessage('human', 'Test', { messageId: 'msg-1' });
+
+                expect(message.querySelector('.copy-btn')).toBeTruthy();
+            });
+
+            it('should add edit button for human messages', () => {
+                const message = addMessage('human', 'Test', { messageId: 'msg-1' });
+
+                expect(message.querySelector('.edit-btn')).toBeTruthy();
+            });
+
+            it('should not add edit button for assistant messages', () => {
+                const message = addMessage('assistant', 'Test', { messageId: 'msg-1' });
+
+                expect(message.querySelector('.edit-btn')).toBeFalsy();
+            });
+
+            it('should add regenerate button for latest assistant message', () => {
+                const message = addMessage('assistant', 'Test', {
+                    messageId: 'msg-1',
+                    isLatestAssistant: true,
+                });
+
+                expect(message.querySelector('.regenerate-btn')).toBeTruthy();
+            });
+
+            it('should not add regenerate button when not latest', () => {
+                const message = addMessage('assistant', 'Test', {
+                    messageId: 'msg-1',
+                    isLatestAssistant: false,
+                });
+
+                expect(message.querySelector('.regenerate-btn')).toBeFalsy();
+            });
+
+            it('should add speak button when TTS is enabled', () => {
+                state.ttsEnabled = true;
+
+                const message = addMessage('assistant', 'Test', { messageId: 'msg-1' });
+
+                expect(message.querySelector('.speak-btn')).toBeTruthy();
+            });
+
+            it('should not add speak button when TTS is disabled', () => {
+                state.ttsEnabled = false;
+
+                const message = addMessage('assistant', 'Test', { messageId: 'msg-1' });
+
+                expect(message.querySelector('.speak-btn')).toBeFalsy();
+            });
+
+            it('should not add buttons for error messages', () => {
+                const message = addMessage('assistant', 'Error', {
+                    messageId: 'msg-1',
+                    isError: true,
+                });
+
+                expect(message.querySelector('.copy-btn')).toBeFalsy();
+            });
+
+            it('should not add buttons when no message ID', () => {
+                const message = addMessage('human', 'Test');
+
+                expect(message.querySelector('.copy-btn')).toBeFalsy();
+                expect(message.querySelector('.edit-btn')).toBeFalsy();
+            });
+        });
+
+        describe('button event handlers', () => {
+            it('should call onEditMessage when edit button clicked', () => {
+                const message = addMessage('human', 'Test content', { messageId: 'msg-1' });
+                const editBtn = message.querySelector('.edit-btn');
+
+                editBtn.click();
+
+                expect(mockCallbacks.onEditMessage).toHaveBeenCalledWith(
+                    message,
+                    'msg-1',
+                    'Test content'
+                );
+            });
+
+            it('should call onRegenerateMessage when regenerate button clicked', () => {
+                const message = addMessage('assistant', 'Test', {
+                    messageId: 'msg-1',
+                    isLatestAssistant: true,
+                });
+                const regenerateBtn = message.querySelector('.regenerate-btn');
+
+                regenerateBtn.click();
+
+                expect(mockCallbacks.onRegenerateMessage).toHaveBeenCalledWith('msg-1');
+            });
+
+            it('should call onSpeakMessage when speak button clicked', () => {
+                state.ttsEnabled = true;
+
+                const message = addMessage('assistant', 'Test content', { messageId: 'msg-1' });
+                const speakBtn = message.querySelector('.speak-btn');
+
+                speakBtn.click();
+
+                expect(mockCallbacks.onSpeakMessage).toHaveBeenCalledWith(
+                    'Test content',
+                    speakBtn,
+                    'msg-1'
+                );
+            });
+        });
+
+        it('should render markdown in content', () => {
+            const message = addMessage('assistant', '**bold** and *italic*');
+
+            expect(message.innerHTML).toContain('<strong>bold</strong>');
+            expect(message.innerHTML).toContain('<em>italic</em>');
+        });
+
+        it('should append message to messages container', () => {
+            addMessage('human', 'Test 1');
+            addMessage('assistant', 'Test 2');
+
+            expect(mockElements.messages.children.length).toBe(2);
+        });
+    });
+
+    describe('addToolMessage', () => {
+        it('should create tool start message', () => {
+            const message = addToolMessage('start', 'web_search', {
+                tool_id: 'tool-1',
+                input: { query: 'test query' },
+            });
+
+            expect(message.classList.contains('tool-message')).toBe(true);
+            expect(message.dataset.toolId).toBe('tool-1');
+            expect(message.innerHTML).toContain('web search');
+            expect(message.innerHTML).toContain('...');
+        });
+
+        it('should include input details when available', () => {
+            const message = addToolMessage('start', 'web_fetch', {
+                tool_id: 'tool-1',
+                input: { url: 'https://example.com' },
+            });
+
+            expect(message.innerHTML).toContain('tool-input-details');
+            expect(message.innerHTML).toContain('https://example.com');
+        });
+
+        it('should update tool start message with result', () => {
+            // Create start message
+            const startMessage = addToolMessage('start', 'web_search', {
+                tool_id: 'tool-1',
+                input: {},
+            });
+
+            // Add result
+            addToolMessage('result', 'web_search', {
+                tool_id: 'tool-1',
+                content: 'Search results here',
+                is_error: false,
+            });
+
+            expect(startMessage.querySelector('.tool-status.success')).toBeTruthy();
+            expect(startMessage.innerHTML).toContain('✓');
+            expect(startMessage.innerHTML).toContain('Search results here');
+        });
+
+        it('should show error status for failed tools', () => {
+            const startMessage = addToolMessage('start', 'web_fetch', {
+                tool_id: 'tool-2',
+                input: {},
+            });
+
+            addToolMessage('result', 'web_fetch', {
+                tool_id: 'tool-2',
+                content: 'Connection failed',
+                is_error: true,
+            });
+
+            expect(startMessage.querySelector('.tool-status.error')).toBeTruthy();
+            expect(startMessage.innerHTML).toContain('✗');
+            expect(startMessage.innerHTML).toContain('(Error)');
+        });
+
+        it('should truncate long tool results', () => {
+            const startMessage = addToolMessage('start', 'web_fetch', {
+                tool_id: 'tool-3',
+                input: {},
+            });
+
+            const longContent = 'x'.repeat(3000);
+            addToolMessage('result', 'web_fetch', {
+                tool_id: 'tool-3',
+                content: longContent,
+                is_error: false,
+            });
+
+            expect(startMessage.innerHTML).toContain('...[truncated]');
+        });
+
+        it('should return null for result type', () => {
+            addToolMessage('start', 'test', { tool_id: 'tool-1', input: {} });
+            const result = addToolMessage('result', 'test', { tool_id: 'tool-1', content: 'ok' });
+
+            expect(result).toBe(null);
+        });
+    });
+
+    describe('createStreamingMessage', () => {
+        it('should create streaming message element', () => {
+            const stream = createStreamingMessage('assistant');
+
+            expect(stream.element.classList.contains('message')).toBe(true);
+            expect(stream.element.classList.contains('assistant')).toBe(true);
+            expect(stream.element.querySelector('.streaming')).toBeTruthy();
+        });
+
+        it('should hide welcome message', () => {
+            mockElements.welcomeMessage.style.display = 'block';
+
+            createStreamingMessage('assistant');
+
+            expect(mockElements.welcomeMessage.style.display).toBe('none');
+        });
+
+        it('should add speaker label for multi-entity', () => {
+            const stream = createStreamingMessage('assistant', 'Claude');
+
+            expect(stream.element.innerHTML).toContain('message-speaker-label');
+            expect(stream.element.innerHTML).toContain('Claude');
+        });
+
+        it('should include streaming cursor', () => {
+            const stream = createStreamingMessage('assistant');
+
+            expect(stream.element.querySelector('.streaming-cursor')).toBeTruthy();
+        });
+
+        it('should update content with new tokens', () => {
+            const stream = createStreamingMessage('assistant');
+
+            stream.updateContent('Hello');
+            stream.updateContent(' world');
+
+            expect(stream.getContent()).toBe('Hello world');
+        });
+
+        it('should accumulate content correctly', () => {
+            const stream = createStreamingMessage('assistant');
+
+            stream.updateContent('Token1 ');
+            stream.updateContent('Token2 ');
+            stream.updateContent('Token3');
+
+            expect(stream.getContent()).toBe('Token1 Token2 Token3');
+        });
+
+        it('should finalize message with markdown rendering', () => {
+            const stream = createStreamingMessage('assistant');
+
+            stream.updateContent('**bold** text');
+            stream.finalize();
+
+            expect(stream.element.innerHTML).toContain('<strong>bold</strong>');
+            expect(stream.element.querySelector('.streaming-cursor')).toBeFalsy();
+            expect(stream.element.querySelector('.streaming')).toBeFalsy();
+        });
+
+        it('should add timestamp on finalize', () => {
+            const stream = createStreamingMessage('assistant');
+
+            stream.updateContent('Test');
+            stream.finalize();
+
+            expect(stream.element.innerHTML).toContain('message-meta');
+        });
+
+        it('should return accumulated content on finalize', () => {
+            const stream = createStreamingMessage('assistant');
+
+            stream.updateContent('Final content');
+            const result = stream.finalize();
+
+            expect(result).toBe('Final content');
+        });
+    });
+
+    describe('addTypingIndicator', () => {
+        it('should create typing indicator element', () => {
+            const indicator = addTypingIndicator();
+
+            expect(indicator.classList.contains('message')).toBe(true);
+            expect(indicator.classList.contains('assistant')).toBe(true);
+            expect(indicator.querySelector('.typing-indicator')).toBeTruthy();
+        });
+
+        it('should include three typing dots', () => {
+            const indicator = addTypingIndicator();
+
+            const dots = indicator.querySelectorAll('.typing-dot');
+            expect(dots.length).toBe(3);
+        });
+
+        it('should call scrollToBottom callback', () => {
+            addTypingIndicator();
+
+            expect(mockCallbacks.scrollToBottom).toHaveBeenCalled();
+        });
+    });
+
+    describe('clearMessages', () => {
+        it('should clear all messages', () => {
+            addMessage('human', 'Test 1');
+            addMessage('assistant', 'Test 2');
+
+            clearMessages();
+
+            // Should only have welcome message
+            expect(mockElements.messages.children.length).toBe(1);
+        });
+
+        it('should show welcome message', () => {
+            mockElements.welcomeMessage.style.display = 'none';
+
+            clearMessages();
+
+            expect(mockElements.welcomeMessage.style.display).toBe('block');
+        });
+
+        it('should handle missing elements gracefully', () => {
+            setElements({});
+            expect(() => clearMessages()).not.toThrow();
+        });
+    });
+
+    describe('removeRegenerateButtons', () => {
+        it('should remove all regenerate buttons from assistant messages', () => {
+            // Add messages with regenerate buttons
+            addMessage('assistant', 'Test 1', { messageId: 'msg-1', isLatestAssistant: true });
+            addMessage('assistant', 'Test 2', { messageId: 'msg-2', isLatestAssistant: true });
+
+            expect(mockElements.messages.querySelectorAll('.regenerate-btn').length).toBe(2);
+
+            removeRegenerateButtons();
+
+            expect(mockElements.messages.querySelectorAll('.regenerate-btn').length).toBe(0);
+        });
+    });
+
+    describe('copyMessage', () => {
+        it('should copy content to clipboard', async () => {
+            const btn = document.createElement('button');
+            btn.innerHTML = '<svg>original</svg>';
+
+            await copyMessage('Test content', btn);
+
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Test content');
+        });
+
+        it('should show copied state on button', async () => {
+            vi.useFakeTimers();
+            const btn = document.createElement('button');
+            btn.innerHTML = '<svg>original</svg>';
+
+            await copyMessage('Test', btn);
+
+            expect(btn.classList.contains('copied')).toBe(true);
+            expect(btn.title).toBe('Copied!');
+
+            vi.advanceTimersByTime(2000);
+
+            expect(btn.classList.contains('copied')).toBe(false);
+            expect(btn.title).toBe('Copy to clipboard');
+
+            vi.useRealTimers();
+        });
+    });
+
+    describe('updateAssistantMessageActions', () => {
+        it('should add action buttons to assistant message', () => {
+            const messageEl = document.createElement('div');
+            messageEl.className = 'message assistant';
+            const bubble = document.createElement('div');
+            bubble.className = 'message-bubble';
+            messageEl.appendChild(bubble);
+
+            updateAssistantMessageActions(messageEl, 'msg-1', 'Content');
+
+            expect(bubble.querySelector('.message-bubble-actions')).toBeTruthy();
+            expect(bubble.querySelector('.copy-btn')).toBeTruthy();
+            expect(bubble.querySelector('.regenerate-btn')).toBeTruthy();
+        });
+
+        it('should include speak button when TTS enabled', () => {
+            state.ttsEnabled = true;
+
+            const messageEl = document.createElement('div');
+            const bubble = document.createElement('div');
+            bubble.className = 'message-bubble';
+            messageEl.appendChild(bubble);
+
+            updateAssistantMessageActions(messageEl, 'msg-1', 'Content');
+
+            expect(bubble.querySelector('.speak-btn')).toBeTruthy();
+        });
+
+        it('should remove existing regenerate buttons', () => {
+            // Add a message with regenerate button
+            addMessage('assistant', 'Old', { messageId: 'old-1', isLatestAssistant: true });
+
+            const messageEl = document.createElement('div');
+            const bubble = document.createElement('div');
+            bubble.className = 'message-bubble';
+            messageEl.appendChild(bubble);
+
+            updateAssistantMessageActions(messageEl, 'new-1', 'New content');
+
+            // Old regenerate button should be gone
+            expect(mockElements.messages.querySelectorAll('.regenerate-btn').length).toBe(0);
+        });
+    });
+
+    describe('isNearBottom', () => {
+        beforeEach(() => {
+            // Setup scrollable container
+            Object.defineProperty(mockElements.messagesContainer, 'scrollTop', {
+                value: 800,
+                writable: true,
+            });
+            Object.defineProperty(mockElements.messagesContainer, 'clientHeight', {
+                value: 100,
+                writable: true,
+            });
+            Object.defineProperty(mockElements.messagesContainer, 'scrollHeight', {
+                value: 1000,
+                writable: true,
+            });
+        });
+
+        it('should return true when at bottom', () => {
+            expect(isNearBottom()).toBe(true);
+        });
+
+        it('should return true when within threshold', () => {
+            mockElements.messagesContainer.scrollTop = 850;
+            expect(isNearBottom(100)).toBe(true);
+        });
+
+        it('should return false when far from bottom', () => {
+            mockElements.messagesContainer.scrollTop = 500;
+            expect(isNearBottom(100)).toBe(false);
+        });
+
+        it('should support custom threshold', () => {
+            mockElements.messagesContainer.scrollTop = 700;
+            expect(isNearBottom(50)).toBe(false);
+            expect(isNearBottom(250)).toBe(true);
+        });
+    });
+
+    describe('scrollToBottom', () => {
+        it('should scroll container to bottom', () => {
+            Object.defineProperty(mockElements.messagesContainer, 'scrollHeight', {
+                value: 1000,
+                writable: true,
+            });
+            mockElements.messagesContainer.scrollTop = 0;
+
+            scrollToBottom();
+
+            expect(mockElements.messagesContainer.scrollTop).toBe(1000);
+        });
+    });
+});

--- a/frontend/js/__tests__/modals.test.js
+++ b/frontend/js/__tests__/modals.test.js
@@ -1,0 +1,255 @@
+/**
+ * Unit Tests for Modals Module
+ * Tests modal management functionality
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    setElements,
+    showModal,
+    hideModal,
+    closeActiveModal,
+    isModalOpen,
+    closeAllDropdowns,
+} from '../modules/modals.js';
+
+describe('Modals Module', () => {
+    let mockElements;
+
+    beforeEach(() => {
+        // Create mock modal elements
+        mockElements = {
+            settingsModal: document.createElement('div'),
+            memoriesModal: document.createElement('div'),
+            archiveModal: document.createElement('div'),
+            renameModal: document.createElement('div'),
+            deleteModal: document.createElement('div'),
+            archivedModal: document.createElement('div'),
+            voiceCloneModal: document.createElement('div'),
+            voiceEditModal: document.createElement('div'),
+            multiEntityModal: document.createElement('div'),
+            goNewGameModal: document.createElement('div'),
+        };
+
+        // Set IDs for debugging
+        Object.entries(mockElements).forEach(([name, el]) => {
+            el.id = name;
+        });
+
+        setElements(mockElements);
+    });
+
+    describe('showModal', () => {
+        it('should add active class to modal', () => {
+            showModal('settingsModal');
+            expect(mockElements.settingsModal.classList.contains('active')).toBe(true);
+        });
+
+        it('should work for different modals', () => {
+            showModal('memoriesModal');
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(true);
+
+            showModal('archiveModal');
+            expect(mockElements.archiveModal.classList.contains('active')).toBe(true);
+        });
+
+        it('should handle unknown modal names gracefully', () => {
+            expect(() => showModal('unknownModal')).not.toThrow();
+        });
+
+        it('should not throw when elements not set', () => {
+            setElements({});
+            expect(() => showModal('settingsModal')).not.toThrow();
+        });
+    });
+
+    describe('hideModal', () => {
+        beforeEach(() => {
+            // Open all modals first
+            Object.values(mockElements).forEach(el => {
+                el.classList.add('active');
+            });
+        });
+
+        it('should remove active class from modal', () => {
+            hideModal('settingsModal');
+            expect(mockElements.settingsModal.classList.contains('active')).toBe(false);
+        });
+
+        it('should work for different modals', () => {
+            hideModal('memoriesModal');
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(false);
+
+            hideModal('deleteModal');
+            expect(mockElements.deleteModal.classList.contains('active')).toBe(false);
+        });
+
+        it('should handle unknown modal names gracefully', () => {
+            expect(() => hideModal('unknownModal')).not.toThrow();
+        });
+
+        it('should not throw when modal already hidden', () => {
+            mockElements.settingsModal.classList.remove('active');
+            expect(() => hideModal('settingsModal')).not.toThrow();
+        });
+    });
+
+    describe('closeActiveModal', () => {
+        it('should close the first active modal found', () => {
+            mockElements.settingsModal.classList.add('active');
+            mockElements.memoriesModal.classList.add('active');
+
+            closeActiveModal();
+
+            // Should close settingsModal (first in the list)
+            expect(mockElements.settingsModal.classList.contains('active')).toBe(false);
+            // memoriesModal should still be open (only first is closed)
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(true);
+        });
+
+        it('should handle no active modals gracefully', () => {
+            expect(() => closeActiveModal()).not.toThrow();
+        });
+
+        it('should close modals in priority order', () => {
+            // Open only memoriesModal
+            mockElements.memoriesModal.classList.add('active');
+
+            closeActiveModal();
+
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(false);
+        });
+    });
+
+    describe('isModalOpen', () => {
+        it('should return true when a modal is active', () => {
+            mockElements.settingsModal.classList.add('active');
+            expect(isModalOpen()).toBe(true);
+        });
+
+        it('should return false when no modals are active', () => {
+            expect(isModalOpen()).toBe(false);
+        });
+
+        it('should detect any active modal', () => {
+            mockElements.multiEntityModal.classList.add('active');
+            expect(isModalOpen()).toBe(true);
+        });
+
+        it('should handle missing elements gracefully', () => {
+            setElements({});
+            expect(isModalOpen()).toBe(false);
+        });
+
+        it('should return true for any of the tracked modals', () => {
+            const modalNames = [
+                'settingsModal',
+                'memoriesModal',
+                'archiveModal',
+                'renameModal',
+                'deleteModal',
+                'archivedModal',
+                'voiceCloneModal',
+                'voiceEditModal',
+                'multiEntityModal',
+                'goNewGameModal',
+            ];
+
+            for (const modalName of modalNames) {
+                // Reset all modals
+                Object.values(mockElements).forEach(el => el.classList.remove('active'));
+
+                // Activate specific modal
+                mockElements[modalName].classList.add('active');
+
+                expect(isModalOpen()).toBe(true);
+            }
+        });
+    });
+
+    describe('closeAllDropdowns', () => {
+        it('should remove active class from all conversation dropdowns', () => {
+            // Create mock dropdowns in document
+            const dropdown1 = document.createElement('div');
+            dropdown1.className = 'conversation-dropdown active';
+            const dropdown2 = document.createElement('div');
+            dropdown2.className = 'conversation-dropdown active';
+            const dropdown3 = document.createElement('div');
+            dropdown3.className = 'conversation-dropdown'; // Not active
+
+            document.body.appendChild(dropdown1);
+            document.body.appendChild(dropdown2);
+            document.body.appendChild(dropdown3);
+
+            closeAllDropdowns();
+
+            expect(dropdown1.classList.contains('active')).toBe(false);
+            expect(dropdown2.classList.contains('active')).toBe(false);
+            expect(dropdown3.classList.contains('active')).toBe(false);
+        });
+
+        it('should handle no dropdowns gracefully', () => {
+            expect(() => closeAllDropdowns()).not.toThrow();
+        });
+
+        it('should not affect non-dropdown elements', () => {
+            const otherElement = document.createElement('div');
+            otherElement.className = 'other-element active';
+            document.body.appendChild(otherElement);
+
+            closeAllDropdowns();
+
+            expect(otherElement.classList.contains('active')).toBe(true);
+        });
+    });
+
+    describe('setElements', () => {
+        it('should accept new element references', () => {
+            const newElements = {
+                settingsModal: document.createElement('div'),
+            };
+
+            setElements(newElements);
+            newElements.settingsModal.classList.add('test');
+
+            showModal('settingsModal');
+            expect(newElements.settingsModal.classList.contains('active')).toBe(true);
+        });
+
+        it('should handle empty object', () => {
+            setElements({});
+            expect(() => showModal('settingsModal')).not.toThrow();
+            expect(() => hideModal('settingsModal')).not.toThrow();
+        });
+    });
+
+    describe('modal workflow', () => {
+        it('should support show -> hide cycle', () => {
+            showModal('settingsModal');
+            expect(isModalOpen()).toBe(true);
+
+            hideModal('settingsModal');
+            expect(isModalOpen()).toBe(false);
+        });
+
+        it('should support multiple modals open at once', () => {
+            showModal('settingsModal');
+            showModal('memoriesModal');
+
+            expect(mockElements.settingsModal.classList.contains('active')).toBe(true);
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(true);
+            expect(isModalOpen()).toBe(true);
+        });
+
+        it('should support closing one of multiple open modals', () => {
+            showModal('settingsModal');
+            showModal('memoriesModal');
+
+            hideModal('settingsModal');
+
+            expect(mockElements.settingsModal.classList.contains('active')).toBe(false);
+            expect(mockElements.memoriesModal.classList.contains('active')).toBe(true);
+            expect(isModalOpen()).toBe(true);
+        });
+    });
+});

--- a/frontend/js/__tests__/setup.js
+++ b/frontend/js/__tests__/setup.js
@@ -1,0 +1,194 @@
+/**
+ * Test Setup File
+ * Configures jsdom environment and mocks for frontend tests
+ */
+
+import { vi, beforeEach, afterEach } from 'vitest';
+
+// Mock localStorage
+const localStorageMock = (() => {
+    let store = {};
+    return {
+        getItem: vi.fn((key) => store[key] || null),
+        setItem: vi.fn((key, value) => {
+            store[key] = String(value);
+        }),
+        removeItem: vi.fn((key) => {
+            delete store[key];
+        }),
+        clear: vi.fn(() => {
+            store = {};
+        }),
+        get length() {
+            return Object.keys(store).length;
+        },
+        key: vi.fn((index) => {
+            return Object.keys(store)[index] || null;
+        }),
+        _getStore: () => store,
+    };
+})();
+
+Object.defineProperty(global, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+});
+
+// Mock URL.createObjectURL and URL.revokeObjectURL
+const mockObjectURLs = new Map();
+let objectURLCounter = 0;
+
+global.URL.createObjectURL = vi.fn((blob) => {
+    const url = `blob:mock-url-${++objectURLCounter}`;
+    mockObjectURLs.set(url, blob);
+    return url;
+});
+
+global.URL.revokeObjectURL = vi.fn((url) => {
+    mockObjectURLs.delete(url);
+});
+
+// Helper to get mock object URLs (for test assertions)
+global._getMockObjectURLs = () => mockObjectURLs;
+
+// Mock navigator.clipboard
+Object.defineProperty(global.navigator, 'clipboard', {
+    value: {
+        writeText: vi.fn(() => Promise.resolve()),
+        readText: vi.fn(() => Promise.resolve('')),
+    },
+    writable: true,
+});
+
+// Mock FileReader
+class MockFileReader {
+    constructor() {
+        this.result = null;
+        this.error = null;
+        this.onload = null;
+        this.onerror = null;
+    }
+
+    readAsText(file) {
+        setTimeout(() => {
+            if (file._mockError) {
+                this.error = new Error('Mock read error');
+                if (this.onerror) this.onerror();
+            } else {
+                this.result = file._mockContent || 'mock file content';
+                if (this.onload) this.onload();
+            }
+        }, 0);
+    }
+
+    readAsDataURL(file) {
+        setTimeout(() => {
+            if (file._mockError) {
+                this.error = new Error('Mock read error');
+                if (this.onerror) this.onerror();
+            } else {
+                const base64Content = file._mockBase64 || 'bW9jayBiYXNlNjQgY29udGVudA==';
+                const mediaType = file.type || 'application/octet-stream';
+                this.result = `data:${mediaType};base64,${base64Content}`;
+                if (this.onload) this.onload();
+            }
+        }, 0);
+    }
+}
+
+global.FileReader = MockFileReader;
+
+// Mock File constructor
+class MockFile {
+    constructor(parts, name, options = {}) {
+        this.name = name;
+        this.type = options.type || '';
+        this.size = parts.reduce((acc, part) => {
+            if (typeof part === 'string') return acc + part.length;
+            if (part instanceof ArrayBuffer) return acc + part.byteLength;
+            return acc;
+        }, 0);
+        this._mockContent = parts.join('');
+        this._mockBase64 = null;
+        this._mockError = false;
+    }
+}
+
+global.File = MockFile;
+
+// Mock Blob
+class MockBlob {
+    constructor(parts = [], options = {}) {
+        this.type = options.type || '';
+        this.size = parts.reduce((acc, part) => {
+            if (typeof part === 'string') return acc + part.length;
+            if (part instanceof ArrayBuffer) return acc + part.byteLength;
+            return acc;
+        }, 0);
+        this._parts = parts;
+    }
+
+    text() {
+        return Promise.resolve(this._parts.join(''));
+    }
+
+    arrayBuffer() {
+        const text = this._parts.join('');
+        const buffer = new ArrayBuffer(text.length);
+        const view = new Uint8Array(buffer);
+        for (let i = 0; i < text.length; i++) {
+            view[i] = text.charCodeAt(i);
+        }
+        return Promise.resolve(buffer);
+    }
+}
+
+global.Blob = MockBlob;
+
+// Mock window.api (global API singleton used by modules)
+global.window = global.window || {};
+global.window.api = {
+    getEntities: vi.fn(() => Promise.resolve([])),
+    getConversations: vi.fn(() => Promise.resolve([])),
+    getConversation: vi.fn(() => Promise.resolve(null)),
+    createConversation: vi.fn(() => Promise.resolve({ id: 'mock-conv-id' })),
+    updateConversation: vi.fn(() => Promise.resolve({})),
+    deleteConversation: vi.fn(() => Promise.resolve()),
+    getMessages: vi.fn(() => Promise.resolve([])),
+    sendMessage: vi.fn(() => Promise.resolve({})),
+    sendMessageStream: vi.fn(() => Promise.resolve(new ReadableStream())),
+    searchMemories: vi.fn(() => Promise.resolve([])),
+    getMemoryStats: vi.fn(() => Promise.resolve({})),
+    getTTSStatus: vi.fn(() => Promise.resolve({ enabled: false })),
+    speak: vi.fn(() => Promise.resolve(new Blob())),
+    transcribe: vi.fn(() => Promise.resolve({ text: '' })),
+    getPresets: vi.fn(() => Promise.resolve({})),
+    archiveConversation: vi.fn(() => Promise.resolve()),
+    unarchiveConversation: vi.fn(() => Promise.resolve()),
+    getArchivedConversations: vi.fn(() => Promise.resolve([])),
+};
+
+// Reset mocks before each test
+beforeEach(() => {
+    // Clear localStorage
+    localStorageMock.clear();
+    vi.clearAllMocks();
+
+    // Reset object URL tracking
+    mockObjectURLs.clear();
+    objectURLCounter = 0;
+
+    // Clear document body
+    document.body.innerHTML = '';
+});
+
+// Cleanup after each test
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// Export utilities for tests
+export {
+    localStorageMock,
+    mockObjectURLs,
+};

--- a/frontend/js/__tests__/state.test.js
+++ b/frontend/js/__tests__/state.test.js
@@ -1,0 +1,340 @@
+/**
+ * Unit Tests for State Module
+ * Tests centralized state management functionality
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    state,
+    resetMemoryState,
+    resetAttachments,
+    clearAudioCache,
+    loadEntitySystemPromptsFromStorage,
+    saveEntitySystemPromptsToStorage,
+    loadSelectedVoiceFromStorage,
+    saveSelectedVoiceToStorage,
+    loadResearcherName,
+    saveResearcherName,
+} from '../modules/state.js';
+
+describe('State Module', () => {
+    describe('state object', () => {
+        it('should have initial conversation state', () => {
+            expect(state.currentConversationId).toBe(null);
+            expect(Array.isArray(state.conversations)).toBe(true);
+        });
+
+        it('should have initial entity state', () => {
+            expect(state.selectedEntityId).toBe(null);
+            expect(Array.isArray(state.entities)).toBe(true);
+            expect(typeof state.entitySystemPrompts).toBe('object');
+        });
+
+        it('should have initial multi-entity state', () => {
+            expect(state.isMultiEntityMode).toBe(false);
+            expect(Array.isArray(state.currentConversationEntities)).toBe(true);
+            expect(state.pendingResponderId).toBe(null);
+        });
+
+        it('should have initial UI state', () => {
+            expect(state.isLoading).toBe(false);
+            expect(state.streamAbortController).toBe(null);
+        });
+
+        it('should have initial settings with defaults', () => {
+            expect(state.settings).toBeDefined();
+            expect(state.settings.model).toBe('claude-sonnet-4-5-20250929');
+            expect(state.settings.temperature).toBe(1.0);
+            expect(state.settings.maxTokens).toBe(4096);
+            expect(state.settings.systemPrompt).toBe(null);
+            expect(state.settings.conversationType).toBe('normal');
+        });
+
+        it('should have initial memory state', () => {
+            expect(Array.isArray(state.retrievedMemories)).toBe(true);
+            expect(typeof state.retrievedMemoriesByEntity).toBe('object');
+            expect(state.expandedMemoryIds).toBeInstanceOf(Set);
+        });
+
+        it('should have initial TTS state', () => {
+            expect(state.ttsEnabled).toBe(false);
+            expect(state.ttsProvider).toBe(null);
+            expect(Array.isArray(state.ttsVoices)).toBe(true);
+            expect(state.selectedVoiceId).toBe(null);
+            expect(state.audioCache).toBeInstanceOf(Map);
+        });
+
+        it('should have initial attachment state', () => {
+            expect(state.pendingAttachments).toBeDefined();
+            expect(Array.isArray(state.pendingAttachments.images)).toBe(true);
+            expect(Array.isArray(state.pendingAttachments.files)).toBe(true);
+        });
+
+        it('should track construction time', () => {
+            expect(typeof state.constructedAt).toBe('number');
+            expect(state.constructedAt).toBeLessThanOrEqual(Date.now());
+        });
+    });
+
+    describe('resetMemoryState', () => {
+        beforeEach(() => {
+            // Setup state with some data
+            state.retrievedMemories = [{ id: '1' }, { id: '2' }];
+            state.retrievedMemoriesByEntity = { entity1: [{ id: '1' }] };
+            state.expandedMemoryIds.add('1');
+            state.expandedMemoryIds.add('2');
+        });
+
+        it('should clear retrieved memories', () => {
+            resetMemoryState();
+            expect(state.retrievedMemories).toEqual([]);
+        });
+
+        it('should clear retrieved memories by entity', () => {
+            resetMemoryState();
+            expect(state.retrievedMemoriesByEntity).toEqual({});
+        });
+
+        it('should clear expanded memory IDs', () => {
+            resetMemoryState();
+            expect(state.expandedMemoryIds.size).toBe(0);
+        });
+    });
+
+    describe('resetAttachments', () => {
+        beforeEach(() => {
+            // Setup state with mock attachments
+            state.pendingAttachments = {
+                images: [
+                    { name: 'img1.png', previewUrl: 'blob:mock-url-1' },
+                    { name: 'img2.jpg', previewUrl: 'blob:mock-url-2' },
+                ],
+                files: [
+                    { name: 'doc.txt', content: 'content' },
+                ],
+            };
+        });
+
+        it('should revoke blob URLs for images', () => {
+            resetAttachments();
+            expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url-1');
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url-2');
+        });
+
+        it('should clear pending attachments', () => {
+            resetAttachments();
+            expect(state.pendingAttachments).toEqual({ images: [], files: [] });
+        });
+
+        it('should handle empty attachments gracefully', () => {
+            state.pendingAttachments = { images: [], files: [] };
+            expect(() => resetAttachments()).not.toThrow();
+            expect(state.pendingAttachments).toEqual({ images: [], files: [] });
+        });
+
+        it('should handle images without previewUrl', () => {
+            state.pendingAttachments = {
+                images: [{ name: 'img.png' }],
+                files: [],
+            };
+            expect(() => resetAttachments()).not.toThrow();
+        });
+    });
+
+    describe('clearAudioCache', () => {
+        beforeEach(() => {
+            // Setup audio cache with mock entries
+            state.audioCache.set('msg1', { url: 'blob:audio-url-1', blob: {} });
+            state.audioCache.set('msg2', { url: 'blob:audio-url-2', blob: {} });
+            state.audioCache.set('msg3', { data: 'no url' }); // Entry without URL
+        });
+
+        it('should revoke blob URLs for cached audio', () => {
+            clearAudioCache();
+            expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:audio-url-1');
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:audio-url-2');
+        });
+
+        it('should clear the audio cache', () => {
+            clearAudioCache();
+            expect(state.audioCache.size).toBe(0);
+        });
+
+        it('should handle empty cache gracefully', () => {
+            state.audioCache.clear();
+            expect(() => clearAudioCache()).not.toThrow();
+        });
+    });
+
+    describe('loadEntitySystemPromptsFromStorage', () => {
+        it('should load saved prompts from localStorage', () => {
+            const savedPrompts = { 'entity-1': 'prompt 1', 'entity-2': 'prompt 2' };
+            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
+
+            loadEntitySystemPromptsFromStorage();
+
+            expect(state.entitySystemPrompts).toEqual(savedPrompts);
+        });
+
+        it('should apply prompt for selected entity', () => {
+            const savedPrompts = { 'entity-1': 'entity 1 prompt' };
+            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
+            state.selectedEntityId = 'entity-1';
+
+            loadEntitySystemPromptsFromStorage();
+
+            expect(state.settings.systemPrompt).toBe('entity 1 prompt');
+        });
+
+        it('should not apply prompt for multi-entity mode', () => {
+            const savedPrompts = { 'multi-entity': 'multi prompt' };
+            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
+            state.selectedEntityId = 'multi-entity';
+            state.settings.systemPrompt = 'original';
+
+            loadEntitySystemPromptsFromStorage();
+
+            expect(state.settings.systemPrompt).toBe('original');
+        });
+
+        it('should handle missing localStorage gracefully', () => {
+            expect(() => loadEntitySystemPromptsFromStorage()).not.toThrow();
+        });
+
+        it('should handle invalid JSON gracefully', () => {
+            localStorage.setItem('entity_system_prompts', 'invalid json');
+            expect(() => loadEntitySystemPromptsFromStorage()).not.toThrow();
+        });
+    });
+
+    describe('saveEntitySystemPromptsToStorage', () => {
+        it('should save prompts to localStorage', () => {
+            state.entitySystemPrompts = { 'entity-1': 'prompt 1' };
+
+            saveEntitySystemPromptsToStorage();
+
+            expect(localStorage.setItem).toHaveBeenCalledWith(
+                'entity_system_prompts',
+                JSON.stringify({ 'entity-1': 'prompt 1' })
+            );
+        });
+
+        it('should handle empty prompts', () => {
+            state.entitySystemPrompts = {};
+
+            expect(() => saveEntitySystemPromptsToStorage()).not.toThrow();
+            expect(localStorage.setItem).toHaveBeenCalled();
+        });
+    });
+
+    describe('loadSelectedVoiceFromStorage', () => {
+        it('should load saved voice ID from localStorage', () => {
+            localStorage.setItem('selected_voice_id', 'voice-123');
+
+            loadSelectedVoiceFromStorage();
+
+            expect(state.selectedVoiceId).toBe('voice-123');
+        });
+
+        it('should handle missing localStorage gracefully', () => {
+            state.selectedVoiceId = null;
+            expect(() => loadSelectedVoiceFromStorage()).not.toThrow();
+            expect(state.selectedVoiceId).toBe(null);
+        });
+    });
+
+    describe('saveSelectedVoiceToStorage', () => {
+        it('should save voice ID to localStorage', () => {
+            state.selectedVoiceId = 'voice-456';
+
+            saveSelectedVoiceToStorage();
+
+            expect(localStorage.setItem).toHaveBeenCalledWith('selected_voice_id', 'voice-456');
+        });
+
+        it('should remove from localStorage when voice is null', () => {
+            state.selectedVoiceId = null;
+
+            saveSelectedVoiceToStorage();
+
+            expect(localStorage.removeItem).toHaveBeenCalledWith('selected_voice_id');
+        });
+    });
+
+    describe('loadResearcherName', () => {
+        it('should load and return saved researcher name', () => {
+            localStorage.setItem('researcher_name', 'Dr. Smith');
+
+            const result = loadResearcherName();
+
+            expect(result).toBe('Dr. Smith');
+            expect(state.settings.researcherName).toBe('Dr. Smith');
+        });
+
+        it('should return null when no name is saved', () => {
+            const result = loadResearcherName();
+
+            expect(result).toBe(null);
+        });
+    });
+
+    describe('saveResearcherName', () => {
+        it('should save researcher name to state and localStorage', () => {
+            saveResearcherName('Dr. Jones');
+
+            expect(state.settings.researcherName).toBe('Dr. Jones');
+            expect(localStorage.setItem).toHaveBeenCalledWith('researcher_name', 'Dr. Jones');
+        });
+
+        it('should use existing state value when name is undefined', () => {
+            state.settings.researcherName = 'Existing Name';
+
+            saveResearcherName(undefined);
+
+            expect(localStorage.setItem).toHaveBeenCalledWith('researcher_name', 'Existing Name');
+        });
+
+        it('should handle empty string', () => {
+            saveResearcherName('');
+
+            expect(state.settings.researcherName).toBe('');
+            expect(localStorage.setItem).toHaveBeenCalledWith('researcher_name', '');
+        });
+    });
+
+    describe('direct state mutation', () => {
+        it('should allow direct mutation of state properties', () => {
+            state.currentConversationId = 'new-conv-id';
+            expect(state.currentConversationId).toBe('new-conv-id');
+
+            state.isLoading = true;
+            expect(state.isLoading).toBe(true);
+
+            state.settings.temperature = 0.7;
+            expect(state.settings.temperature).toBe(0.7);
+        });
+
+        it('should allow mutation of nested objects', () => {
+            state.pendingAttachments.images.push({ name: 'test.png' });
+            expect(state.pendingAttachments.images.length).toBe(1);
+        });
+
+        it('should allow mutation of Set objects', () => {
+            state.expandedMemoryIds.add('memory-1');
+            expect(state.expandedMemoryIds.has('memory-1')).toBe(true);
+
+            state.expandedMemoryIds.delete('memory-1');
+            expect(state.expandedMemoryIds.has('memory-1')).toBe(false);
+        });
+
+        it('should allow mutation of Map objects', () => {
+            state.audioCache.set('key', { value: 'data' });
+            expect(state.audioCache.get('key')).toEqual({ value: 'data' });
+
+            state.audioCache.delete('key');
+            expect(state.audioCache.has('key')).toBe(false);
+        });
+    });
+});

--- a/frontend/js/__tests__/theme.test.js
+++ b/frontend/js/__tests__/theme.test.js
@@ -1,0 +1,154 @@
+/**
+ * Unit Tests for Theme Module
+ * Tests theme switching and persistence
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    loadTheme,
+    getCurrentTheme,
+    setTheme,
+} from '../modules/theme.js';
+
+describe('Theme Module', () => {
+    const THEME_KEY = 'here-i-am-theme';
+
+    beforeEach(() => {
+        // Clear theme classes from document root
+        document.documentElement.classList.remove('theme-light', 'theme-dark');
+    });
+
+    describe('getCurrentTheme', () => {
+        it('should return saved theme from localStorage', () => {
+            localStorage.setItem(THEME_KEY, 'dark');
+            expect(getCurrentTheme()).toBe('dark');
+        });
+
+        it('should return "system" when no theme is saved', () => {
+            expect(getCurrentTheme()).toBe('system');
+        });
+
+        it('should return light theme when saved', () => {
+            localStorage.setItem(THEME_KEY, 'light');
+            expect(getCurrentTheme()).toBe('light');
+        });
+    });
+
+    describe('loadTheme', () => {
+        it('should apply dark theme class when dark theme is saved', () => {
+            localStorage.setItem(THEME_KEY, 'dark');
+
+            loadTheme();
+
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+        });
+
+        it('should apply light theme class when light theme is saved', () => {
+            localStorage.setItem(THEME_KEY, 'light');
+
+            loadTheme();
+
+            expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+        });
+
+        it('should not apply any theme class when system theme is saved', () => {
+            localStorage.setItem(THEME_KEY, 'system');
+
+            loadTheme();
+
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+        });
+
+        it('should not apply any theme class when no theme is saved', () => {
+            loadTheme();
+
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+        });
+
+        it('should remove existing theme classes before applying new one', () => {
+            document.documentElement.classList.add('theme-light');
+            localStorage.setItem(THEME_KEY, 'dark');
+
+            loadTheme();
+
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+        });
+    });
+
+    describe('setTheme', () => {
+        describe('dark theme', () => {
+            it('should add theme-dark class', () => {
+                setTheme('dark');
+                expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+            });
+
+            it('should remove theme-light class', () => {
+                document.documentElement.classList.add('theme-light');
+                setTheme('dark');
+                expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            });
+
+            it('should save to localStorage', () => {
+                setTheme('dark');
+                expect(localStorage.getItem(THEME_KEY)).toBe('dark');
+            });
+        });
+
+        describe('light theme', () => {
+            it('should add theme-light class', () => {
+                setTheme('light');
+                expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+            });
+
+            it('should remove theme-dark class', () => {
+                document.documentElement.classList.add('theme-dark');
+                setTheme('light');
+                expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+            });
+
+            it('should save to localStorage', () => {
+                setTheme('light');
+                expect(localStorage.getItem(THEME_KEY)).toBe('light');
+            });
+        });
+
+        describe('system theme', () => {
+            it('should remove both theme classes', () => {
+                document.documentElement.classList.add('theme-dark');
+                setTheme('system');
+                expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+                expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            });
+
+            it('should save to localStorage', () => {
+                setTheme('system');
+                expect(localStorage.getItem(THEME_KEY)).toBe('system');
+            });
+        });
+
+        it('should handle unknown theme values as system theme', () => {
+            setTheme('unknown');
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            expect(localStorage.getItem(THEME_KEY)).toBe('system');
+        });
+
+        it('should handle theme switching correctly', () => {
+            setTheme('dark');
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+
+            setTheme('light');
+            expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+
+            setTheme('system');
+            expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+            expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+        });
+    });
+});

--- a/frontend/js/__tests__/utils.test.js
+++ b/frontend/js/__tests__/utils.test.js
@@ -1,0 +1,387 @@
+/**
+ * Unit Tests for Utils Module
+ * Tests utility functions used across the application
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    escapeHtml,
+    truncateText,
+    renderMarkdown,
+    stripMarkdown,
+    readFileAsText,
+    readFileAsBase64,
+    setToastContainer,
+    showToast,
+    showLoading,
+} from '../modules/utils.js';
+
+describe('Utils Module', () => {
+    describe('escapeHtml', () => {
+        it('should escape < and > characters', () => {
+            expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+                '&lt;script&gt;alert("xss")&lt;/script&gt;'
+            );
+        });
+
+        it('should escape & character', () => {
+            expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+        });
+
+        it('should escape " character', () => {
+            expect(escapeHtml('He said "hello"')).toBe('He said "hello"');
+        });
+
+        it('should handle empty string', () => {
+            expect(escapeHtml('')).toBe('');
+        });
+
+        it('should handle string with no special characters', () => {
+            expect(escapeHtml('Hello World')).toBe('Hello World');
+        });
+
+        it('should handle multiple special characters', () => {
+            expect(escapeHtml('<div class="test">&nbsp;</div>')).toBe(
+                '&lt;div class="test"&gt;&amp;nbsp;&lt;/div&gt;'
+            );
+        });
+    });
+
+    describe('truncateText', () => {
+        it('should truncate text longer than maxLength', () => {
+            expect(truncateText('Hello World!', 5)).toBe('Hello...');
+        });
+
+        it('should not truncate text shorter than maxLength', () => {
+            expect(truncateText('Hello', 10)).toBe('Hello');
+        });
+
+        it('should not truncate text equal to maxLength', () => {
+            expect(truncateText('Hello', 5)).toBe('Hello');
+        });
+
+        it('should handle null input', () => {
+            expect(truncateText(null, 10)).toBe(null);
+        });
+
+        it('should handle undefined input', () => {
+            expect(truncateText(undefined, 10)).toBe(undefined);
+        });
+
+        it('should handle empty string', () => {
+            expect(truncateText('', 10)).toBe('');
+        });
+
+        it('should truncate at specified boundary', () => {
+            expect(truncateText('abcdefghij', 7)).toBe('abcdefg...');
+        });
+    });
+
+    describe('renderMarkdown', () => {
+        it('should handle empty input', () => {
+            expect(renderMarkdown('')).toBe('');
+            expect(renderMarkdown(null)).toBe('');
+            expect(renderMarkdown(undefined)).toBe('');
+        });
+
+        describe('code blocks', () => {
+            it('should render fenced code blocks with language', () => {
+                const input = '```javascript\nconst x = 1;\n```';
+                const result = renderMarkdown(input);
+                expect(result).toContain('<pre class="md-code-block"');
+                expect(result).toContain('data-language="javascript"');
+                expect(result).toContain('const x = 1;');
+            });
+
+            it('should render fenced code blocks without language', () => {
+                const input = '```\nsome code\n```';
+                const result = renderMarkdown(input);
+                expect(result).toContain('<pre class="md-code-block"');
+                expect(result).toContain('some code');
+            });
+
+            it('should render inline code', () => {
+                const result = renderMarkdown('Use `const` for constants');
+                expect(result).toContain('<code class="md-inline-code">const</code>');
+            });
+        });
+
+        describe('emphasis', () => {
+            it('should render bold with double asterisks', () => {
+                const result = renderMarkdown('This is **bold** text');
+                expect(result).toContain('<strong>bold</strong>');
+            });
+
+            it('should render bold with double underscores', () => {
+                const result = renderMarkdown('This is __bold__ text');
+                expect(result).toContain('<strong>bold</strong>');
+            });
+
+            it('should render italic with single asterisks', () => {
+                const result = renderMarkdown('This is *italic* text');
+                expect(result).toContain('<em>italic</em>');
+            });
+
+            it('should render italic with underscores at word boundaries', () => {
+                const result = renderMarkdown('This is _italic_ text');
+                expect(result).toContain('<em>italic</em>');
+            });
+        });
+
+        describe('links', () => {
+            it('should render links', () => {
+                const result = renderMarkdown('[Click here](https://example.com)');
+                expect(result).toContain('<a href="https://example.com"');
+                expect(result).toContain('target="_blank"');
+                expect(result).toContain('rel="noopener noreferrer"');
+                expect(result).toContain('>Click here</a>');
+            });
+        });
+
+        describe('headers', () => {
+            it('should render h2 headers', () => {
+                const result = renderMarkdown('# Heading 1');
+                expect(result).toContain('<h2 class="md-header">Heading 1</h2>');
+            });
+
+            it('should render h3 headers', () => {
+                const result = renderMarkdown('## Heading 2');
+                expect(result).toContain('<h3 class="md-header">Heading 2</h3>');
+            });
+
+            it('should render h4 headers', () => {
+                const result = renderMarkdown('### Heading 3');
+                expect(result).toContain('<h4 class="md-header">Heading 3</h4>');
+            });
+        });
+
+        describe('lists', () => {
+            it('should render unordered lists', () => {
+                const result = renderMarkdown('- Item 1\n- Item 2');
+                expect(result).toContain('<ul class="md-list">');
+                expect(result).toContain('<li class="md-list-item">Item 1</li>');
+                expect(result).toContain('<li class="md-list-item">Item 2</li>');
+            });
+
+            it('should render ordered lists', () => {
+                const result = renderMarkdown('1. First\n2. Second');
+                expect(result).toContain('<ol class="md-list">');
+                expect(result).toContain('<li class="md-list-item-ordered">First</li>');
+                expect(result).toContain('<li class="md-list-item-ordered">Second</li>');
+            });
+        });
+
+        describe('blockquotes', () => {
+            it('should render blockquotes', () => {
+                const result = renderMarkdown('> This is a quote');
+                expect(result).toContain('<blockquote class="md-blockquote">This is a quote</blockquote>');
+            });
+        });
+
+        describe('horizontal rules', () => {
+            it('should render horizontal rules with dashes', () => {
+                const result = renderMarkdown('---');
+                expect(result).toContain('<hr class="md-hr">');
+            });
+
+            it('should render horizontal rules with asterisks', () => {
+                const result = renderMarkdown('***');
+                expect(result).toContain('<hr class="md-hr">');
+            });
+        });
+
+        describe('XSS prevention', () => {
+            it('should escape HTML in input', () => {
+                const result = renderMarkdown('<script>alert("xss")</script>');
+                expect(result).not.toContain('<script>');
+                expect(result).toContain('&lt;script&gt;');
+            });
+        });
+    });
+
+    describe('stripMarkdown', () => {
+        it('should handle empty input', () => {
+            expect(stripMarkdown('')).toBe('');
+            expect(stripMarkdown(null)).toBe('');
+            expect(stripMarkdown(undefined)).toBe('');
+        });
+
+        it('should remove code blocks', () => {
+            const input = 'Before ```code block``` After';
+            expect(stripMarkdown(input)).toBe('Before  After');
+        });
+
+        it('should remove inline code', () => {
+            const result = stripMarkdown('Use `const` for constants');
+            expect(result).toBe('Use  for constants');
+        });
+
+        it('should remove headers', () => {
+            const result = stripMarkdown('# Heading\nParagraph');
+            expect(result).toBe('Heading\nParagraph');
+        });
+
+        it('should remove bold formatting but keep text', () => {
+            const result = stripMarkdown('This is **bold** text');
+            expect(result).toBe('This is bold text');
+        });
+
+        it('should remove italic formatting but keep text', () => {
+            const result = stripMarkdown('This is *italic* text');
+            expect(result).toBe('This is italic text');
+        });
+
+        it('should remove links but keep text', () => {
+            const result = stripMarkdown('[Click here](https://example.com)');
+            expect(result).toBe('Click here');
+        });
+
+        it('should remove blockquote markers', () => {
+            const result = stripMarkdown('> This is a quote');
+            expect(result).toBe('This is a quote');
+        });
+
+        it('should remove list markers', () => {
+            const result = stripMarkdown('- Item 1\n- Item 2');
+            expect(result).toBe('Item 1\nItem 2');
+        });
+
+        it('should remove ordered list markers', () => {
+            const result = stripMarkdown('1. First\n2. Second');
+            expect(result).toBe('First\nSecond');
+        });
+
+        it('should remove horizontal rules', () => {
+            const result = stripMarkdown('Before\n---\nAfter');
+            expect(result).toBe('Before\n\nAfter');
+        });
+
+        it('should clean up extra whitespace', () => {
+            const result = stripMarkdown('Line 1\n\n\n\nLine 2');
+            expect(result).toBe('Line 1\n\nLine 2');
+        });
+    });
+
+    describe('readFileAsText', () => {
+        it('should read file content as text', async () => {
+            const mockFile = new File(['test content'], 'test.txt', { type: 'text/plain' });
+            mockFile._mockContent = 'test content';
+
+            const result = await readFileAsText(mockFile);
+            expect(result).toBe('test content');
+        });
+
+        it('should reject on read error', async () => {
+            const mockFile = new File([''], 'test.txt');
+            mockFile._mockError = true;
+
+            await expect(readFileAsText(mockFile)).rejects.toThrow('Failed to read file');
+        });
+    });
+
+    describe('readFileAsBase64', () => {
+        it('should read file content as base64', async () => {
+            const mockFile = new File(['test'], 'test.png', { type: 'image/png' });
+            mockFile._mockBase64 = 'dGVzdA==';
+
+            const result = await readFileAsBase64(mockFile);
+            expect(result).toBe('dGVzdA==');
+        });
+
+        it('should reject on read error', async () => {
+            const mockFile = new File([''], 'test.png');
+            mockFile._mockError = true;
+
+            await expect(readFileAsBase64(mockFile)).rejects.toThrow('Failed to read file');
+        });
+    });
+
+    describe('showToast', () => {
+        let toastContainer;
+
+        beforeEach(() => {
+            toastContainer = document.createElement('div');
+            toastContainer.id = 'toast-container';
+            document.body.appendChild(toastContainer);
+            setToastContainer(toastContainer);
+        });
+
+        it('should create and append toast element', () => {
+            showToast('Test message', 'info');
+
+            const toast = toastContainer.querySelector('.toast');
+            expect(toast).toBeTruthy();
+            expect(toast.textContent).toBe('Test message');
+            expect(toast.classList.contains('info')).toBe(true);
+        });
+
+        it('should support different toast types', () => {
+            showToast('Success', 'success');
+            const successToast = toastContainer.querySelector('.toast.success');
+            expect(successToast).toBeTruthy();
+
+            showToast('Warning', 'warning');
+            const warningToast = toastContainer.querySelector('.toast.warning');
+            expect(warningToast).toBeTruthy();
+
+            showToast('Error', 'error');
+            const errorToast = toastContainer.querySelector('.toast.error');
+            expect(errorToast).toBeTruthy();
+        });
+
+        it('should default to info type', () => {
+            showToast('Default type');
+
+            const toast = toastContainer.querySelector('.toast.info');
+            expect(toast).toBeTruthy();
+        });
+
+        it('should auto-remove toast after timeout', async () => {
+            vi.useFakeTimers();
+
+            showToast('Temporary message');
+            expect(toastContainer.querySelector('.toast')).toBeTruthy();
+
+            vi.advanceTimersByTime(3000);
+
+            expect(toastContainer.querySelector('.toast')).toBeFalsy();
+
+            vi.useRealTimers();
+        });
+
+        it('should handle missing container gracefully', () => {
+            setToastContainer(null);
+            document.body.innerHTML = '';
+
+            expect(() => showToast('Test')).not.toThrow();
+        });
+    });
+
+    describe('showLoading', () => {
+        let overlay;
+
+        beforeEach(() => {
+            overlay = document.createElement('div');
+            overlay.id = 'loading-overlay';
+        });
+
+        it('should add active class when show is true', () => {
+            showLoading(overlay, true);
+            expect(overlay.classList.contains('active')).toBe(true);
+        });
+
+        it('should remove active class when show is false', () => {
+            overlay.classList.add('active');
+            showLoading(overlay, false);
+            expect(overlay.classList.contains('active')).toBe(false);
+        });
+
+        it('should handle toggling', () => {
+            showLoading(overlay, true);
+            expect(overlay.classList.contains('active')).toBe(true);
+
+            showLoading(overlay, false);
+            expect(overlay.classList.contains('active')).toBe(false);
+        });
+    });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "here-i-am-frontend",
+  "version": "1.0.0",
+  "description": "Frontend for Here I Am - Experiential Interpretability Research Application",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0",
+    "@vitest/ui": "^2.1.0",
+    "@vitest/coverage-v8": "^2.1.0",
+    "jsdom": "^25.0.0"
+  },
+  "keywords": [
+    "ai",
+    "research",
+    "interpretability"
+  ],
+  "private": true
+}

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        // Use jsdom environment for DOM testing
+        environment: 'jsdom',
+
+        // Enable global test APIs (describe, it, expect, etc.)
+        globals: true,
+
+        // Setup file for mocks and globals
+        setupFiles: ['./js/__tests__/setup.js'],
+
+        // Test file patterns
+        include: ['./js/__tests__/**/*.test.js'],
+
+        // Coverage configuration
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'html', 'json'],
+            include: ['js/modules/**/*.js'],
+            exclude: ['js/__tests__/**', 'js/app.js'],
+        },
+
+        // Timeout for tests (in ms)
+        testTimeout: 10000,
+
+        // Report slow tests
+        slowTestThreshold: 300,
+    },
+});


### PR DESCRIPTION
Set up Vitest testing infrastructure with jsdom environment and create 236 unit tests covering:
- state.js: State management, localStorage persistence, reset functions
- utils.js: HTML escaping, markdown rendering, text utilities, toast system
- theme.js: Theme switching and localStorage persistence
- modals.js: Modal show/hide/close functionality
- attachments.js: File processing, validation, preview generation
- messages.js: Message rendering, streaming, tool display, action buttons

Test coverage:
- utils.js: 100%
- theme.js: 100%
- modals.js: 100%
- state.js: 96.92%
- messages.js: 95.6%
- attachments.js: 88.92%

Includes:
- package.json with Vitest, jsdom, and coverage dependencies
- vitest.config.js with jsdom environment configuration
- setup.js with mocks for localStorage, URL APIs, FileReader, and clipboard
- .gitignore updates for node_modules and coverage reports