### PR TITLE
Filter archived conversation memories from session and search results

### DIFF
--- a/backend/app/services/memory_tools.py
+++ b/backend/app/services/memory_tools.py
@@ -76,33 +76,45 @@ async def _memory_query(query: str, num_results: int = 5) -> str:
     num_results = max(1, min(10, num_results))
     
     try:
-        # Search memories by pure semantic similarity (no significance reranking).
-        # Exclude current conversation—its content is already in context.
+        # Fetch more candidates than requested so archived-conversation filtering
+        # below does not silently shrink the result set.
         candidates = await memory_service.search_memories(
             query=query,
-            top_k=num_results,
+            top_k=num_results * 2,
             exclude_conversation_id=conversation_id,  # Exclude current conversation
             exclude_ids=None,  # Include all memories
             entity_id=entity_id,
             use_cache=True,
         )
-        
+
         if not candidates:
             return f"No memories found matching: \"{query}\""
-        
+
         # Get full content and update retrieval stats
         # We need our own DB session since tools don't receive one
         async with async_session_maker() as db:
+            # Exclude memories from archived conversations. Unarchiving a
+            # conversation removes its IDs from this set, so its memories
+            # become retrievable again automatically.
+            archived_ids = await memory_service.get_archived_conversation_ids(
+                db, entity_id=entity_id
+            )
+
             memories = []
             now = datetime.utcnow()
-            
+
             for candidate in candidates:
+                if len(memories) >= num_results:
+                    break
                 try:
+                    if candidate.get("conversation_id") in archived_ids:
+                        continue
+
                     # Get full memory content from SQL
                     mem_data = await memory_service.get_full_memory_content(
                         candidate["id"], db
                     )
-                    
+
                     if not mem_data:
                         logger.warning(f"Memory {candidate['id']} not found in SQL (orphaned)")
                         continue

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -220,6 +220,18 @@ class SessionManager:
         other_count = len(messages) - human_count - assistant_count
         logger.info(f"[SESSION] Loading {len(messages)} messages from DB ({human_count} human, {assistant_count} assistant, {other_count} other)")
 
+        # Fetch archived source-conversation IDs so we can drop memories whose
+        # source conversation has been archived since they were first retrieved.
+        # Without this, ConversationMemoryLink would re-inject those memories
+        # into context on every session reload, bypassing the live archive
+        # filter. Unarchiving the source conversation removes its ID from this
+        # set, so its memories become retrievable again on the next reload.
+        archived_source_ids: Set[str] = set()
+        if memory_service.is_configured(entity_id=entity_id):
+            archived_source_ids = await memory_service.get_archived_conversation_ids(
+                db, entity_id=entity_id
+            )
+
         # For memory-in-context mode, we need to interleave messages with memories
         # based on retrieval timestamps. Get memories with timestamps first.
         memories_with_timestamps = []
@@ -231,13 +243,17 @@ class SessionManager:
         # Build a mapping of message_id -> memory data for quick lookup
         memory_data_by_id: Dict[str, Optional[Dict]] = {}
         retrieved_ids = set()
+        skipped_archived = 0
 
         if memories_with_timestamps:
             for mem_info in memories_with_timestamps:
                 mem_id = mem_info["message_id"]
-                retrieved_ids.add(mem_id)
                 mem_data = await memory_service.get_full_memory_content(mem_id, db)
                 if mem_data:
+                    if mem_data["conversation_id"] in archived_source_ids:
+                        skipped_archived += 1
+                        continue
+                    retrieved_ids.add(mem_id)
                     str_id = mem_data["id"]
                     memory_data_by_id[str_id] = {
                         "data": mem_data,
@@ -263,15 +279,18 @@ class SessionManager:
             memory_queue = list(sorted_memory_entries)  # List of (mem_id, {data, retrieved_at})
         else:
             # Non-memory-in-context mode: just load retrieved IDs for deduplication
-            retrieved_ids = await memory_service.get_retrieved_ids_for_conversation(
+            all_retrieved_ids = await memory_service.get_retrieved_ids_for_conversation(
                 conversation_id, db, entity_id=entity_id if is_multi_entity else None
             )
-            session.retrieved_ids = retrieved_ids
 
             # Load full memory content for already-retrieved memories
-            for mem_id in retrieved_ids:
+            for mem_id in all_retrieved_ids:
                 mem_data = await memory_service.get_full_memory_content(mem_id, db)
                 if mem_data:
+                    if mem_data["conversation_id"] in archived_source_ids:
+                        skipped_archived += 1
+                        continue
+                    retrieved_ids.add(mem_id)
                     str_id = mem_data["id"]
                     session.session_memories[str_id] = MemoryEntry(
                         id=str_id,
@@ -282,7 +301,13 @@ class SessionManager:
                         times_retrieved=mem_data["times_retrieved"],
                     )
                     session.in_context_ids.add(str_id)
+            session.retrieved_ids = retrieved_ids
             memory_queue = []
+
+        if skipped_archived:
+            logger.info(
+                f"[MEMORY] Skipped {skipped_archived} memories from archived source conversations during session load"
+            )
 
         # Build conversation context, interleaving memories at their original positions
         memory_insert_count = 0


### PR DESCRIPTION
## Summary
This PR adds filtering logic to prevent memories from archived source conversations from being injected into sessions and search results. When a conversation is archived, its memories should no longer be retrievable until the conversation is unarchived.

## Key Changes

- **Session Loading (`session_manager.py`)**:
  - Fetch archived conversation IDs at session load time
  - Filter out memories whose source conversation has been archived in both memory-in-context and non-memory-in-context modes
  - Track and log the count of skipped archived memories
  - Ensure `retrieved_ids` only contains non-archived memories for proper deduplication

- **Memory Search (`memory_tools.py`)**:
  - Fetch archived conversation IDs before processing search results
  - Filter candidates to exclude memories from archived conversations
  - Fetch 2x the requested number of candidates to compensate for filtering, ensuring the result set isn't silently reduced
  - Stop processing candidates once the desired number of non-archived results is reached

## Implementation Details

- Archived conversation filtering is applied consistently across both session loading paths (memory-in-context and standard modes)
- Unarchiving a conversation automatically makes its memories retrievable again on the next session reload or search, without requiring code changes
- The filtering happens after retrieval but before inclusion in context, maintaining the integrity of the archive feature
- Search results fetch extra candidates upfront to ensure users still get the requested number of results after filtering

https://claude.ai/code/session_01UR1S1oxhipHt1sZxm9YPEz