### PR TITLE
Simplify system prompt state management in SettingsModal

### DIFF
--- a/frontend-svelte/src/components/modals/SettingsModal.svelte
+++ b/frontend-svelte/src/components/modals/SettingsModal.svelte
@@ -13,21 +13,23 @@
     const dispatch = createEventDispatcher();
 
     let activeTab = 'general';
-    let localSystemPrompt = '';
     let entityPrompt = '';
     let loadingRateLimits = false;
 
     $: currentEntity = $selectedEntity;
 
+    // Load entity-specific system prompt when entity changes or modal opens
     $: {
-        // Load entity-specific system prompt when entity changes
         if ($selectedEntityId) {
             entityPrompt = entitySystemPrompts.getForEntity($selectedEntityId);
         }
     }
 
     onMount(async () => {
-        localSystemPrompt = $settings.systemPrompt || '';
+        // Re-initialize entity prompt on modal mount to ensure fresh value
+        if ($selectedEntityId) {
+            entityPrompt = entitySystemPrompts.getForEntity($selectedEntityId);
+        }
         await loadPresets();
 
         if ($ttsEnabled) {
@@ -58,7 +60,6 @@
         const presetId = event.target.value;
         if (presetId) {
             applyPreset(presetId);
-            localSystemPrompt = $settings.systemPrompt || '';
         }
     }
 
@@ -75,8 +76,7 @@
     }
 
     function handleSystemPromptChange(event) {
-        localSystemPrompt = event.target.value;
-        updateSettings({ systemPrompt: localSystemPrompt });
+        updateSettings({ systemPrompt: event.target.value });
     }
 
     function handleEntityPromptChange(event) {
@@ -221,7 +221,7 @@
                     </p>
                     <textarea
                         class="prompt-textarea"
-                        value={localSystemPrompt}
+                        value={$settings.systemPrompt || ''}
                         on:input={handleSystemPromptChange}
                         placeholder="No system prompt (research mode)"
                         rows="4"


### PR DESCRIPTION
## Summary
Removed unnecessary local state management for the system prompt in SettingsModal by using the reactive settings store directly instead of maintaining a separate `localSystemPrompt` variable.

## Key Changes
- Removed `localSystemPrompt` local variable that was duplicating state from `$settings.systemPrompt`
- Updated the system prompt textarea to bind directly to `$settings.systemPrompt` instead of the local variable
- Simplified `handleSystemPromptChange()` to directly update settings without intermediate local state
- Removed redundant `localSystemPrompt` initialization from `onMount()` hook
- Removed redundant `localSystemPrompt` update from `handlePresetChange()` function
- Enhanced `onMount()` to re-initialize entity prompt on modal mount for consistency

## Implementation Details
This change eliminates state duplication and simplifies the component logic by relying on the reactive settings store as the single source of truth. The system prompt textarea now directly reflects and updates the store value, reducing complexity and potential synchronization issues.

https://claude.ai/code/session_01WyrAEUu47Db4DR3oeJo6xW