### PR TITLE
Move per-entity system prompts to backend (entity_settings table)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,6 @@ from app.models.conversation import Conversation, ConversationType
 from app.models.message import Message, MessageRole
 from app.models.conversation_memory_link import ConversationMemoryLink
 from app.models.conversation_entity import ConversationEntity
+from app.models.entity_setting import EntitySetting
 
-__all__ = ["Conversation", "ConversationType", "Message", "MessageRole", "ConversationMemoryLink", "ConversationEntity"]
+__all__ = ["Conversation", "ConversationType", "Message", "MessageRole", "ConversationMemoryLink", "ConversationEntity", "EntitySetting"]

--- a/backend/app/models/entity_setting.py
+++ b/backend/app/models/entity_setting.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Optional
+from sqlalchemy import String, Text, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+class EntitySetting(Base):
+    """
+    Per-entity, user-editable settings that must survive across sessions.
+
+    Entities themselves are defined in config (PINECONE_INDEXES), which is
+    immutable at runtime. This table holds the mutable per-entity preferences
+    the researcher sets in the UI — currently the entity's default system
+    prompt — keyed by the entity's Pinecone index name.
+    """
+    __tablename__ = "entity_settings"
+
+    # Matches Conversation.entity_id / EntityConfig.index_name (the Pinecone index name)
+    entity_id: Mapped[str] = mapped_column(String(100), primary_key=True)
+    # Default system prompt for this entity. NULL means "no system prompt".
+    system_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True
+    )

--- a/backend/app/routes/entities.py
+++ b/backend/app/routes/entities.py
@@ -1,8 +1,12 @@
-from typing import List, Optional
-from fastapi import APIRouter, HTTPException
+from typing import List, Optional, Dict
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from pydantic import BaseModel
 
 from app.config import settings
+from app.database import get_db
+from app.models import EntitySetting
 from app.services import memory_service
 
 router = APIRouter(prefix="/api/entities", tags=["entities"])
@@ -15,6 +19,8 @@ class EntityResponse(BaseModel):
     llm_provider: str = "anthropic"
     default_model: Optional[str] = None
     is_default: bool = False
+    # Persisted per-entity default system prompt (None means no prompt).
+    system_prompt: Optional[str] = None
 
 
 class EntityListResponse(BaseModel):
@@ -22,13 +28,31 @@ class EntityListResponse(BaseModel):
     default_entity: Optional[str] = None
 
 
+class SystemPromptUpdate(BaseModel):
+    # None / empty clears the entity's system prompt.
+    system_prompt: Optional[str] = None
+
+
+class SystemPromptResponse(BaseModel):
+    entity_id: str
+    system_prompt: Optional[str] = None
+
+
+async def _load_system_prompts(db: AsyncSession) -> Dict[str, Optional[str]]:
+    """Load all persisted per-entity system prompts, keyed by entity_id."""
+    result = await db.execute(select(EntitySetting))
+    return {row.entity_id: row.system_prompt for row in result.scalars().all()}
+
+
 @router.get("/", response_model=EntityListResponse)
-async def list_entities():
+async def list_entities(db: AsyncSession = Depends(get_db)):
     """
     List all configured AI entities.
 
     Each entity corresponds to a separate Pinecone index with its own
     conversation history and memory, and can have its own model provider/model.
+    Each entity also carries its persisted default system prompt so the UI can
+    render it without keeping any client-side copy.
     """
     entities = settings.get_entities()
     default_entity = settings.get_default_entity()
@@ -40,6 +64,8 @@ async def list_entities():
             default_entity=None,
         )
 
