### PR TITLE
Add Node.js version requirement to package.json

### DIFF
--- a/frontend-svelte/package.json
+++ b/frontend-svelte/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
Added an explicit Node.js version requirement to the frontend-svelte package configuration to ensure compatibility and prevent issues with older Node.js versions.

## Changes
- Added `engines` field to `package.json` specifying Node.js >= 20.0.0
- This ensures developers and CI/CD pipelines use a compatible Node.js version

## Details
This change enforces a minimum Node.js version of 20.0.0 for the project. Package managers like npm and yarn will warn users if they attempt to install dependencies with an incompatible Node.js version, helping prevent runtime errors and compatibility issues.

https://claude.ai/code/session_013YHQE4jXK65Xu2iVqhkWtj