### PR TITLE
Add support for Claude Opus 4.6 model

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -365,6 +365,7 @@ class Settings(BaseSettings):
     # the provider APIs, so new models should work automatically when released.
     #
     # ANTHROPIC MODELS:
+    #   - claude-opus-4-6
     #   - claude-sonnet-4-5-20250929
     #   - claude-opus-4-5-20251101
     #   - claude-sonnet-4-20250514

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -29,6 +29,8 @@ MODEL_PROVIDER_MAP = {
     "claude-sonnet-4-5-20250929": ModelProvider.ANTHROPIC,
     "claude-opus-4-5-20251101": ModelProvider.ANTHROPIC,
     "claude-haiku-4-5-20251001": ModelProvider.ANTHROPIC,
+    # Anthropic Claude 4.6 models
+    "claude-opus-4-6": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
     "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
     "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
@@ -64,6 +66,7 @@ MODEL_PROVIDER_MAP = {
 # Available models by provider
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
+        {"id": "claude-opus-4-6", "name": "Claude Opus 4.6"},
         {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5"},
         {"id": "claude-opus-4-5-20251101", "name": "Claude Opus 4.5"},
         {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5"},

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,6 +137,7 @@
                 <div class="form-group">
                     <label for="model-select">Model</label>
                     <select id="model-select">
+                        <option value="claude-opus-4-6">Claude Opus 4.6</option>
                         <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</option>
                         <option value="claude-opus-4-5-20251101">Claude Opus 4.5</option>
                         <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5</option>


### PR DESCRIPTION
## Summary
This PR adds support for the new Claude Opus 4.6 model across the backend and frontend, enabling users to select and use this latest Anthropic model.

## Changes
- **Backend Configuration** (`backend/app/config.py`): Added Claude Opus 4.6 to the documented list of supported Anthropic models
- **LLM Service** (`backend/app/services/llm_service.py`): 
  - Registered `claude-opus-4-6` model ID with the Anthropic provider in the model mapping
  - Added Claude Opus 4.6 to the `AVAILABLE_MODELS` list with display name "Claude Opus 4.6"
- **Frontend UI** (`frontend/index.html`): Added Claude Opus 4.6 as the first option in the model selection dropdown

## Implementation Details
The model is positioned at the top of the available models list, making it the default selection. The implementation follows the existing pattern used for other Anthropic models and requires no additional configuration or API changes.

https://claude.ai/code/session_01XKHaqH42CEGQbQPt6vuYQX