### PR TITLE
Review and refactor outdated unit tests

### DIFF
--- a/backend/tests/test_codebase_navigator.py
+++ b/backend/tests/test_codebase_navigator.py
@@ -312,7 +312,8 @@ class TestNavigatorClient:
         """Test client raises error without API key."""
         client = NavigatorClient(api_key=None)
 
-        with patch("app.services.codebase_navigator.client.settings") as mock_settings:
+        # Patch app.config.settings since it's imported lazily inside the api_key property
+        with patch("app.config.settings") as mock_settings:
             mock_settings.mistral_api_key = ""
 
             with pytest.raises(NavigatorNotConfiguredError):
@@ -574,7 +575,8 @@ class TestNavigatorTools:
     @pytest.mark.asyncio
     async def test_navigate_codebase_not_configured(self):
         """Test navigate_codebase returns error when not configured."""
-        with patch("app.services.codebase_navigator_tools.codebase_navigator_service") as mock_service:
+        # Patch the service where it's imported from (inside the function)
+        with patch("app.services.codebase_navigator_service.codebase_navigator_service") as mock_service:
             mock_service.is_configured.return_value = False
 
             result = await navigate_codebase("Test task")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -84,8 +84,8 @@ class TestSettings:
         assert settings.default_openai_model == "gpt-5.1"
         assert settings.default_temperature == 1.0
         assert settings.default_max_tokens == 64000
-        assert settings.retrieval_top_k == 5
-        assert settings.similarity_threshold == 0.3
+        assert settings.retrieval_top_k == 3  # Updated to match current default
+        assert settings.similarity_threshold == 0.4  # Updated: tuned for llama-text-embed-v2
 
     def test_settings_custom_values(self, test_settings):
         """Test Settings with custom values."""


### PR DESCRIPTION
- test_attachment_service.py: Fixed module pollution where sys.modules['app.config'] was patched at module level and never restored, causing other test files to get MagicMock objects instead of real Settings/EntityConfig. Now saves and restores the original module immediately after loading the attachment_service module.

- test_config.py: Updated outdated default value assertions (retrieval_top_k: 5->3,
  similarity_threshold: 0.3->0.4) to match current settings in config.py.

- test_codebase_navigator.py: Fixed incorrect patch paths for lazily-imported modules. Changed 'app.services.codebase_navigator.client.settings' to 'app.config.settings' and 'app.services.codebase_navigator_tools.codebase_navigator_service' to 'app.services.codebase_navigator_service.codebase_navigator_service'.

All 550 tests now pass.