### PR TITLE
Load chat config and update model selector on app init

### DIFF
--- a/frontend/js/modules/entities.js
+++ b/frontend/js/modules/entities.js
@@ -209,10 +209,11 @@ export function handleEntityChange(entityId) {
  * Update model selector based on entity's LLM provider
  * @param {string} provider - LLM provider name
  */
-function updateModelSelectorForProvider(provider) {
+export function updateModelSelectorForProvider(provider) {
     if (!elements.modelSelect || !state.availableModels) return;
 
-    const models = state.availableModels[provider] || [];
+    // Filter models by provider from flat array
+    const models = state.availableModels.filter(m => m.provider === provider);
     elements.modelSelect.innerHTML = '';
 
     models.forEach(model => {


### PR DESCRIPTION
## Summary
This PR adds chat configuration loading during app initialization and ensures the model selector is properly updated based on the selected entity's LLM provider when entities are loaded.

## Key Changes
- Added `loadChatConfig()` method to fetch available models from the server during app startup
- Store available models in `state.availableModels` as a flat array with provider information
- Export `updateModelSelectorForProvider()` function to make it reusable across modules
- Updated `onEntitiesLoaded()` callback to automatically update the model selector for the currently selected entity's provider
- Modified model filtering logic to work with flat array structure (filtering by `m.provider` instead of nested object lookup)

## Implementation Details
- Chat config is loaded early in the initialization sequence, before entities and conversations are loaded
- The model selector update is triggered when entities are loaded, ensuring the UI reflects the correct available models for the selected entity's provider
- Graceful error handling with console logging if chat config fails to load
- Defaults to 'anthropic' provider if entity doesn't specify an LLM provider

https://claude.ai/code/session_01YLJLTMQDNPfHobv25pjrrA