### PR TITLE
Allow user interaction during message streaming

### DIFF
--- a/frontend-svelte/src/components/layout/ChatArea.svelte
+++ b/frontend-svelte/src/components/layout/ChatArea.svelte
@@ -136,6 +136,9 @@
                 speakerLabel: $isMultiEntityMode ? getEntityLabel(respondingEntityId) : null
             });
 
+            // Turn off loading overlay once streaming starts - user can interact during streaming
+            isLoading.set(false);
+
             let conversationCreated = false;
 
             await api.sendMessageStream(requestData, {
@@ -234,6 +237,9 @@
 
         try {
             startStreaming();
+
+            // Turn off loading overlay once streaming starts - user can interact during streaming
+            isLoading.set(false);
 
             await api.regenerateStream({
                 message_id: messageId,


### PR DESCRIPTION
## Summary
This change improves the user experience by disabling the loading overlay as soon as streaming begins, rather than keeping it active throughout the entire streaming process. This allows users to interact with the chat interface while messages are being streamed.

## Key Changes
- Disable loading overlay immediately after streaming starts in `sendMessageStream` flow
- Disable loading overlay immediately after streaming starts in `regenerateStream` flow
- Users can now interact with the chat interface during active streaming instead of being blocked by the loading overlay

## Implementation Details
The `isLoading.set(false)` call is placed right after `startStreaming()` is invoked in both message sending and message regeneration flows. This ensures the loading overlay is dismissed as soon as the streaming connection is established, while the actual streaming operation continues in the background. The user can now perform actions like scrolling, editing, or sending new messages while waiting for the response to complete.

https://claude.ai/code/session_01XyBUM6AYwL8CQuhB8Kj595