### PR TITLE
Add mobile sidebar open state control to Sidebar component

### DIFF
--- a/frontend-svelte/src/components/layout/Sidebar.svelte
+++ b/frontend-svelte/src/components/layout/Sidebar.svelte
@@ -8,6 +8,9 @@
 
     const dispatch = createEventDispatcher();
 
+    // Mobile sidebar open state (controlled by parent)
+    export let isOpen = false;
+
     let openDropdownId = null;
 
     function handleEntityChange(event) {
@@ -83,7 +86,7 @@
 
 <svelte:window on:click={handleWindowClick} />
 
-<aside class="sidebar">
+<aside class="sidebar" class:open={isOpen}>
     <div class="sidebar-header">
         <h1 class="app-title">Here I Am</h1>
         <p class="app-subtitle">Experiential Research Interface</p>


### PR DESCRIPTION
## Summary
Added support for controlling the mobile sidebar's open/closed state from the parent component by introducing an `isOpen` export prop that conditionally applies an `open` class to the sidebar element.

## Changes
- Added `isOpen` export prop (defaults to `false`) to allow parent components to control sidebar visibility on mobile
- Updated sidebar `<aside>` element to conditionally apply the `open` class based on the `isOpen` state
- Added clarifying comment documenting that mobile sidebar state is controlled by parent

## Implementation Details
The `isOpen` prop enables parent components (likely a layout wrapper or app shell) to manage mobile sidebar visibility, typically in response to a hamburger menu toggle. The conditional class binding (`class:open={isOpen}`) allows CSS to handle the visual presentation of the open/closed states without requiring additional JavaScript logic in the sidebar component itself.

https://claude.ai/code/session_01FPjsWdVydhy5xauVt7tKnV