### PR TITLE
Fix streaming content handling by using data.content instead of data.token

### DIFF
--- a/frontend-svelte/src/components/layout/ChatArea.svelte
+++ b/frontend-svelte/src/components/layout/ChatArea.svelte
@@ -152,7 +152,9 @@
                     }
                 },
                 onToken: (data) => {
-                    appendStreamingContent(data.token);
+                    if (data.content) {
+                        appendStreamingContent(data.content);
+                    }
                 },
                 onToolStart: (data) => {
                     addStreamingTool({
@@ -246,7 +248,9 @@
                 },
                 onStart: () => {},
                 onToken: (data) => {
-                    appendStreamingContent(data.token);
+                    if (data.content) {
+                        appendStreamingContent(data.content);
+                    }
                 },
                 onToolStart: (data) => {
                     addStreamingTool({


### PR DESCRIPTION
## Summary
Updated the streaming content handlers to use `data.content` instead of `data.token` and added null/undefined checks to prevent errors when processing streamed data.

## Changes
- Modified two `onToken` callback handlers in ChatArea.svelte to access `data.content` instead of `data.token`
- Added conditional checks to ensure `data.content` exists before calling `appendStreamingContent()`
- Applied changes consistently across both streaming handlers (lines 152-157 and 248-253)

## Details
This fix addresses a mismatch between the expected data structure from the streaming API and how the handlers were accessing the token data. The `data.content` field is the correct property to use, and the added safety checks prevent potential runtime errors when content is undefined or null.

https://claude.ai/code/session_01JmUEnEY4zD4Yfir2AKViu6