### PR TITLE
Add per-entity model selection persistence

### DIFF
--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -16,6 +16,7 @@ export const state = {
     selectedEntityId: null,
     entities: [],
     entitySystemPrompts: {},
+    entityModels: {},  // Per-entity model selection persistence
 
     // Multi-entity state
     isMultiEntityMode: false,
@@ -163,6 +164,31 @@ export function saveEntitySystemPromptsToStorage() {
         localStorage.setItem('entity_system_prompts', JSON.stringify(state.entitySystemPrompts));
     } catch (e) {
         console.warn('Failed to save entity system prompts:', e);
+    }
+}
+
+/**
+ * Load entity models from localStorage
+ */
+export function loadEntityModelsFromStorage() {
+    try {
+        const saved = localStorage.getItem('entity_models');
+        if (saved) {
+            state.entityModels = JSON.parse(saved);
+        }
+    } catch (e) {
+        console.warn('Failed to load entity models:', e);
+    }
+}
+
+/**
+ * Save entity models to localStorage
+ */
+export function saveEntityModelsToStorage() {
+    try {
+        localStorage.setItem('entity_models', JSON.stringify(state.entityModels));
+    } catch (e) {
+        console.warn('Failed to save entity models:', e);
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the ability to save and restore model selection preferences on a per-entity basis, similar to the existing per-entity system prompt functionality. Users can now select different models for different entities, and their choices will be persisted across sessions.

## Key Changes
- **State Management**: Added `entityModels` object to track model selections per entity in `state.js`
- **Storage Functions**: Implemented `loadEntityModelsFromStorage()` and `saveEntityModelsToStorage()` to persist model preferences to localStorage
- **Settings Application**: Modified `applySettings()` in `settings.js` to save the current model selection when switching entities
- **Entity Switching**: Updated `handleEntityChange()` in `entities.js` to restore saved model preferences when switching between entities, with fallback to entity default models
- **App Initialization**: Added `loadEntityModelsFromStorage()` call during app startup to restore saved preferences
- **Model Indicator**: Enhanced `updateModelIndicator()` to display friendly model names from the available models list instead of raw model IDs
- **UI Updates**: Added calls to `updateModelIndicator()` and `updateTemperatureRange()` when entities are loaded or changed to ensure UI consistency

## Implementation Details
- Saved model selections are validated against the current provider's available models before applying
- If a saved model is invalid for the current provider, the entity's default model is used as fallback
- Model dropdown values are explicitly updated to reflect the selected model when switching entities
- The implementation mirrors the existing per-entity system prompt pattern for consistency

https://claude.ai/code/session_01QV4diZFAVDQDjoar7qKcJR