### PR TITLE
Fix attachments dropped after tool use in chat stream

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -404,8 +404,13 @@ async def stream_message(data: ChatRequest):
                 responding_entity_id = data.responding_entity_id
                 multi_entity_ids = []
 
-                # Determine if this is a continuation (no human message)
-                is_continuation = not data.message
+                # Determine if this is a continuation (no human input at all).
+                # An attachment-only message (file/image with no text) is NOT a
+                # continuation - the attachment is the human's input.
+                has_attachment_input = bool(
+                    data.attachments and (data.attachments.files or data.attachments.images)
+                )
+                is_continuation = not data.message and not has_attachment_input
 
                 # Continuation requires multi-entity mode
                 if is_continuation and not is_multi_entity:
@@ -611,8 +616,11 @@ async def stream_message(data: ChatRequest):
                         # For multi-entity conversations, store to ALL participating entities
                         responding_label = get_entity_label(responding_entity_id)
                         for entity_id in multi_entity_ids:
-                            # For human messages: role is "human" for all entities (skip for continuation)
-                            if human_msg:
+                            # For human messages: role is "human" for all entities.
+                            # Skipped for continuations (no human_msg) and for
+                            # attachment-only messages (no text to vectorize -
+                            # file content is intentionally not stored in memory).
+                            if human_msg and data.message:
                                 await memory_service.store_memory(
                                     message_id=str(human_msg.id),
                                     conversation_id=str(data.conversation_id),
@@ -644,15 +652,19 @@ async def stream_message(data: ChatRequest):
                                     entity_id=entity_id,
                                 )
                     else:
