### PR TITLE
Fix dictation recording button issues

### DIFF
--- a/backend/app/services/whisper_service.py
+++ b/backend/app/services/whisper_service.py
@@ -122,12 +122,14 @@ class WhisperService:
         dictation_mode = self.dictation_mode
         
         if not self.enabled:
+            effective_mode = "browser" if dictation_mode != "whisper" else "none"
             return {
+                "enabled": effective_mode != "none",
                 "configured": False,
                 "provider": "none",
                 "server_healthy": False,
                 "dictation_mode": dictation_mode,
-                "effective_mode": "browser" if dictation_mode != "whisper" else "none",
+                "effective_mode": effective_mode,
             }
 
         try:
@@ -146,6 +148,7 @@ class WhisperService:
                         effective_mode = "whisper" if server_healthy else "browser"
                     
                     return {
+                        "enabled": effective_mode != "none",
                         "configured": True,
                         "provider": "whisper",
                         "server_healthy": server_healthy,
@@ -165,8 +168,9 @@ class WhisperService:
             effective_mode = "browser"
         else:  # auto
             effective_mode = "browser"
-            
+
         return {
+            "enabled": effective_mode != "none",
             "configured": True,
             "provider": "whisper",
             "server_healthy": False,


### PR DESCRIPTION
…tatus response

The frontend checkSTTStatus() function was checking for status.enabled, but the backend was only returning status.configured. This caused the dictation button to not appear because status.enabled was always undefined (falsy).

Added the 'enabled' field to all return paths in whisper_service.get_status(). The field is True when effective_mode != 'none', indicating dictation is actually available (either via Whisper or browser Web Speech API).