### PR TITLE
Fix note-write truncation by raising frontend max_tokens cap to 64000

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -166,7 +166,7 @@
 
                 <div class="form-group">
                     <label for="max-tokens-input">Max Tokens</label>
-                    <input type="number" id="max-tokens-input" value="4096" min="100" max="8192">
+                    <input type="number" id="max-tokens-input" value="64000" min="100" max="64000">
                 </div>
 
                 <div class="form-group">

--- a/frontend/js/__tests__/state.test.js
+++ b/frontend/js/__tests__/state.test.js
@@ -45,7 +45,7 @@ describe('State Module', () => {
             expect(state.settings).toBeDefined();
             expect(state.settings.model).toBe('claude-sonnet-4-5-20250929');
             expect(state.settings.temperature).toBe(1.0);
-            expect(state.settings.maxTokens).toBe(4096);
+            expect(state.settings.maxTokens).toBe(64000);
             expect(state.settings.systemPrompt).toBe(null);
             expect(state.settings.conversationType).toBe('normal');
         });

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -41,7 +41,7 @@ export const state = {
     settings: {
         model: 'claude-sonnet-4-5-20250929',
         temperature: 1.0,
-        maxTokens: 4096,
+        maxTokens: 64000,
         systemPrompt: null,
         conversationType: 'normal',
         verbosity: 'medium',


### PR DESCRIPTION
The notes_write tool failed for notes over ~4096 tokens because the note
content is emitted as a tool_use block, which counts against the response
max_tokens budget. The frontend defaulted max_tokens to 4096 and hard-capped
the input at 8192, overriding the backend's 64000 capability on every request.
Long notes truncated the tool_use block mid-stream, so the tool never executed
and an 'output tokens exceeded' error surfaced.

Align the frontend default and input ceiling with the backend's
default_max_tokens (64000).