### PR TITLE
Add support for Claude Opus 4.7 model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2466,7 +2466,7 @@ DEFAULT_GOOGLE_MODEL = "gemini-2.5-flash"  # Google default
 DEFAULT_MINIMAX_MODEL = "MiniMax-M2.5"  # MiniMax default
 
 # Supported Anthropic models include:
-#   claude-opus-4-6, claude-sonnet-4-5-20250929
+#   claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-5-20250929
 #   claude-opus-4-5-20251101, claude-sonnet-4-20250514
 
 # Supported OpenAI models include:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -367,6 +367,7 @@ class Settings(BaseSettings):
     # the provider APIs, so new models should work automatically when released.
     #
     # ANTHROPIC MODELS:
+    #   - claude-opus-4-7
     #   - claude-opus-4-6
     #   - claude-sonnet-4-5-20250929
     #   - claude-opus-4-5-20251101

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -32,6 +32,8 @@ MODEL_PROVIDER_MAP = {
     "claude-haiku-4-5-20251001": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4.6 models
     "claude-opus-4-6": ModelProvider.ANTHROPIC,
+    # Anthropic Claude 4.7 models
+    "claude-opus-4-7": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
     "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
     "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
@@ -72,6 +74,7 @@ MODEL_PROVIDER_MAP = {
 # Available models by provider
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
+        {"id": "claude-opus-4-7", "name": "Claude Opus 4.7"},
         {"id": "claude-opus-4-6", "name": "Claude Opus 4.6"},
         {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5"},
         {"id": "claude-opus-4-5-20251101", "name": "Claude Opus 4.5"},

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,6 +137,7 @@
                 <div class="form-group" id="model-group">
                     <label for="model-select">Model</label>
                     <select id="model-select">
+                        <option value="claude-opus-4-7">Claude Opus 4.7</option>
                         <option value="claude-opus-4-6">Claude Opus 4.6</option>
                         <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</option>
                         <option value="claude-opus-4-5-20251101">Claude Opus 4.5</option>


### PR DESCRIPTION
## Summary
This PR adds support for the new Claude Opus 4.7 model across the application's backend and frontend components.

## Key Changes
- **Backend Service**: Added `claude-opus-4-7` to the model provider mapping in `llm_service.py`, mapping it to the Anthropic provider
- **Available Models**: Registered the new model in the `AVAILABLE_MODELS` configuration with display name "Claude Opus 4.7"
- **Configuration**: Updated documentation in `config.py` to list `claude-opus-4-7` as a supported Anthropic model
- **Frontend UI**: Added the new model option to the model selection dropdown in `index.html`
- **Documentation**: Updated `CLAUDE.md` to include `claude-opus-4-7` in the list of supported Anthropic models

## Implementation Details
The new model is positioned as the latest/primary option in selection lists, appearing before Claude Opus 4.6. All changes follow the existing pattern for model registration and are consistent with how other Anthropic models are integrated into the system.

https://claude.ai/code/session_01Am2UVBCkJhBo4rLqUyNaxh