### PR TITLE
Skip non-string content blocks in message matching logic

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -884,6 +884,10 @@ async def regenerate_response(data: RegenerateRequest):
                         if msg.get("role") == "assistant":
                             # Check if content matches (may have speaker label prefix)
                             ctx_content = msg.get("content", "")
+                            # Tool-exchange messages store content as a list of blocks;
+                            # skip those since they can't match a plain-text assistant message.
+                            if not isinstance(ctx_content, str):
+                                continue
                             if assistant_content and (ctx_content == assistant_content or ctx_content.endswith(assistant_content)):
                                 truncate_index = i
                                 break
@@ -894,6 +898,10 @@ async def regenerate_response(data: RegenerateRequest):
                         # The context uses "user" role, but we stored "human" in DB
                         if msg.get("role") == "user":
                             ctx_content = msg.get("content", "")
+                            # Tool-exchange messages store content as a list of blocks;
+                            # skip those since they can't match a plain-text human message.
+                            if not isinstance(ctx_content, str):
+                                continue
                             # Check for exact match or labeled match (multi-entity format)
                             if ctx_content == user_message_content:
                                 truncate_index = i


### PR DESCRIPTION
## Summary
Fix message matching logic in the chat stream handler to properly skip tool-exchange messages that store content as structured blocks rather than plain text strings.

## Changes
- Add type checks before comparing message content in the assistant message matching loop (line 887–890)
- Add type checks before comparing message content in the user message matching loop (line 901–904)
- Both checks skip messages where `content` is not a string, since tool-exchange messages store content as a list of blocks and cannot match plain-text messages

## Details
The `generate_stream()` function searches conversation history to find and truncate duplicate messages. However, tool-exchange messages (per CLAUDE.md point 5) store their content as JSON blocks in `Message.content` rather than as plain strings. The previous logic would attempt string comparison against these block structures, leading to incorrect matching behavior.

The fix adds explicit `isinstance(ctx_content, str)` checks to skip non-string content before attempting equality comparisons, ensuring only plain-text messages participate in the deduplication logic.

https://claude.ai/code/session_01RvATy37C3bVn6Kv5trp6AA