### PR TITLE
Add Claude Opus 4.8 model support

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -367,6 +367,7 @@ class Settings(BaseSettings):
     # the provider APIs, so new models should work automatically when released.
     #
     # ANTHROPIC MODELS:
+    #   - claude-opus-4-8
     #   - claude-opus-4-7
     #   - claude-opus-4-6
     #   - claude-sonnet-4-5-20250929

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -34,6 +34,8 @@ MODEL_PROVIDER_MAP = {
     "claude-opus-4-6": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4.7 models
     "claude-opus-4-7": ModelProvider.ANTHROPIC,
+    # Anthropic Claude 4.8 models
+    "claude-opus-4-8": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
     "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
     "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
@@ -74,6 +76,7 @@ MODEL_PROVIDER_MAP = {
 # Available models by provider
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
+        {"id": "claude-opus-4-8", "name": "Claude Opus 4.8"},
         {"id": "claude-opus-4-7", "name": "Claude Opus 4.7"},
         {"id": "claude-opus-4-6", "name": "Claude Opus 4.6"},
         {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5"},

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,6 +137,7 @@
                 <div class="form-group" id="model-group">
                     <label for="model-select">Model</label>
                     <select id="model-select">
+                        <option value="claude-opus-4-8">Claude Opus 4.8</option>
                         <option value="claude-opus-4-7">Claude Opus 4.7</option>
                         <option value="claude-opus-4-6">Claude Opus 4.6</option>
                         <option value="claude-sonnet-4-5-20250929">Claude Sonnet 4.5</option>


### PR DESCRIPTION
## Summary
Add support for the new Claude Opus 4.8 model across the backend and frontend.

## Changes
- **Backend (`llm_service.py`):** Register `claude-opus-4-8` model ID with Anthropic provider in the model mapping and add it to the available models list for Anthropic
- **Backend (`config.py`):** Document the new model in the supported Anthropic models list
- **Frontend (`index.html`):** Add Claude Opus 4.8 as an option in the model selection dropdown

The new model is positioned at the top of the Anthropic models list, indicating it as the latest/preferred option.

https://claude.ai/code/session_01AsSkYeYykva9iTGpw9PwPn