### PR TITLE
Run unit tests from previous session

### DIFF
--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -609,7 +609,7 @@ class TestCacheBreakpointPlacement:
         first_context_content1 = messages1[0]["content"]
         first_context_content2 = messages2[0]["content"]
 
-        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN]" in first_context_content1
+        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN. DO NOT WRITE FOR OTHER PARTICIPANTS. DO NOT LABEL YOUR MESSAGES WITH YOUR NAME.]" in first_context_content1
         assert first_context_content1 == first_context_content2
 
     def test_multi_entity_header_consistent_across_entities(self):
@@ -657,8 +657,8 @@ class TestCacheBreakpointPlacement:
         first_content_claude = messages_claude[0]["content"]
         first_content_gpt = messages_gpt[0]["content"]
 
-        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN]" in first_content_claude
-        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN]" in first_content_gpt
+        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN. DO NOT WRITE FOR OTHER PARTICIPANTS. DO NOT LABEL YOUR MESSAGES WITH YOUR NAME.]" in first_content_claude
+        assert "[THIS IS A CONVERSATION BETWEEN MULTIPLE AI AND ONE HUMAN. DO NOT WRITE FOR OTHER PARTICIPANTS. DO NOT LABEL YOUR MESSAGES WITH YOUR NAME.]" in first_content_gpt
         # The header is now the same regardless of responding entity (simplified for cache stability)
         assert first_content_claude == first_content_gpt
 

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -491,6 +491,7 @@ class TestSessionManager:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
@@ -537,6 +538,7 @@ class TestSessionManager:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
@@ -804,6 +806,7 @@ class TestMultiEntityMemoryIsolation:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
+            mock_settings.use_memory_in_context = False
             mock_settings.get_entity_by_index.return_value = MagicMock(
                 label="Claude",
                 default_model="claude-sonnet-4-5-20250929",
@@ -840,6 +843,7 @@ class TestMultiEntityMemoryIsolation:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
@@ -889,7 +893,7 @@ class TestMultiEntityMemoryIsolation:
         assert session.responding_entity_label == "Claude"
 
     def test_multi_entity_add_exchange_labels_messages(self):
-        """Test that add_exchange labels messages in multi-entity conversations."""
+        """Test that add_exchange labels assistant messages in multi-entity conversations."""
         session = ConversationSession(
             conversation_id="conv-123",
             is_multi_entity=True,
@@ -899,8 +903,8 @@ class TestMultiEntityMemoryIsolation:
         session.add_exchange("Hello!", "Hi there!")
 
         assert len(session.conversation_context) == 2
-        # Human messages should be labeled
-        assert session.conversation_context[0]["content"] == "[Human]: Hello!"
+        # Human messages are NOT labeled (only one human in conversation)
+        assert session.conversation_context[0]["content"] == "Hello!"
         # Assistant messages should be labeled with responding entity
         assert session.conversation_context[1]["content"] == "[Claude]: Hi there!"
 
@@ -1102,6 +1106,7 @@ class TestCacheStateManagement:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             # Load without preserving - should use full context length
             session1 = await manager.load_session_from_db(
@@ -1137,6 +1142,7 @@ class TestCacheStateManagement:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             # Load with preserved value larger than actual context
             session = await manager.load_session_from_db(
@@ -1251,6 +1257,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1284,6 +1291,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1317,6 +1325,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1367,6 +1376,7 @@ class TestSystemPromptSelection:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
+            mock_settings.use_memory_in_context = False
             mock_entity = MagicMock()
             mock_entity.label = "Claude"
             mock_entity.default_model = "claude-sonnet-4-5-20250929"
@@ -1428,6 +1438,7 @@ class TestSystemPromptSelection:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
+            mock_settings.use_memory_in_context = False
 
             # Mock entity configs
             def get_entity(eid):
@@ -1511,6 +1522,7 @@ class TestSystemPromptSelection:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
+            mock_settings.use_memory_in_context = False
             mock_entity = MagicMock()
             mock_entity.label = "GPT"
             mock_entity.default_model = "gpt-4o"
@@ -1555,6 +1567,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1587,6 +1600,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1618,6 +1632,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1651,6 +1666,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1683,6 +1699,7 @@ class TestSystemPromptSelection:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
+            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 

--- a/frontend/js/__tests__/entities.test.js
+++ b/frontend/js/__tests__/entities.test.js
@@ -9,9 +9,8 @@ import {
     setElements,
     setCallbacks,
     loadEntities,
-    getSelectedEntity,
-    selectEntity,
-    isMultiEntityConversation,
+    handleEntityChange,
+    getEntityLabel,
 } from '../modules/entities.js';
 
 describe('Entities Module', () => {
@@ -108,33 +107,31 @@ describe('Entities Module', () => {
         });
     });
 
-    describe('getSelectedEntity', () => {
-        it('should return null when no entity selected', () => {
-            state.selectedEntityId = null;
+    describe('getEntityLabel', () => {
+        it('should return empty string when entity not found', () => {
             state.entities = [];
 
-            const result = getSelectedEntity();
+            const result = getEntityLabel('nonexistent');
 
-            expect(result).toBeNull();
+            expect(result).toBe('');
         });
 
-        it('should return entity object when selected', () => {
+        it('should return entity label when found', () => {
             state.entities = [
                 { id: 'entity-1', label: 'Claude' },
             ];
-            state.selectedEntityId = 'entity-1';
 
-            const result = getSelectedEntity();
+            const result = getEntityLabel('entity-1');
 
-            expect(result).toEqual({ id: 'entity-1', label: 'Claude' });
+            expect(result).toBe('Claude');
         });
     });
 
-    describe('selectEntity', () => {
+    describe('handleEntityChange', () => {
         it('should update selectedEntityId in state', () => {
             state.entities = [{ id: 'entity-1', label: 'Claude' }];
 
-            selectEntity('entity-1');
+            handleEntityChange('entity-1');
 
             expect(state.selectedEntityId).toBe('entity-1');
         });
@@ -142,23 +139,21 @@ describe('Entities Module', () => {
         it('should call onEntityChanged callback', () => {
             state.entities = [{ id: 'entity-1', label: 'Claude' }];
 
-            selectEntity('entity-1');
+            handleEntityChange('entity-1');
 
             expect(mockCallbacks.onEntityChanged).toHaveBeenCalled();
         });
     });
 
-    describe('isMultiEntityConversation', () => {
-        it('should return false for normal conversations', () => {
-            state.isMultiEntityMode = false;
-
-            expect(isMultiEntityConversation()).toBe(false);
+    describe('state.isMultiEntityMode', () => {
+        it('should be false by default', () => {
+            expect(state.isMultiEntityMode).toBe(false);
         });
 
-        it('should return true when in multi-entity mode', () => {
+        it('can be set to true for multi-entity mode', () => {
             state.isMultiEntityMode = true;
 
-            expect(isMultiEntityConversation()).toBe(true);
+            expect(state.isMultiEntityMode).toBe(true);
         });
     });
 });


### PR DESCRIPTION
…s, and voice tests

Backend fixes:
- Add use_memory_in_context=False mock setting to all session manager tests that call load_session_from_db
- Update multi-entity header assertion to match new format with instructions
- Fix test_multi_entity_add_exchange_labels_messages to match actual behavior (human messages not labeled)

Frontend fixes:
- Update entities.test.js to use actual exported functions (handleEntityChange, getEntityLabel instead of non-existent functions)
- Fix voice.test.js stopSpeaking tests to use correct state property (currentAudio not _currentAudio)
- Fix voice.test.js checkSTTStatus tests to check dictationMode instead of sttEnabled
- Fix voice.test.js speakMessage tests with correct parameter order and mock button

Test results improved:
- Backend: 76 -> 56 failures (20 fixed)
- Frontend: 46 -> 37 failures (9 fixed)