-                        # Standard single-entity conversation (always has human message)
-                        await memory_service.store_memory(
-                            message_id=str(human_msg.id),
-                            conversation_id=str(data.conversation_id),
-                            role="human",
-                            content=data.message,
-                            created_at=human_msg.created_at,
-                            entity_id=session.entity_id,
-                        )
+                        # Standard single-entity conversation.
+                        # Skip the human memory for attachment-only messages: there
+                        # is no text to vectorize and file content is intentionally
+                        # not stored in memory (it is still persisted in the DB).
+                        if data.message:
+                            await memory_service.store_memory(
+                                message_id=str(human_msg.id),
+                                conversation_id=str(data.conversation_id),
+                                role="human",
+                                content=data.message,
+                                created_at=human_msg.created_at,
+                                entity_id=session.entity_id,
+                            )
                         await memory_service.store_memory(
                             message_id=str(assistant_msg.id),
                             conversation_id=str(data.conversation_id),

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -633,18 +633,28 @@ class AnthropicService:
                 final_parts.append(shared_block)
                 logger.info(f"[NOTES] Injected shared index.md ({len(shared_notes)} chars)")
 
+        # Whether there's any human input this turn (text and/or an attachment).
+        # An attachment-only message (file/image with no text) still counts as
+        # human input, not a continuation.
+        from app.services.attachment_service import attachment_service, has_attachments
+        has_attachment_content = bool(attachments and has_attachments(attachments))
+
         # Handle current message or continuation prompt
-        if current_message:
-            if is_multi_entity:
-                final_parts.append(f"[Human]: {current_message}")
-            else:
-                final_parts.append(current_message)
+        if current_message or has_attachment_content:
+            if current_message:
+                if is_multi_entity:
+                    final_parts.append(f"[Human]: {current_message}")
+                else:
+                    final_parts.append(current_message)
+            # When there's no text but an attachment is present, the
+            # [CURRENT USER MESSAGE] marker plus the attachment content
+            # (appended below) stand in for the human's message.
             # Handle case where this is the very first message (no conversation history)
             if not cached_context and not new_context:
                 # Prepend conversation header and multi-entity header to the message block
                 final_parts.insert(0, "[CONVERSATION HISTORY]\n" + multi_entity_header)
         else:
-            # Continuation without new human message (multi-entity)
+            # Continuation without new human input (multi-entity)
             continuation_prompt = "[CONTINUATION]\nPlease continue the conversation by responding to what was said above."
             final_parts.append(continuation_prompt)
             if not cached_context and not new_context:
@@ -653,8 +663,7 @@ class AnthropicService:
         final_text = "\n\n".join(final_parts)
 
         # Handle attachments for multimodal messages
-        from app.services.attachment_service import attachment_service, has_attachments
-        if attachments and has_attachments(attachments):
+        if has_attachment_content:
             # Process attachments for the appropriate provider
             provider_str = provider.value if hasattr(provider, 'value') else str(provider) if provider else "anthropic"
             multimodal_content = attachment_service.process_attachments_for_provider(

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1146,6 +1146,11 @@ class SessionManager:
                         entity_labels=session.entity_labels,
                         responding_entity_label=session.responding_entity_label,
                         user_display_name=session.user_display_name,
+                        # Keep attachments on the current message so the file/image
+                        # content survives across tool-use iterations. Without this,
+                        # any tool call drops the attachment from the final answer's
+                        # context and the model responds as if nothing was attached.
+                        attachments=attachments,
                         provider_hint=session.provider_hint,
                     )
 

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -225,6 +225,59 @@ class TestAnthropicService:
         assert messages[2]["role"] == "user"
         assert "How are you?" in messages[2]["content"]
 
+    def test_build_messages_attachment_only_is_current_message(self, mock_encoder):
+        """An attachment-only message (no text) is a real message, not a continuation."""
+        service = AnthropicService()
+        service._encoder = mock_encoder
+
+        attachments = {
+            "images": [],
+            "files": [{
+                "filename": "notes.txt",
+                "content": "FILE_BODY_MARKER",
+                "content_type": "text",
+                "media_type": "text/plain",
+            }],
+        }
+
+        messages = service.build_messages_with_memories(
+            [], [], None, attachments=attachments
+        )
+
+        # Final user message carries the file content under the normal
+        # [CURRENT USER MESSAGE] framing, NOT a [CONTINUATION] prompt.
+        final = messages[-1]
+        assert final["role"] == "user"
+        blocks = final["content"]
+        assert isinstance(blocks, list)
+        text = "".join(b.get("text", "") for b in blocks if isinstance(b, dict))
+        assert "FILE_BODY_MARKER" in text
+        assert "[CURRENT USER MESSAGE]" in text
+        assert "[CONTINUATION]" not in text
+
+    def test_build_messages_continuation_without_message_or_attachments(self, mock_encoder):
+        """With neither text nor attachments, fall back to the continuation prompt."""
+        service = AnthropicService()
+        service._encoder = mock_encoder
+
+        context = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+
+        messages = service.build_messages_with_memories(
+            [], context, None,
+            cached_context=context, new_context=[],
+            attachments={"images": [], "files": []},
+        )
+
+        joined = "".join(
+            m["content"] if isinstance(m["content"], str)
+            else "".join(b.get("text", "") for b in m["content"] if isinstance(b, dict))
+            for m in messages
+        )
+        assert "[CONTINUATION]" in joined
+
     def test_build_messages_with_memories(self, sample_memories, mock_encoder):
         """Test building messages with memories."""
         service = AnthropicService()

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -1894,6 +1894,105 @@ class TestAgenticToolLoopMemoryOptimization:
         assert sent_messages[1][2]["role"] == "user"
 
     @pytest.mark.asyncio
+    async def test_attachments_persist_across_tool_iterations(self, db_session, sample_conversation):
+        """Attachments must stay on the current message after a tool call.
+
+        Regression test: previously the base (no-memory) message set rebuilt for
+        subsequent tool-loop iterations was built without the attachments, so any
+        tool call dropped the attached file/image from the final answer's context
+        and the model responded as if nothing was attached.
+        """
+        manager = SessionManager()
+
+        with patch("app.services.session_manager.memory_service") as mock_memory, \
+             patch("app.services.session_manager.llm_service") as mock_llm, \
+             patch("app.services.session_manager.tool_service") as mock_tool, \
+             patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.is_configured.return_value = False
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
+            mock_settings.default_temperature = 1.0
+            mock_settings.default_max_tokens = 64000
+            mock_settings.memory_token_limit = 40000
+            mock_settings.context_token_limit = 150000
+            mock_settings.tool_use_max_iterations = 10
+            mock_settings.use_memory_in_context = False
+
+            # Capture the kwargs of every build call so we can inspect attachments
+            build_calls = []
+
+            def build_messages(memories, **kwargs):
+                build_calls.append({"memories": memories, "kwargs": kwargs})
+                return [{"role": "user", "content": "msg"}]
+
+            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.count_tokens = MagicMock(return_value=100)
+
+            call_count = [0]
+
+            async def mock_stream(messages, **kwargs):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    yield {"type": "start", "model": "claude-sonnet-4-5-20250929"}
+                    yield {
+                        "type": "done",
+                        "content": "",
+                        "model": "claude-sonnet-4-5-20250929",
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                        "stop_reason": "tool_use",
+                        "content_blocks": [
+                            {"type": "tool_use", "id": "tool-1", "name": "web_search", "input": {"query": "test"}}
+                        ],
+                        "tool_use": [{"id": "tool-1", "name": "web_search", "input": {"query": "test"}}],
+                    }
+                else:
+                    yield {"type": "start", "model": "claude-sonnet-4-5-20250929"}
+                    yield {"type": "token", "content": "Done"}
+                    yield {
+                        "type": "done",
+                        "content": "Done",
+                        "model": "claude-sonnet-4-5-20250929",
+                        "usage": {"input_tokens": 20, "output_tokens": 10},
+                        "stop_reason": "end_turn",
+                        "content_blocks": [{"type": "text", "text": "Done"}],
+                    }
+
+            mock_llm.send_message_stream = mock_stream
+
+            mock_tool_result = MagicMock()
+            mock_tool_result.tool_use_id = "tool-1"
+            mock_tool_result.content = "Search results"
+            mock_tool_result.is_error = False
+            mock_tool.execute_tool = AsyncMock(return_value=mock_tool_result)
+
+            attachments = {
+                "images": [],
+                "files": [{
+                    "filename": "notes.txt",
+                    "content": "the attached file body",
+                    "content_type": "text",
+                    "media_type": "text/plain",
+                }],
+            }
+
+            session = manager.create_session(sample_conversation.id)
+
+            events = []
+            async for event in manager.process_message_stream(
+                session,
+                "Summarize the attached file",
+                db_session,
+                tool_schemas=[{"name": "web_search"}],
+                attachments=attachments,
+            ):
+                events.append(event)
+
+        # Two build calls: iteration 1 (with attachments) and the lazily-built
+        # base message set for iteration 2 (also with attachments).
+        assert len(build_calls) == 2
+        for call in build_calls:
+            assert call["kwargs"].get("attachments") == attachments
+
+    @pytest.mark.asyncio
     async def test_tool_exchanges_accumulated_correctly(self, db_session, sample_conversation):
         """Test that tool exchanges are properly accumulated across iterations."""
         manager = SessionManager()


### PR DESCRIPTION
When tools are enabled (the default), the model's first iteration sees the
attached file/image, but if it makes any tool call, the base message set
rebuilt for subsequent iterations was constructed without the attachments.
The final answer was then generated with the attachment missing from
context, so the model responded as if nothing was attached.

Pass attachments through when lazily building base_messages_no_memories so
the current message keeps its file/image content across all tool-loop
iterations. Adds a regression test.