### PR TITLE
Fix entity system prompt handling to combine with global prompt

### DIFF
--- a/frontend-svelte/src/App.svelte
+++ b/frontend-svelte/src/App.svelte
@@ -13,7 +13,7 @@
     import ImportExportModal from './components/modals/ImportExportModal.svelte';
 
     import { theme, isLoading, activeModal, showToast, availableModels, githubRepos, githubRateLimits } from './lib/stores/app.js';
-    import { entities, selectedEntityId, isMultiEntityMode, resetMultiEntityState, currentConversationEntities, getEntity, entitySystemPrompts, entitySessionPreferences } from './lib/stores/entities.js';
+    import { entities, selectedEntityId, isMultiEntityMode, resetMultiEntityState, currentConversationEntities, getEntity, entitySessionPreferences } from './lib/stores/entities.js';
     import { conversations, currentConversationId, currentConversation, resetConversationState, getNextRequestId, isValidRequestId } from './lib/stores/conversations.js';
     import { messages, resetMessagesState } from './lib/stores/messages.js';
     import { resetMemoriesState } from './lib/stores/memories.js';
@@ -221,14 +221,9 @@
             debug(`Reset voice to default`);
         }
 
-        // Restore entity-specific system prompt if stored (persisted to localStorage)
-        const storedPrompt = entitySystemPrompts.getForEntity(entityId);
-        if (storedPrompt !== undefined && storedPrompt !== '') {
-            updateSettingQuietly('systemPrompt', storedPrompt);
-        } else {
-            // Clear system prompt when switching to entity without stored prompt
-            updateSettingQuietly('systemPrompt', '');
-        }
+        // Note: Entity-specific system prompts are stored separately in entitySystemPrompts
+        // and should NOT overwrite the global settings.systemPrompt. The entity prompt is
+        // combined with the global prompt when sending messages (in chat.js or the backend).
     }
 
     // Handle conversation selection

--- a/frontend-svelte/src/components/layout/ChatArea.svelte
+++ b/frontend-svelte/src/components/layout/ChatArea.svelte
@@ -84,9 +84,18 @@
                 addConversationToList(newConv);
             }
 
-            // Get entity-specific system prompt
-            const entityPrompts = entitySystemPrompts.getForEntity(respondingEntityId);
-            const systemPrompt = entityPrompts || $settings.systemPrompt;
+            // Get entity-specific system prompt (prepended to global prompt if both exist)
+            const entityPrompt = entitySystemPrompts.getForEntity(respondingEntityId);
+            const globalPrompt = $settings.systemPrompt;
+            // Combine: entity prompt prepended to global prompt (with separator if both exist)
+            let systemPrompt = '';
+            if (entityPrompt && globalPrompt) {
+                systemPrompt = `${entityPrompt}\n\n${globalPrompt}`;
+            } else if (entityPrompt) {
+                systemPrompt = entityPrompt;
+            } else if (globalPrompt) {
+                systemPrompt = globalPrompt;
+            }
 
             // Prepare request data
             const requestData = {


### PR DESCRIPTION
## Summary
This PR fixes the entity-specific system prompt behavior to properly combine entity prompts with global prompts instead of replacing them. Previously, switching to an entity would overwrite the global system prompt with the entity-specific one. Now, entity prompts are prepended to the global prompt when both exist.

## Key Changes
- **App.svelte**: Removed the logic that overwrites the global `systemPrompt` setting when switching entities. Added a clarifying comment explaining that entity prompts should be combined with global prompts during message sending, not during entity selection.
- **ChatArea.svelte**: Updated the system prompt composition logic to properly combine entity and global prompts:
  - Entity prompt is prepended to global prompt with a `\n\n` separator when both exist
  - Falls back to entity prompt alone if no global prompt exists
  - Falls back to global prompt alone if no entity prompt exists
  - Results in an empty string only if neither prompt exists

## Implementation Details
The change ensures that entity-specific system prompts enhance rather than replace the global system prompt configuration. This allows users to maintain a consistent global system prompt while adding entity-specific instructions on top of it.

https://claude.ai/code/session_01RqCzMsYQVtTgJC843Jdkos