### PR TITLE
Add unit tests for Svelte 5 Vite frontend

### DIFF
--- a/frontend-svelte/package.json
+++ b/frontend-svelte/package.json
@@ -6,11 +6,19 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/svelte": "^5.2.6",
+    "jsdom": "^26.0.0",
     "svelte": "^5.43.8",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^3.0.0"
   }
 }

--- a/frontend-svelte/src/components/common/Button.test.js
+++ b/frontend-svelte/src/components/common/Button.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for Button component
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Button from './Button.svelte';
+
+describe('Button', () => {
+  it('should render with default props', () => {
+    render(Button);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('should apply primary variant class by default', () => {
+    render(Button);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('primary-btn');
+  });
+
+  it('should apply secondary variant class', () => {
+    render(Button, { props: { variant: 'secondary' } });
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('secondary-btn');
+  });
+
+  it('should apply danger variant class', () => {
+    render(Button, { props: { variant: 'danger' } });
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('danger-btn');
+  });
+
+  it('should apply small size class', () => {
+    render(Button, { props: { size: 'small' } });
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('small');
+  });
+
+  it('should not apply small class for normal size', () => {
+    render(Button, { props: { size: 'normal' } });
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveClass('small');
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    render(Button, { props: { disabled: true } });
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('should set button type', () => {
+    render(Button, { props: { type: 'submit' } });
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('type', 'submit');
+  });
+
+  it('should emit click event', async () => {
+    const handleClick = vi.fn();
+    // In Svelte 5, use the events option instead of $on
+    render(Button, {
+      props: {},
+      events: { click: handleClick },
+    });
+
+    const button = screen.getByRole('button');
+    await fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have disabled attribute when disabled', () => {
+    render(Button, { props: { disabled: true } });
+    const button = screen.getByRole('button');
+
+    // Verify the button has the disabled attribute
+    expect(button).toHaveAttribute('disabled');
+  });
+});

--- a/frontend-svelte/src/components/common/Modal.test.js
+++ b/frontend-svelte/src/components/common/Modal.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for Modal component
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import Modal from './Modal.svelte';
+
+describe('Modal', () => {
+  afterEach(() => {
+    cleanup();
+    // Reset body overflow style
+    document.body.style.overflow = '';
+  });
+
+  it('should render with default props', () => {
+    render(Modal);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('should render title when provided', () => {
+    render(Modal, { props: { title: 'Test Modal' } });
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Test Modal' })).toBeInTheDocument();
+  });
+
+  it('should render close button by default', () => {
+    render(Modal, { props: { title: 'Test' } });
+    expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
+  });
+
+  it('should hide close button when showClose is false', () => {
+    render(Modal, { props: { title: 'Test', showClose: false } });
+    expect(screen.queryByLabelText('Close modal')).not.toBeInTheDocument();
+  });
+
+  it('should apply size classes', () => {
+    const { container, rerender } = render(Modal, { props: { size: 'small' } });
+    expect(container.querySelector('.small')).toBeInTheDocument();
+
+    rerender({ size: 'medium' });
+    expect(container.querySelector('.medium')).toBeInTheDocument();
+
+    rerender({ size: 'large' });
+    expect(container.querySelector('.large')).toBeInTheDocument();
+
+    rerender({ size: 'xlarge' });
+    expect(container.querySelector('.xlarge')).toBeInTheDocument();
+  });
+
+  it('should dispatch close event when close button clicked', async () => {
+    const handleClose = vi.fn();
+    // In Svelte 5, use events option
+    render(Modal, {
+      props: { title: 'Test' },
+      events: { close: handleClose },
+    });
+
+    const closeBtn = screen.getByLabelText('Close modal');
+    await fireEvent.click(closeBtn);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dispatch close event when backdrop clicked', async () => {
+    const handleClose = vi.fn();
+    render(Modal, {
+      props: {},
+      events: { close: handleClose },
+    });
+
+    const backdrop = screen.getByRole('dialog');
+    await fireEvent.click(backdrop);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close when clicking inside modal container', async () => {
+    const handleClose = vi.fn();
+    const { container } = render(Modal, {
+      props: { title: 'Test' },
+      events: { close: handleClose },
+    });
+
+    const modalContainer = container.querySelector('.modal-container');
+    await fireEvent.click(modalContainer);
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('should dispatch close event on Escape key', async () => {
+    const handleClose = vi.fn();
+    render(Modal, {
+      props: {},
+      events: { close: handleClose },
+    });
+
+    await fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close on other key presses', async () => {
+    const handleClose = vi.fn();
+    render(Modal, {
+      props: {},
+      events: { close: handleClose },
+    });
+
+    await fireEvent.keyDown(document, { key: 'Enter' });
+    await fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('should set body overflow to hidden on mount', () => {
+    render(Modal);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('should reset body overflow on unmount', () => {
+    const { unmount } = render(Modal);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('should have proper aria attributes', () => {
+    render(Modal, { props: { title: 'Accessible Modal' } });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title');
+  });
+});

--- a/frontend-svelte/src/components/common/Toast.test.js
+++ b/frontend-svelte/src/components/common/Toast.test.js
@@ -1,0 +1,78 @@
+/**
+ * Tests for Toast component
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { toasts } from '../../lib/stores/app.js';
+import Toast from './Toast.svelte';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    toasts.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    toasts.clear();
+  });
+
+  it('should render toast container', () => {
+    const { container } = render(Toast);
+    expect(container.querySelector('.toast-container')).toBeInTheDocument();
+  });
+
+  it('should render nothing when no toasts', () => {
+    const { container } = render(Toast);
+    expect(container.querySelectorAll('.toast')).toHaveLength(0);
+  });
+
+  it('should render toast when added to store', async () => {
+    render(Toast);
+    toasts.add('Test message', 'info', 0);
+
+    // Wait for Svelte to update
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('should apply success type class', async () => {
+    const { container } = render(Toast);
+    toasts.add('Success message', 'success', 0);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(container.querySelector('.toast.success')).toBeInTheDocument();
+  });
+
+  it('should apply error type class', async () => {
+    const { container } = render(Toast);
+    toasts.add('Error message', 'error', 0);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(container.querySelector('.toast.error')).toBeInTheDocument();
+  });
+
+  it('should apply warning type class', async () => {
+    const { container } = render(Toast);
+    toasts.add('Warning message', 'warning', 0);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(container.querySelector('.toast.warning')).toBeInTheDocument();
+  });
+
+  it('should apply info type class', async () => {
+    const { container } = render(Toast);
+    toasts.add('Info message', 'info', 0);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(container.querySelector('.toast.info')).toBeInTheDocument();
+  });
+
+  it('should remove toast when removed from store', async () => {
+    render(Toast);
+
+    const id = toasts.add('Test message', 'info', 0);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+
+    toasts.remove(id);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+});

--- a/frontend-svelte/src/lib/stores/app.test.js
+++ b/frontend-svelte/src/lib/stores/app.test.js
@@ -1,0 +1,218 @@
+/**
+ * Tests for app store
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  theme,
+  isLoading,
+  activeModal,
+  toasts,
+  showToast,
+  streamAbortController,
+  createAbortController,
+  abortStream,
+  availableModels,
+  githubRepos,
+  githubRateLimits,
+} from './app.js';
+
+describe('theme store', () => {
+  beforeEach(() => {
+    localStorage.getItem.mockReturnValue(null);
+  });
+
+  it('should have initial value of "system" when localStorage is empty', () => {
+    // Re-import to get fresh store with mocked localStorage
+    localStorage.getItem.mockReturnValue(null);
+    expect(get(theme)).toBeDefined();
+  });
+
+  it('should toggle between dark and light', () => {
+    theme.set('dark');
+    theme.toggle();
+    expect(get(theme)).toBe('light');
+    theme.toggle();
+    expect(get(theme)).toBe('dark');
+  });
+
+  it('should persist to localStorage', () => {
+    theme.set('dark');
+    expect(localStorage.setItem).toHaveBeenCalledWith('theme', 'dark');
+  });
+});
+
+describe('isLoading store', () => {
+  it('should default to false', () => {
+    expect(get(isLoading)).toBe(false);
+  });
+
+  it('should be settable', () => {
+    isLoading.set(true);
+    expect(get(isLoading)).toBe(true);
+    isLoading.set(false);
+    expect(get(isLoading)).toBe(false);
+  });
+});
+
+describe('activeModal store', () => {
+  it('should default to null', () => {
+    expect(get(activeModal)).toBe(null);
+  });
+
+  it('should be settable', () => {
+    activeModal.set('settings');
+    expect(get(activeModal)).toBe('settings');
+    activeModal.set(null);
+    expect(get(activeModal)).toBe(null);
+  });
+});
+
+describe('toasts store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    toasts.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start empty', () => {
+    expect(get(toasts)).toEqual([]);
+  });
+
+  it('should add a toast', () => {
+    toasts.add('Test message', 'info', 0);
+    const currentToasts = get(toasts);
+    expect(currentToasts).toHaveLength(1);
+    expect(currentToasts[0].message).toBe('Test message');
+    expect(currentToasts[0].type).toBe('info');
+  });
+
+  it('should auto-remove toast after duration', () => {
+    toasts.add('Test message', 'info', 1000);
+    expect(get(toasts)).toHaveLength(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(get(toasts)).toHaveLength(0);
+  });
+
+  it('should not auto-remove if duration is 0', () => {
+    toasts.add('Test message', 'info', 0);
+    vi.advanceTimersByTime(5000);
+    expect(get(toasts)).toHaveLength(1);
+  });
+
+  it('should remove specific toast by id', () => {
+    const id = toasts.add('Test message', 'info', 0);
+    expect(get(toasts)).toHaveLength(1);
+
+    toasts.remove(id);
+    expect(get(toasts)).toHaveLength(0);
+  });
+
+  it('should clear all toasts', () => {
+    toasts.add('Message 1', 'info', 0);
+    toasts.add('Message 2', 'error', 0);
+    expect(get(toasts)).toHaveLength(2);
+
+    toasts.clear();
+    expect(get(toasts)).toHaveLength(0);
+  });
+});
+
+describe('showToast helper', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    toasts.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should add a toast with default type', () => {
+    showToast('Test message');
+    const currentToasts = get(toasts);
+    expect(currentToasts).toHaveLength(1);
+    expect(currentToasts[0].type).toBe('info');
+  });
+
+  it('should add a toast with custom type', () => {
+    showToast('Error message', 'error');
+    const currentToasts = get(toasts);
+    expect(currentToasts[0].type).toBe('error');
+  });
+
+  it('should return the toast id', () => {
+    const id = showToast('Test');
+    expect(typeof id).toBe('number');
+  });
+});
+
+describe('streamAbortController', () => {
+  it('should default to null', () => {
+    streamAbortController.set(null);
+    expect(get(streamAbortController)).toBe(null);
+  });
+
+  it('should create new abort controller', () => {
+    const controller = createAbortController();
+    expect(controller).toBeInstanceOf(AbortController);
+    expect(get(streamAbortController)).toBe(controller);
+  });
+
+  it('should abort stream and reset controller', () => {
+    const controller = createAbortController();
+    expect(controller.signal.aborted).toBe(false);
+
+    abortStream();
+    expect(controller.signal.aborted).toBe(true);
+    expect(get(streamAbortController)).toBe(null);
+  });
+
+  it('should handle abort when no controller exists', () => {
+    streamAbortController.set(null);
+    expect(() => abortStream()).not.toThrow();
+  });
+});
+
+describe('availableModels store', () => {
+  it('should default to empty array', () => {
+    expect(get(availableModels)).toEqual([]);
+  });
+
+  it('should be settable', () => {
+    const models = ['claude-3', 'gpt-4'];
+    availableModels.set(models);
+    expect(get(availableModels)).toEqual(models);
+    availableModels.set([]);
+  });
+});
+
+describe('githubRepos store', () => {
+  it('should default to empty array', () => {
+    expect(get(githubRepos)).toEqual([]);
+  });
+
+  it('should be settable', () => {
+    const repos = [{ owner: 'test', repo: 'repo' }];
+    githubRepos.set(repos);
+    expect(get(githubRepos)).toEqual(repos);
+    githubRepos.set([]);
+  });
+});
+
+describe('githubRateLimits store', () => {
+  it('should default to empty object', () => {
+    expect(get(githubRateLimits)).toEqual({});
+  });
+
+  it('should be settable', () => {
+    const limits = { 'test/repo': { remaining: 100 } };
+    githubRateLimits.set(limits);
+    expect(get(githubRateLimits)).toEqual(limits);
+    githubRateLimits.set({});
+  });
+});

--- a/frontend-svelte/src/lib/stores/attachments.test.js
+++ b/frontend-svelte/src/lib/stores/attachments.test.js
@@ -1,0 +1,307 @@
+/**
+ * Tests for attachments store
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  ALLOWED_IMAGE_TYPES,
+  ALLOWED_TEXT_EXTENSIONS,
+  MAX_FILE_SIZE,
+  pendingAttachments,
+  isDragging,
+  hasAttachments,
+  attachmentCount,
+  validateFile,
+  readFileAsBase64,
+  readFileAsText,
+  processFile,
+} from './attachments.js';
+
+describe('attachment constants', () => {
+  it('should define allowed image types', () => {
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/jpeg');
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/png');
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/gif');
+    expect(ALLOWED_IMAGE_TYPES).toContain('image/webp');
+  });
+
+  it('should define allowed text extensions', () => {
+    expect(ALLOWED_TEXT_EXTENSIONS).toContain('.txt');
+    expect(ALLOWED_TEXT_EXTENSIONS).toContain('.md');
+    expect(ALLOWED_TEXT_EXTENSIONS).toContain('.js');
+    expect(ALLOWED_TEXT_EXTENSIONS).toContain('.py');
+    expect(ALLOWED_TEXT_EXTENSIONS).toContain('.json');
+  });
+
+  it('should set max file size to 5MB', () => {
+    expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+  });
+});
+
+describe('pendingAttachments store', () => {
+  beforeEach(() => {
+    pendingAttachments.reset();
+  });
+
+  it('should start empty', () => {
+    const attachments = get(pendingAttachments);
+    expect(attachments.images).toEqual([]);
+    expect(attachments.files).toEqual([]);
+  });
+
+  it('should add an image', () => {
+    const mockFile = { name: 'test.jpg', type: 'image/jpeg' };
+    pendingAttachments.addImage(mockFile, 'blob:preview', 'base64data');
+
+    const attachments = get(pendingAttachments);
+    expect(attachments.images).toHaveLength(1);
+    expect(attachments.images[0]).toEqual({
+      file: mockFile,
+      previewUrl: 'blob:preview',
+      base64: 'base64data',
+    });
+  });
+
+  it('should add a file', () => {
+    const mockFile = { name: 'test.txt', type: 'text/plain' };
+    pendingAttachments.addFile(mockFile, 'file content');
+
+    const attachments = get(pendingAttachments);
+    expect(attachments.files).toHaveLength(1);
+    expect(attachments.files[0]).toEqual({
+      file: mockFile,
+      content: 'file content',
+    });
+  });
+
+  it('should remove an image and revoke URL', () => {
+    const mockFile = { name: 'test.jpg', type: 'image/jpeg' };
+    pendingAttachments.addImage(mockFile, 'blob:preview', 'base64data');
+    expect(get(pendingAttachments).images).toHaveLength(1);
+
+    pendingAttachments.removeImage(0);
+    expect(get(pendingAttachments).images).toHaveLength(0);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:preview');
+  });
+
+  it('should remove a file', () => {
+    const mockFile = { name: 'test.txt', type: 'text/plain' };
+    pendingAttachments.addFile(mockFile, 'content');
+    expect(get(pendingAttachments).files).toHaveLength(1);
+
+    pendingAttachments.removeFile(0);
+    expect(get(pendingAttachments).files).toHaveLength(0);
+  });
+
+  it('should reset and revoke all URLs', () => {
+    pendingAttachments.addImage({ name: 'test1.jpg' }, 'blob:1', 'b64-1');
+    pendingAttachments.addImage({ name: 'test2.jpg' }, 'blob:2', 'b64-2');
+    pendingAttachments.addFile({ name: 'test.txt' }, 'content');
+
+    pendingAttachments.reset();
+
+    const attachments = get(pendingAttachments);
+    expect(attachments.images).toEqual([]);
+    expect(attachments.files).toEqual([]);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:1');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:2');
+  });
+});
+
+describe('isDragging store', () => {
+  it('should default to false', () => {
+    expect(get(isDragging)).toBe(false);
+  });
+
+  it('should be settable', () => {
+    isDragging.set(true);
+    expect(get(isDragging)).toBe(true);
+    isDragging.set(false);
+    expect(get(isDragging)).toBe(false);
+  });
+});
+
+describe('hasAttachments derived store', () => {
+  beforeEach(() => {
+    pendingAttachments.reset();
+  });
+
+  it('should return false when empty', () => {
+    expect(get(hasAttachments)).toBe(false);
+  });
+
+  it('should return true when has images', () => {
+    pendingAttachments.addImage({ name: 'test.jpg' }, 'blob:url', 'b64');
+    expect(get(hasAttachments)).toBe(true);
+  });
+
+  it('should return true when has files', () => {
+    pendingAttachments.addFile({ name: 'test.txt' }, 'content');
+    expect(get(hasAttachments)).toBe(true);
+  });
+});
+
+describe('attachmentCount derived store', () => {
+  beforeEach(() => {
+    pendingAttachments.reset();
+  });
+
+  it('should return 0 when empty', () => {
+    expect(get(attachmentCount)).toBe(0);
+  });
+
+  it('should count images and files', () => {
+    pendingAttachments.addImage({ name: 'test.jpg' }, 'blob:url', 'b64');
+    pendingAttachments.addFile({ name: 'test.txt' }, 'content');
+    pendingAttachments.addFile({ name: 'test2.txt' }, 'content2');
+    expect(get(attachmentCount)).toBe(3);
+  });
+});
+
+describe('validateFile', () => {
+  it('should reject files over max size', () => {
+    const file = { name: 'large.txt', size: 10 * 1024 * 1024 };
+    const result = validateFile(file);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('exceeds maximum size');
+  });
+
+  it('should accept valid image types', () => {
+    for (const type of ALLOWED_IMAGE_TYPES) {
+      const file = { name: 'test.jpg', size: 1000, type };
+      const result = validateFile(file);
+      expect(result.valid).toBe(true);
+      expect(result.type).toBe('image');
+    }
+  });
+
+  it('should accept valid text extensions', () => {
+    const extensions = ['.txt', '.md', '.js', '.py', '.json'];
+    for (const ext of extensions) {
+      const file = { name: `test${ext}`, size: 1000, type: 'text/plain' };
+      const result = validateFile(file);
+      expect(result.valid).toBe(true);
+      expect(result.type).toBe('text');
+    }
+  });
+
+  it('should accept PDF files', () => {
+    const file = { name: 'document.pdf', size: 1000, type: 'application/pdf' };
+    const result = validateFile(file);
+    expect(result.valid).toBe(true);
+    expect(result.type).toBe('pdf');
+  });
+
+  it('should accept DOCX files', () => {
+    const file = { name: 'document.docx', size: 1000, type: 'application/vnd.openxmlformats' };
+    const result = validateFile(file);
+    expect(result.valid).toBe(true);
+    expect(result.type).toBe('docx');
+  });
+
+  it('should reject unsupported file types', () => {
+    const file = { name: 'test.exe', size: 1000, type: 'application/x-msdownload' };
+    const result = validateFile(file);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('not supported');
+  });
+});
+
+describe('readFileAsBase64', () => {
+  it('should read file as base64 data URL', async () => {
+    const mockFile = new Blob(['test content'], { type: 'text/plain' });
+
+    // Mock FileReader
+    const mockReader = {
+      result: 'data:text/plain;base64,dGVzdCBjb250ZW50',
+      onload: null,
+      onerror: null,
+      readAsDataURL: vi.fn(function () {
+        setTimeout(() => this.onload?.(), 0);
+      }),
+    };
+    vi.spyOn(global, 'FileReader').mockImplementation(() => mockReader);
+
+    const promise = readFileAsBase64(mockFile);
+    await vi.waitFor(() => expect(mockReader.readAsDataURL).toHaveBeenCalled());
+
+    const result = await promise;
+    expect(result).toBe(mockReader.result);
+  });
+});
+
+describe('readFileAsText', () => {
+  it('should read file as text', async () => {
+    const mockFile = new Blob(['test content'], { type: 'text/plain' });
+
+    // Mock FileReader
+    const mockReader = {
+      result: 'test content',
+      onload: null,
+      onerror: null,
+      readAsText: vi.fn(function () {
+        setTimeout(() => this.onload?.(), 0);
+      }),
+    };
+    vi.spyOn(global, 'FileReader').mockImplementation(() => mockReader);
+
+    const promise = readFileAsText(mockFile);
+    await vi.waitFor(() => expect(mockReader.readAsText).toHaveBeenCalled());
+
+    const result = await promise;
+    expect(result).toBe('test content');
+  });
+});
+
+describe('processFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should throw for invalid files', async () => {
+    const file = { name: 'test.exe', size: 1000, type: 'application/x-msdownload' };
+    await expect(processFile(file)).rejects.toThrow('not supported');
+  });
+
+  it('should throw for oversized files', async () => {
+    const file = { name: 'test.txt', size: 10 * 1024 * 1024, type: 'text/plain' };
+    await expect(processFile(file)).rejects.toThrow('exceeds maximum size');
+  });
+
+  it('should process image files', async () => {
+    const mockReader = {
+      result: 'data:image/jpeg;base64,abc123',
+      onload: null,
+      readAsDataURL: vi.fn(function () {
+        setTimeout(() => this.onload?.(), 0);
+      }),
+    };
+    vi.spyOn(global, 'FileReader').mockImplementation(() => mockReader);
+
+    const file = { name: 'test.jpg', size: 1000, type: 'image/jpeg' };
+    const result = await processFile(file);
+
+    expect(result.type).toBe('image');
+    expect(result.file).toBe(file);
+    expect(result.base64).toBe('data:image/jpeg;base64,abc123');
+    expect(result.previewUrl).toBe('blob:mock-url');
+  });
+
+  it('should process text files', async () => {
+    const mockReader = {
+      result: 'file content',
+      onload: null,
+      readAsText: vi.fn(function () {
+        setTimeout(() => this.onload?.(), 0);
+      }),
+    };
+    vi.spyOn(global, 'FileReader').mockImplementation(() => mockReader);
+
+    const file = { name: 'test.txt', size: 1000, type: 'text/plain' };
+    const result = await processFile(file);
+
+    expect(result.type).toBe('file');
+    expect(result.file).toBe(file);
+    expect(result.content).toBe('file content');
+  });
+});

--- a/frontend-svelte/src/lib/utils.test.js
+++ b/frontend-svelte/src/lib/utils.test.js
@@ -1,0 +1,442 @@
+/**
+ * Tests for utility functions
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  escapeHtml,
+  renderMarkdown,
+  truncateText,
+  formatDate,
+  formatRelativeTime,
+  generateId,
+  debounce,
+  throttle,
+  copyToClipboard,
+  parseToolContent,
+  isToolMessage,
+  getFileExtension,
+  formatFileSize,
+  scrollToBottom,
+  isScrolledToBottom,
+} from './utils.js';
+
+describe('escapeHtml', () => {
+  it('should escape HTML special characters', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert("xss")&lt;/script&gt;'
+    );
+  });
+
+  it('should escape ampersands', () => {
+    expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+  });
+
+  it('should escape quotes', () => {
+    expect(escapeHtml('"quoted"')).toBe('"quoted"');
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('should handle plain text without special characters', () => {
+    expect(escapeHtml('Hello World')).toBe('Hello World');
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('should return empty string for null/undefined', () => {
+    expect(renderMarkdown(null)).toBe('');
+    expect(renderMarkdown(undefined)).toBe('');
+    expect(renderMarkdown('')).toBe('');
+  });
+
+  it('should render inline code', () => {
+    const result = renderMarkdown('Use `console.log()` to debug');
+    expect(result).toContain('<code>console.log()</code>');
+  });
+
+  it('should render code blocks with language', () => {
+    const result = renderMarkdown('```javascript\nconst x = 1;\n```');
+    expect(result).toContain('<pre><code class="language-javascript">');
+    expect(result).toContain('const x = 1;');
+  });
+
+  it('should render code blocks without language', () => {
+    const result = renderMarkdown('```\nsome code\n```');
+    expect(result).toContain('<pre><code>');
+    expect(result).toContain('some code');
+  });
+
+  it('should render bold text with **', () => {
+    const result = renderMarkdown('This is **bold** text');
+    expect(result).toContain('<strong>bold</strong>');
+  });
+
+  it('should render bold text with __', () => {
+    const result = renderMarkdown('This is __bold__ text');
+    expect(result).toContain('<strong>bold</strong>');
+  });
+
+  it('should render italic text with *', () => {
+    const result = renderMarkdown('This is *italic* text');
+    expect(result).toContain('<em>italic</em>');
+  });
+
+  it('should render italic text with _', () => {
+    const result = renderMarkdown('This is _italic_ text');
+    expect(result).toContain('<em>italic</em>');
+  });
+
+  it('should render links', () => {
+    const result = renderMarkdown('Check [this link](https://example.com)');
+    expect(result).toContain('<a href="https://example.com" target="_blank" rel="noopener">this link</a>');
+  });
+
+  it('should render headers', () => {
+    expect(renderMarkdown('# Header 1')).toContain('<h2>Header 1</h2>');
+    expect(renderMarkdown('## Header 2')).toContain('<h3>Header 2</h3>');
+    expect(renderMarkdown('### Header 3')).toContain('<h4>Header 3</h4>');
+  });
+
+  it('should render horizontal rules', () => {
+    expect(renderMarkdown('---')).toContain('<hr>');
+    expect(renderMarkdown('***')).toContain('<hr>');
+  });
+
+  it('should render blockquotes', () => {
+    const result = renderMarkdown('> This is a quote');
+    expect(result).toContain('<blockquote>This is a quote</blockquote>');
+  });
+
+  it('should render unordered lists', () => {
+    const result = renderMarkdown('- Item 1\n- Item 2');
+    expect(result).toContain('<li>Item 1</li>');
+    expect(result).toContain('<li>Item 2</li>');
+    expect(result).toContain('<ul>');
+  });
+
+  it('should convert newlines to br tags', () => {
+    const result = renderMarkdown('Line 1\nLine 2');
+    expect(result).toContain('<br>');
+  });
+
+  it('should escape HTML before processing markdown', () => {
+    const result = renderMarkdown('<script>bad</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+});
+
+describe('truncateText', () => {
+  it('should truncate text longer than maxLength', () => {
+    expect(truncateText('Hello World', 5)).toBe('Hello...');
+  });
+
+  it('should not truncate text shorter than maxLength', () => {
+    expect(truncateText('Hello', 10)).toBe('Hello');
+  });
+
+  it('should not truncate text equal to maxLength', () => {
+    expect(truncateText('Hello', 5)).toBe('Hello');
+  });
+
+  it('should handle empty string', () => {
+    expect(truncateText('', 10)).toBe('');
+  });
+
+  it('should handle null/undefined', () => {
+    expect(truncateText(null, 10)).toBe(null);
+    expect(truncateText(undefined, 10)).toBe(undefined);
+  });
+
+  it('should use default maxLength of 100', () => {
+    const longText = 'a'.repeat(150);
+    expect(truncateText(longText)).toBe('a'.repeat(100) + '...');
+  });
+});
+
+describe('formatDate', () => {
+  it('should format a valid date string', () => {
+    const result = formatDate('2024-01-15T10:30:00Z');
+    expect(result).toContain('Jan');
+    expect(result).toContain('15');
+    expect(result).toContain('2024');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(formatDate('')).toBe('');
+    expect(formatDate(null)).toBe('');
+    expect(formatDate(undefined)).toBe('');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return "just now" for very recent times', () => {
+    const result = formatRelativeTime('2024-01-15T11:59:30Z');
+    expect(result).toBe('just now');
+  });
+
+  it('should return minutes ago', () => {
+    const result = formatRelativeTime('2024-01-15T11:30:00Z');
+    expect(result).toBe('30m ago');
+  });
+
+  it('should return hours ago', () => {
+    const result = formatRelativeTime('2024-01-15T10:00:00Z');
+    expect(result).toBe('2h ago');
+  });
+
+  it('should return days ago', () => {
+    const result = formatRelativeTime('2024-01-13T12:00:00Z');
+    expect(result).toBe('2d ago');
+  });
+
+  it('should return formatted date for older dates', () => {
+    const result = formatRelativeTime('2024-01-01T12:00:00Z');
+    expect(result).toContain('Jan');
+    expect(result).toContain('2024');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(formatRelativeTime('')).toBe('');
+    expect(formatRelativeTime(null)).toBe('');
+  });
+});
+
+describe('generateId', () => {
+  it('should generate unique IDs', () => {
+    const id1 = generateId();
+    const id2 = generateId();
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should generate IDs with expected format', () => {
+    const id = generateId();
+    expect(id).toMatch(/^\d+-[a-z0-9]+$/);
+  });
+});
+
+describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should debounce function calls', () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced();
+    debounced();
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass arguments to the debounced function', () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced('arg1', 'arg2');
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledWith('arg1', 'arg2');
+  });
+
+  it('should reset timer on each call', () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    vi.advanceTimersByTime(50);
+    debounced();
+    vi.advanceTimersByTime(50);
+    debounced();
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should throttle function calls', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled();
+    throttled();
+    throttled();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow function call after throttle period', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled();
+    vi.advanceTimersByTime(100);
+    throttled();
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should pass arguments to the throttled function', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled('arg1', 'arg2');
+
+    expect(fn).toHaveBeenCalledWith('arg1', 'arg2');
+  });
+});
+
+describe('copyToClipboard', () => {
+  it('should copy text to clipboard', async () => {
+    const result = await copyToClipboard('test text');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('test text');
+    expect(result).toBe(true);
+  });
+
+  it('should return false on failure', async () => {
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValueOnce(new Error('Failed'));
+    const result = await copyToClipboard('test text');
+    expect(result).toBe(false);
+  });
+});
+
+describe('parseToolContent', () => {
+  it('should parse JSON string content', () => {
+    const content = '[{"type": "tool_use", "id": "123"}]';
+    const result = parseToolContent(content);
+    expect(result).toEqual([{ type: 'tool_use', id: '123' }]);
+  });
+
+  it('should return array as-is', () => {
+    const content = [{ type: 'tool_use' }];
+    const result = parseToolContent(content);
+    expect(result).toEqual(content);
+  });
+
+  it('should return empty array for invalid JSON', () => {
+    const result = parseToolContent('not json');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for null/undefined', () => {
+    expect(parseToolContent(null)).toEqual([]);
+    expect(parseToolContent(undefined)).toEqual([]);
+  });
+
+  it('should wrap non-array objects in array', () => {
+    const content = { type: 'tool_use' };
+    const result = parseToolContent(content);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('isToolMessage', () => {
+  it('should return true for tool_use role', () => {
+    expect(isToolMessage({ role: 'tool_use' })).toBe(true);
+  });
+
+  it('should return true for tool_result role', () => {
+    expect(isToolMessage({ role: 'tool_result' })).toBe(true);
+  });
+
+  it('should return false for other roles', () => {
+    expect(isToolMessage({ role: 'human' })).toBe(false);
+    expect(isToolMessage({ role: 'assistant' })).toBe(false);
+  });
+
+  it('should return false for null/undefined', () => {
+    expect(isToolMessage(null)).toBe(false);
+    expect(isToolMessage(undefined)).toBe(false);
+  });
+});
+
+describe('getFileExtension', () => {
+  it('should extract file extension', () => {
+    expect(getFileExtension('document.pdf')).toBe('pdf');
+    expect(getFileExtension('image.PNG')).toBe('png');
+    expect(getFileExtension('script.test.js')).toBe('js');
+  });
+
+  it('should handle files without extension', () => {
+    expect(getFileExtension('README')).toBe('readme');
+  });
+});
+
+describe('formatFileSize', () => {
+  it('should format bytes', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+  });
+
+  it('should format kilobytes', () => {
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+    expect(formatFileSize(2560)).toBe('2.5 KB');
+  });
+
+  it('should format megabytes', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+    expect(formatFileSize(2.5 * 1024 * 1024)).toBe('2.5 MB');
+  });
+});
+
+describe('scrollToBottom', () => {
+  it('should set scrollTop to scrollHeight', () => {
+    const element = { scrollTop: 0, scrollHeight: 1000 };
+    scrollToBottom(element);
+    expect(element.scrollTop).toBe(1000);
+  });
+
+  it('should handle null element', () => {
+    expect(() => scrollToBottom(null)).not.toThrow();
+  });
+});
+
+describe('isScrolledToBottom', () => {
+  it('should return true when at bottom', () => {
+    const element = { scrollHeight: 1000, scrollTop: 900, clientHeight: 100 };
+    expect(isScrolledToBottom(element)).toBe(true);
+  });
+
+  it('should return true when within threshold', () => {
+    const element = { scrollHeight: 1000, scrollTop: 870, clientHeight: 100 };
+    expect(isScrolledToBottom(element, 50)).toBe(true);
+  });
+
+  it('should return false when not at bottom', () => {
+    const element = { scrollHeight: 1000, scrollTop: 500, clientHeight: 100 };
+    expect(isScrolledToBottom(element)).toBe(false);
+  });
+
+  it('should return true for null element', () => {
+    expect(isScrolledToBottom(null)).toBe(true);
+  });
+});

--- a/frontend-svelte/src/test/setup.js
+++ b/frontend-svelte/src/test/setup.js
@@ -1,0 +1,70 @@
+/**
+ * Vitest test setup file
+ */
+import '@testing-library/jest-dom/vitest';
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock URL.createObjectURL and URL.revokeObjectURL
+global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+global.URL.revokeObjectURL = vi.fn();
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(),
+    readText: vi.fn().mockResolvedValue(''),
+  },
+});
+
+// Mock ResizeObserver
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock IntersectionObserver
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock AbortController
+global.AbortController = class AbortController {
+  constructor() {
+    this.signal = { aborted: false };
+  }
+  abort() {
+    this.signal.aborted = true;
+  }
+};
+
+// Reset mocks before each test
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorageMock.getItem.mockReturnValue(null);
+});

--- a/frontend-svelte/vitest.config.js
+++ b/frontend-svelte/vitest.config.js
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [
+    svelte({
+      hot: !process.env.VITEST,
+    }),
+  ],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    setupFiles: ['./src/test/setup.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.d.ts',
+        '**/*.config.{js,ts}',
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      '$lib': '/src/lib',
+      '$components': '/src/components',
+    },
+    // Force browser conditions for proper Svelte 5 module resolution
+    conditions: ['browser'],
+  },
+});


### PR DESCRIPTION
- Add Vitest, @testing-library/svelte, and jsdom as dev dependencies
- Configure vitest.config.js for Svelte 5 component testing
- Add test setup file with mocks for localStorage, clipboard, etc.
- Add 64 unit tests for utility functions (utils.js)
- Add 54 unit tests for stores (app.js, attachments.js)
- Add 31 unit tests for common components (Button, Modal, Toast)
- All 149 tests passing