+    system_prompts = await _load_system_prompts(db)
+
     return EntityListResponse(
         entities=[
             EntityResponse(
@@ -49,6 +75,7 @@ async def list_entities():
                 llm_provider=entity.llm_provider,
                 default_model=entity.default_model,
                 is_default=(entity.index_name == default_entity.index_name),
+                system_prompt=system_prompts.get(entity.index_name),
             )
             for entity in entities
         ],
@@ -57,7 +84,7 @@ async def list_entities():
 
 
 @router.get("/{entity_id}", response_model=EntityResponse)
-async def get_entity(entity_id: str):
+async def get_entity(entity_id: str, db: AsyncSession = Depends(get_db)):
     """Get a specific entity by its index name."""
     entity = settings.get_entity_by_index(entity_id)
 
@@ -65,6 +92,7 @@ async def get_entity(entity_id: str):
         raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
 
     default_entity = settings.get_default_entity()
+    setting = await db.get(EntitySetting, entity_id)
 
     return EntityResponse(
         index_name=entity.index_name,
@@ -73,7 +101,41 @@ async def get_entity(entity_id: str):
         llm_provider=entity.llm_provider,
         default_model=entity.default_model,
         is_default=(entity.index_name == default_entity.index_name),
+        system_prompt=setting.system_prompt if setting else None,
     )
+
+
+@router.put("/{entity_id}/system-prompt", response_model=SystemPromptResponse)
+async def update_entity_system_prompt(
+    entity_id: str,
+    payload: SystemPromptUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Set (or clear) the persisted default system prompt for an entity.
+
+    This is the source of truth for an entity's system prompt — the UI only
+    sends the text the researcher typed; persistence lives here so the prompt
+    survives across browsers and sessions.
+    """
+    if not settings.get_entity_by_index(entity_id):
+        raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
+
+    # Normalize empty strings to NULL so "no prompt" is represented one way.
+    prompt = payload.system_prompt
+    if prompt is not None and prompt.strip() == "":
+        prompt = None
+
+    setting = await db.get(EntitySetting, entity_id)
+    if setting is None:
+        setting = EntitySetting(entity_id=entity_id, system_prompt=prompt)
+        db.add(setting)
+    else:
+        setting.system_prompt = prompt
+
+    await db.commit()
+
+    return SystemPromptResponse(entity_id=entity_id, system_prompt=prompt)
 
 
 @router.get("/{entity_id}/status")

--- a/backend/tests/test_entities_routes.py
+++ b/backend/tests/test_entities_routes.py
@@ -5,12 +5,63 @@ Tests cover:
 - GET /api/entities/ - List all configured entities
 - GET /api/entities/{entity_id} - Get specific entity
 - GET /api/entities/{entity_id}/status - Get entity Pinecone status
+- PUT /api/entities/{entity_id}/system-prompt - Persist entity system prompt
 """
 
 import pytest
 from unittest.mock import patch, MagicMock, PropertyMock
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
 from app.config import EntityConfig
+from app.database import Base, get_db
+from app.models import EntitySetting
+
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+async def entities_client():
+    """
+    Async test client for the entities router backed by an in-memory SQLite DB
+    with all tables created. The list/get endpoints read persisted system
+    prompts from the entity_settings table, so a real DB is required.
+
+    Yields (client, session_factory); the factory lets tests seed/inspect rows.
+    Everything runs in a single event loop, avoiding cross-loop async-engine
+    issues that a sync TestClient would otherwise hit with in-memory SQLite.
+    """
+    from app.routes.entities import router
+
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        echo=False,
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = override_get_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, session_factory
+
+    await engine.dispose()
 
 
 # ============================================================
@@ -37,15 +88,9 @@ class TestListEntities:
     """Tests for listing all configured entities."""
 
     @patch("app.routes.entities.settings")
-    def test_list_entities_success(self, mock_settings):
+    async def test_list_entities_success(self, mock_settings, entities_client):
         """Should return list of configured entities."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        client, _ = entities_client
 
         entities = [
             _make_entity("claude-test", "Claude", "Primary", "anthropic"),
@@ -54,7 +99,7 @@ class TestListEntities:
         mock_settings.get_entities.return_value = entities
         mock_settings.get_default_entity.return_value = entities[0]
 
-        response = client.get("/api/entities/")
+        response = await client.get("/api/entities/")
         assert response.status_code == 200
         data = response.json()
 
@@ -64,20 +109,14 @@ class TestListEntities:
         assert data["entities"][1]["is_default"] is False
 
     @patch("app.routes.entities.settings")
-    def test_list_entities_empty(self, mock_settings):
+    async def test_list_entities_empty(self, mock_settings, entities_client):
         """Should return empty list when no entities configured."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        client, _ = entities_client
 
         mock_settings.get_entities.return_value = []
         mock_settings.get_default_entity.return_value = None
 
-        response = client.get("/api/entities/")
+        response = await client.get("/api/entities/")
         assert response.status_code == 200
         data = response.json()
 
@@ -85,15 +124,9 @@ class TestListEntities:
         assert data["default_entity"] is None
 
     @patch("app.routes.entities.settings")
-    def test_list_entities_with_llm_providers(self, mock_settings):
+    async def test_list_entities_with_llm_providers(self, mock_settings, entities_client):
         """Should include LLM provider information."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        client, _ = entities_client
 
         entities = [
             _make_entity("claude-test", "Claude", "Test", "anthropic", "claude-sonnet-4-5-20250929"),
@@ -102,13 +135,37 @@ class TestListEntities:
         mock_settings.get_entities.return_value = entities
         mock_settings.get_default_entity.return_value = entities[0]
 
-        response = client.get("/api/entities/")
+        response = await client.get("/api/entities/")
         data = response.json()
 
         assert data["entities"][0]["llm_provider"] == "anthropic"
         assert data["entities"][0]["default_model"] == "claude-sonnet-4-5-20250929"
         assert data["entities"][1]["llm_provider"] == "openai"
         assert data["entities"][1]["default_model"] == "gpt-4o"
+
+    @patch("app.routes.entities.settings")
+    async def test_list_entities_includes_persisted_system_prompt(self, mock_settings, entities_client):
+        """Should include each entity's persisted system prompt (None if unset)."""
+        client, session_factory = entities_client
+
+        entities = [
+            _make_entity("claude-test", "Claude", "Primary", "anthropic"),
+            _make_entity("gpt-test", "GPT", "OpenAI", "openai", "gpt-4o"),
+        ]
+        mock_settings.get_entities.return_value = entities
+        mock_settings.get_default_entity.return_value = entities[0]
+
+        # Seed a stored prompt for one entity only.
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", system_prompt="Be Claude"))
+            await session.commit()
+
+        response = await client.get("/api/entities/")
+        data = response.json()
+
+        prompts = {e["index_name"]: e["system_prompt"] for e in data["entities"]}
+        assert prompts["claude-test"] == "Be Claude"
+        assert prompts["gpt-test"] is None
 
 
 # ============================================================
@@ -119,63 +176,157 @@ class TestGetEntity:
     """Tests for getting a specific entity."""
 
     @patch("app.routes.entities.settings")
-    def test_get_entity_success(self, mock_settings):
+    async def test_get_entity_success(self, mock_settings, entities_client):
         """Should return entity details."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        client, _ = entities_client
 
         entity = _make_entity("claude-test", "Claude Test", "Primary", "anthropic")
         mock_settings.get_entity_by_index.return_value = entity
         mock_settings.get_default_entity.return_value = entity
 
-        response = client.get("/api/entities/claude-test")
+        response = await client.get("/api/entities/claude-test")
         assert response.status_code == 200
         data = response.json()
 
         assert data["index_name"] == "claude-test"
         assert data["label"] == "Claude Test"
         assert data["is_default"] is True
+        assert data["system_prompt"] is None
 
     @patch("app.routes.entities.settings")
-    def test_get_entity_not_found(self, mock_settings):
-        """Should return 404 for unknown entity."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
+    async def test_get_entity_returns_persisted_system_prompt(self, mock_settings, entities_client):
+        """Should return the stored system prompt for the entity."""
+        client, session_factory = entities_client
 
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        entity = _make_entity("claude-test", "Claude Test", "Primary", "anthropic")
+        mock_settings.get_entity_by_index.return_value = entity
+        mock_settings.get_default_entity.return_value = entity
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", system_prompt="Persisted prompt"))
+            await session.commit()
+
+        response = await client.get("/api/entities/claude-test")
+        data = response.json()
+        assert data["system_prompt"] == "Persisted prompt"
+
+    @patch("app.routes.entities.settings")
+    async def test_get_entity_not_found(self, mock_settings, entities_client):
+        """Should return 404 for unknown entity."""
+        client, _ = entities_client
 
         mock_settings.get_entity_by_index.return_value = None
 
-        response = client.get("/api/entities/nonexistent")
+        response = await client.get("/api/entities/nonexistent")
         assert response.status_code == 404
 
     @patch("app.routes.entities.settings")
-    def test_get_entity_not_default(self, mock_settings):
+    async def test_get_entity_not_default(self, mock_settings, entities_client):
         """Should show is_default=False for non-default entity."""
-        from fastapi.testclient import TestClient
-        from app.routes.entities import router
-        from fastapi import FastAPI
-
-        app = FastAPI()
-        app.include_router(router)
-        client = TestClient(app)
+        client, _ = entities_client
 
         entity = _make_entity("gpt-test", "GPT", "Secondary", "openai")
         default = _make_entity("claude-test", "Claude", "Primary", "anthropic")
         mock_settings.get_entity_by_index.return_value = entity
         mock_settings.get_default_entity.return_value = default
 
-        response = client.get("/api/entities/gpt-test")
+        response = await client.get("/api/entities/gpt-test")
         data = response.json()
         assert data["is_default"] is False
+
+
+# ============================================================
+# Tests for PUT /api/entities/{entity_id}/system-prompt
+# ============================================================
+
+class TestUpdateEntitySystemPrompt:
+    """Tests for persisting an entity's default system prompt."""
+
+    @patch("app.routes.entities.settings")
+    async def test_create_system_prompt(self, mock_settings, entities_client):
+        """Should persist a new system prompt for the entity."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        response = await client.put(
+            "/api/entities/claude-test/system-prompt",
+            json={"system_prompt": "You are Claude."},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"entity_id": "claude-test", "system_prompt": "You are Claude."}
+
+        # Verify it was persisted.
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting is not None
+            assert setting.system_prompt == "You are Claude."
+
+    @patch("app.routes.entities.settings")
+    async def test_update_existing_system_prompt(self, mock_settings, entities_client):
+        """Should overwrite an existing system prompt."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", system_prompt="Old"))
+            await session.commit()
+
+        response = await client.put(
+            "/api/entities/claude-test/system-prompt",
+            json={"system_prompt": "New"},
+        )
+        assert response.status_code == 200
+        assert response.json()["system_prompt"] == "New"
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.system_prompt == "New"
+
+    @patch("app.routes.entities.settings")
+    async def test_clear_system_prompt_with_null(self, mock_settings, entities_client):
+        """Should clear the prompt when null is sent."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", system_prompt="Existing"))
+            await session.commit()
+
+        response = await client.put(
+            "/api/entities/claude-test/system-prompt",
+            json={"system_prompt": None},
+        )
+        assert response.status_code == 200
+        assert response.json()["system_prompt"] is None
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.system_prompt is None
+
+    @patch("app.routes.entities.settings")
+    async def test_blank_string_normalized_to_null(self, mock_settings, entities_client):
+        """Should normalize a whitespace-only prompt to NULL."""
+        client, _ = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        response = await client.put(
+            "/api/entities/claude-test/system-prompt",
+            json={"system_prompt": "   "},
+        )
+        assert response.status_code == 200
+        assert response.json()["system_prompt"] is None
+
+    @patch("app.routes.entities.settings")
+    async def test_update_unknown_entity_returns_404(self, mock_settings, entities_client):
+        """Should 404 when the entity is not configured."""
+        client, _ = entities_client
+        mock_settings.get_entity_by_index.return_value = None
+
+        response = await client.put(
+            "/api/entities/nonexistent/system-prompt",
+            json={"system_prompt": "x"},
+        )
+        assert response.status_code == 404
 
 
 # ============================================================

--- a/frontend/js/__tests__/entities.test.js
+++ b/frontend/js/__tests__/entities.test.js
@@ -106,6 +106,36 @@ describe('Entities Module', () => {
 
             expect(mockCallbacks.onEntityLoaded).toHaveBeenCalled();
         });
+
+        it('should populate entitySystemPrompts cache from the backend response', async () => {
+            window.api.listEntities = vi.fn(() => Promise.resolve({
+                entities: [
+                    { index_name: 'entity-1', label: 'Claude', system_prompt: 'Be Claude' },
+                    { index_name: 'entity-2', label: 'GPT', system_prompt: null },
+                ],
+                default_entity: 'entity-1',
+            }));
+
+            await loadEntities();
+
+            expect(state.entitySystemPrompts['entity-1']).toBe('Be Claude');
+            expect(state.entitySystemPrompts['entity-2']).toBeNull();
+        });
+
+        it('should apply the selected entity\'s persisted prompt to settings on load', async () => {
+            state.selectedEntityId = 'entity-1';
+            state.settings.systemPrompt = 'stale';
+            window.api.listEntities = vi.fn(() => Promise.resolve({
+                entities: [
+                    { index_name: 'entity-1', label: 'Claude', system_prompt: 'Be Claude' },
+                ],
+                default_entity: 'entity-1',
+            }));
+
+            await loadEntities();
+
+            expect(state.settings.systemPrompt).toBe('Be Claude');
+        });
     });
 
     describe('getEntityLabel', () => {

--- a/frontend/js/__tests__/settings.test.js
+++ b/frontend/js/__tests__/settings.test.js
@@ -199,6 +199,39 @@ describe('Settings Module', () => {
 
             expect(state.settings.systemPrompt).toBeNull();
         });
+
+        it('should persist the system prompt to the backend for the selected entity', async () => {
+            state.selectedEntityId = 'claude-test';
+            state.entitySystemPrompts = {};
+            window.api.updateEntitySystemPrompt = vi.fn(() => Promise.resolve({ system_prompt: 'New prompt' }));
+            mockElements.systemPromptInput.value = 'New prompt';
+
+            await applySettings();
+
+            expect(window.api.updateEntitySystemPrompt).toHaveBeenCalledWith('claude-test', 'New prompt');
+            expect(state.entitySystemPrompts['claude-test']).toBe('New prompt');
+        });
+
+        it('should not call the backend when the prompt is unchanged', async () => {
+            state.selectedEntityId = 'claude-test';
+            state.entitySystemPrompts = { 'claude-test': 'Same prompt' };
+            window.api.updateEntitySystemPrompt = vi.fn(() => Promise.resolve({}));
+            mockElements.systemPromptInput.value = 'Same prompt';
+
+            await applySettings();
+
+            expect(window.api.updateEntitySystemPrompt).not.toHaveBeenCalled();
+        });
+
+        it('should not persist a system prompt in multi-entity mode', async () => {
+            state.selectedEntityId = 'multi-entity';
+            window.api.updateEntitySystemPrompt = vi.fn(() => Promise.resolve({}));
+            mockElements.systemPromptInput.value = 'Whatever';
+
+            await applySettings();
+
+            expect(window.api.updateEntitySystemPrompt).not.toHaveBeenCalled();
+        });
     });
 
     describe('loadPreset', () => {

--- a/frontend/js/__tests__/setup.js
+++ b/frontend/js/__tests__/setup.js
@@ -165,6 +165,7 @@ global.window.api = {
     speak: vi.fn(() => Promise.resolve(new Blob())),
     transcribe: vi.fn(() => Promise.resolve({ text: '' })),
     getPresets: vi.fn(() => Promise.resolve({})),
+    updateEntitySystemPrompt: vi.fn(() => Promise.resolve({ system_prompt: null })),
     archiveConversation: vi.fn(() => Promise.resolve()),
     unarchiveConversation: vi.fn(() => Promise.resolve()),
     getArchivedConversations: vi.fn(() => Promise.resolve([])),

--- a/frontend/js/__tests__/state.test.js
+++ b/frontend/js/__tests__/state.test.js
@@ -9,8 +9,6 @@ import {
     resetMemoryState,
     resetAttachments,
     clearAudioCache,
-    loadEntitySystemPromptsFromStorage,
-    saveEntitySystemPromptsToStorage,
     loadSelectedVoiceFromStorage,
     saveSelectedVoiceToStorage,
     loadResearcherName,
@@ -168,66 +166,10 @@ describe('State Module', () => {
         });
     });
 
-    describe('loadEntitySystemPromptsFromStorage', () => {
-        it('should load saved prompts from localStorage', () => {
-            const savedPrompts = { 'entity-1': 'prompt 1', 'entity-2': 'prompt 2' };
-            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
-
-            loadEntitySystemPromptsFromStorage();
-
-            expect(state.entitySystemPrompts).toEqual(savedPrompts);
-        });
-
-        it('should apply prompt for selected entity', () => {
-            const savedPrompts = { 'entity-1': 'entity 1 prompt' };
-            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
-            state.selectedEntityId = 'entity-1';
-
-            loadEntitySystemPromptsFromStorage();
-
-            expect(state.settings.systemPrompt).toBe('entity 1 prompt');
-        });
-
-        it('should not apply prompt for multi-entity mode', () => {
-            const savedPrompts = { 'multi-entity': 'multi prompt' };
-            localStorage.setItem('entity_system_prompts', JSON.stringify(savedPrompts));
-            state.selectedEntityId = 'multi-entity';
-            state.settings.systemPrompt = 'original';
-
-            loadEntitySystemPromptsFromStorage();
-
-            expect(state.settings.systemPrompt).toBe('original');
-        });
-
-        it('should handle missing localStorage gracefully', () => {
-            expect(() => loadEntitySystemPromptsFromStorage()).not.toThrow();
-        });
-
-        it('should handle invalid JSON gracefully', () => {
-            localStorage.setItem('entity_system_prompts', 'invalid json');
-            expect(() => loadEntitySystemPromptsFromStorage()).not.toThrow();
-        });
-    });
-
-    describe('saveEntitySystemPromptsToStorage', () => {
-        it('should save prompts to localStorage', () => {
-            state.entitySystemPrompts = { 'entity-1': 'prompt 1' };
-
-            saveEntitySystemPromptsToStorage();
-
-            expect(localStorage.setItem).toHaveBeenCalledWith(
-                'entity_system_prompts',
-                JSON.stringify({ 'entity-1': 'prompt 1' })
-            );
-        });
-
-        it('should handle empty prompts', () => {
-            state.entitySystemPrompts = {};
-
-            expect(() => saveEntitySystemPromptsToStorage()).not.toThrow();
-            expect(localStorage.setItem).toHaveBeenCalled();
-        });
-    });
+    // Per-entity system prompts are no longer persisted in localStorage. The
+    // backend (entity_settings table / /api/entities/{id}/system-prompt) is the
+    // source of truth, and state.entitySystemPrompts is populated from the
+    // entities API response. See entities.test.js / settings.test.js.
 
     describe('loadSelectedVoiceFromStorage', () => {
         it('should load saved voice ID from localStorage', () => {

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -61,6 +61,15 @@ class ApiClient {
         return this.request(`/entities/${entityId}/status`);
     }
 
+    // Persist an entity's default system prompt (backend is the source of
+    // truth). Pass null/empty to clear it.
+    async updateEntitySystemPrompt(entityId, systemPrompt) {
+        return this.request(`/entities/${entityId}/system-prompt`, {
+            method: 'PUT',
+            body: { system_prompt: systemPrompt },
+        });
+    }
+
     // Conversations
     async listConversations(limit = 50, offset = 0, entityId = null) {
         let url = `/conversations/?limit=${limit}&offset=${offset}`;

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -4,7 +4,7 @@
  */
 
 // Import modules
-import { state, resetMemoryState, loadEntitySystemPromptsFromStorage, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName } from './modules/state.js';
+import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
 import { showToast, showLoading, setToastContainer, escapeHtml, renderMarkdown, truncateText, stripMarkdown } from './modules/utils.js';
 import { loadTheme, getCurrentTheme, setTheme } from './modules/theme.js';
 import { setElements as setModalElements, showModal, hideModal, closeActiveModal, isModalOpen, closeAllDropdowns } from './modules/modals.js';
@@ -569,8 +569,7 @@ class App {
             this.elements.themeSelect.value = getCurrentTheme();
         }
 
-        // Load saved state from localStorage
-        loadEntitySystemPromptsFromStorage();
+        // Load saved state from localStorage (system prompts are backend-owned)
         loadEntityModelsFromStorage();
         loadSelectedVoiceFromStorage();
         const savedResearcherName = loadResearcherName();
@@ -587,6 +586,10 @@ class App {
         // Load entities and conversations
         await loadEntities();
 
+        // One-time migration: lift any prompts a previous version stored in
+        // localStorage up to the backend (now the source of truth).
+        await this.migrateLegacyEntityPrompts();
+
         // Check TTS status
         await checkTTSStatus();
 
@@ -595,6 +598,51 @@ class App {
 
         // Load GitHub repos info
         await this.loadGitHubReposInfo();
+    }
+
+    /**
+     * One-time migration of per-entity system prompts from localStorage to the
+     * backend. Earlier versions persisted prompts client-side, which lost them
+     * across browsers/sessions. We push any locally-saved prompt the backend
+     * doesn't already have, then clear the localStorage key. Runs after
+     * loadEntities() so state.entitySystemPrompts reflects the backend.
+     */
+    async migrateLegacyEntityPrompts() {
+        let legacy;
+        try {
+            const raw = localStorage.getItem(LEGACY_ENTITY_PROMPTS_KEY);
+            if (!raw) return;
+            legacy = JSON.parse(raw);
+        } catch (e) {
+            localStorage.removeItem(LEGACY_ENTITY_PROMPTS_KEY);
+            return;
+        }
+        if (!legacy || typeof legacy !== 'object') {
+            localStorage.removeItem(LEGACY_ENTITY_PROMPTS_KEY);
+            return;
+        }
+
+        for (const [entityId, prompt] of Object.entries(legacy)) {
+            const isKnown = state.entities.some(e => e.index_name === entityId);
+            const backendHasPrompt = state.entitySystemPrompts[entityId] != null;
+            if (isKnown && !backendHasPrompt && prompt) {
+                try {
+                    await api.updateEntitySystemPrompt(entityId, prompt);
+                    state.entitySystemPrompts[entityId] = prompt;
+                } catch (e) {
+                    console.error('Failed to migrate entity system prompt:', e);
+                    // Leave the localStorage key intact to retry on next load.
+                    return;
+                }
+            }
+        }
+
+        localStorage.removeItem(LEGACY_ENTITY_PROMPTS_KEY);
+
+        // Re-apply the active entity's prompt in case it was just migrated.
+        if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
+            state.settings.systemPrompt = state.entitySystemPrompts[state.selectedEntityId] ?? null;
+        }
     }
 
     /**

--- a/frontend/js/modules/conversations.js
+++ b/frontend/js/modules/conversations.js
@@ -3,7 +3,7 @@
  * Handles conversation listing, creation, loading, and management
  */
 
-import { state, resetMemoryState, saveEntitySystemPromptsToStorage } from './state.js';
+import { state, resetMemoryState } from './state.js';
 import { showToast, escapeHtml, escapeForInlineHandler } from './utils.js';
 import { showModal, hideModal, closeAllDropdowns } from './modals.js';
 import { getEntityLabel, updateModelSelectorMultiEntityState } from './entities.js';

--- a/frontend/js/modules/entities.js
+++ b/frontend/js/modules/entities.js
@@ -3,7 +3,7 @@
  * Handles entity loading, selection, and multi-entity conversations
  */
 
-import { state, saveEntitySystemPromptsToStorage } from './state.js';
+import { state } from './state.js';
 import { showToast, escapeHtml } from './utils.js';
 import { showModal, hideModal, closeAllDropdowns } from './modals.js';
 
@@ -52,6 +52,14 @@ export async function loadEntities() {
         console.log('[Entities] Parsed entities:', entities);
         state.entities = entities;
 
+        // The backend is the source of truth for per-entity system prompts.
+        // Rebuild the in-memory cache from the response so prompts survive
+        // across sessions/browsers (no client-side persistence).
+        state.entitySystemPrompts = {};
+        entities.forEach(entity => {
+            state.entitySystemPrompts[entity.index_name] = entity.system_prompt ?? null;
+        });
+
         // Update entity selector
         console.log('[Entities] entitySelect element:', elements.entitySelect);
         if (elements.entitySelect) {
@@ -88,6 +96,13 @@ export async function loadEntities() {
         // Restore entity selection in the dropdown
         if (state.selectedEntityId && elements.entitySelect) {
             elements.entitySelect.value = state.selectedEntityId;
+        }
+
+        // Apply the selected entity's persisted system prompt to the active
+        // settings. Setting the dropdown's .value above does not fire a change
+        // event, so handleEntityChange won't run on initial load — do it here.
+        if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
+            state.settings.systemPrompt = state.entitySystemPrompts[state.selectedEntityId] ?? null;
         }
 
         updateEntityDescription();

--- a/frontend/js/modules/settings.js
+++ b/frontend/js/modules/settings.js
@@ -3,7 +3,7 @@
  * Handles settings modal, configuration presets, and settings application
  */
 
-import { state, saveEntitySystemPromptsToStorage, saveEntityModelsToStorage, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName } from './state.js';
+import { state, saveEntityModelsToStorage, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName } from './state.js';
 import { showToast } from './utils.js';
 import { showModal, hideModal } from './modals.js';
 import { setTheme } from './theme.js';
@@ -40,7 +40,7 @@ export function setCallbacks(cbs) {
 /**
  * Apply settings from the settings modal
  */
-export function applySettings() {
+export async function applySettings() {
     state.settings.model = elements.modelSelect.value;
     state.settings.temperature = parseFloat(elements.temperatureInput.value);
     state.settings.maxTokens = parseInt(elements.maxTokensInput.value);
@@ -52,14 +52,26 @@ export function applySettings() {
     state.settings.researcherName = elements.researcherNameInput.value.trim() || '';
     saveResearcherName(state.settings.researcherName);
 
-    // Save system prompt and model per-entity (for single-entity mode)
+    // Persist the system prompt per-entity on the backend (the source of
+    // truth) so it survives across sessions and browsers. The model stays a
+    // client-side preference in localStorage.
     if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
-        state.entitySystemPrompts[state.selectedEntityId] = state.settings.systemPrompt;
         state.entityModels[state.selectedEntityId] = state.settings.model;
+
+        const entityId = state.selectedEntityId;
+        const newPrompt = state.settings.systemPrompt;
+        if (state.entitySystemPrompts[entityId] !== newPrompt) {
+            state.entitySystemPrompts[entityId] = newPrompt;
+            try {
+                await api.updateEntitySystemPrompt(entityId, newPrompt);
+            } catch (error) {
+                console.error('Failed to save entity system prompt:', error);
+                showToast('Failed to save system prompt', 'error');
+            }
+        }
     }
 
-    // Persist entity system prompts and models to localStorage
-    saveEntitySystemPromptsToStorage();
+    // Persist per-entity model selection to localStorage
     saveEntityModelsToStorage();
 
     // Apply theme

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -139,36 +139,14 @@ export function clearAudioCache() {
     state.audioCache.clear();
 }
 
-/**
- * Load entity system prompts from localStorage
- */
-export function loadEntitySystemPromptsFromStorage() {
-    try {
-        const saved = localStorage.getItem('entity_system_prompts');
-        if (saved) {
-            state.entitySystemPrompts = JSON.parse(saved);
-            // If we have a selected entity, apply its system prompt
-            if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
-                if (state.entitySystemPrompts[state.selectedEntityId] !== undefined) {
-                    state.settings.systemPrompt = state.entitySystemPrompts[state.selectedEntityId];
-                }
-            }
-        }
-    } catch (e) {
-        console.warn('Failed to load entity system prompts:', e);
-    }
-}
-
-/**
- * Save entity system prompts to localStorage
- */
-export function saveEntitySystemPromptsToStorage() {
-    try {
-        localStorage.setItem('entity_system_prompts', JSON.stringify(state.entitySystemPrompts));
-    } catch (e) {
-        console.warn('Failed to save entity system prompts:', e);
-    }
-}
+// NOTE: Per-entity system prompts are NOT stored client-side. The backend
+// (entity_settings table, /api/entities/{id}/system-prompt) is the source of
+// truth; the cache in state.entitySystemPrompts is populated from the entities
+// API response on load. See modules/entities.js and modules/settings.js.
+//
+// LEGACY_ENTITY_PROMPTS_KEY is only read once at startup to migrate any
+// prompts a previous version saved in localStorage up to the backend.
+export const LEGACY_ENTITY_PROMPTS_KEY = 'entity_system_prompts';
 
 /**
  * Load entity models from localStorage


### PR DESCRIPTION
## Summary

Migrates per-entity system prompts from client-side localStorage to the backend as the source of truth. Prompts are now persisted in a new `entity_settings` table and managed via a new `PUT /api/entities/{entity_id}/system-prompt` endpoint. This ensures prompts survive across browsers and sessions, and simplifies the frontend by removing client-side persistence logic.

## Key Changes

**Backend:**
- Added `EntitySetting` model (`app/models/entity_setting.py`) with `entity_id` (PK) and `system_prompt` fields
- New `PUT /api/entities/{entity_id}/system-prompt` endpoint to create/update/clear per-entity prompts
  - Normalizes whitespace-only strings to `NULL`
  - Returns 404 if entity is not configured
- Updated `GET /api/entities/` and `GET /api/entities/{entity_id}` to include `system_prompt` field from the database
- Added async test fixture (`entities_client`) backed by in-memory SQLite for integration testing
- Comprehensive test coverage for prompt CRUD operations and edge cases

**Frontend:**
- Removed `loadEntitySystemPromptsFromStorage()` and `saveEntitySystemPromptsToStorage()` from `state.js`
- Updated `applySettings()` to call `api.updateEntitySystemPrompt()` when prompt changes (only for single-entity mode)
- Updated `loadEntities()` to populate `state.entitySystemPrompts` cache from the API response
- Added one-time migration in `App.migrateLegacyEntityPrompts()` to push any locally-saved prompts to the backend on first load, then clear localStorage
- Updated `entities.js` and `settings.js` to use the backend as the source of truth
- Removed localStorage persistence calls from `conversations.js`
- Added `api.updateEntitySystemPrompt()` method

**Tests:**
- Removed localStorage-based tests for prompt persistence from `state.test.js`
- Added backend integration tests for prompt CRUD, normalization, and 404 handling
- Added frontend tests verifying backend persistence and multi-entity mode behavior
- Updated mock setup to include `updateEntitySystemPrompt` API stub

## Implementation Details

- Prompts are keyed by `entity_id` (the Pinecone index name), matching `Conversation.entity_id` and `EntityConfig.index_name`
- The migration runs after `loadEntities()` so the backend state is known before pushing legacy prompts
- Whitespace-only prompts are normalized to `NULL` to ensure a single representation of "no prompt"
- Multi-entity mode does not persist prompts (only single-entity selections do)
- The in-memory `state.entitySystemPrompts` cache is rebuilt from the API response on each load, ensuring consistency with the backend

https://claude.ai/code/session_01VvsFFzN9PWgf9K32zrYwxV