### PR TITLE
Add Claude Fable 5 and MiniMax M3 model support

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -367,6 +367,7 @@ class Settings(BaseSettings):
     # the provider APIs, so new models should work automatically when released.
     #
     # ANTHROPIC MODELS:
+    #   - claude-fable-5
     #   - claude-opus-4-8
     #   - claude-opus-4-7
     #   - claude-opus-4-6
@@ -398,9 +399,16 @@ class Settings(BaseSettings):
     #   - gemini-2.0-flash
     #   - gemini-2.0-flash-lite
     #
-    # To use a model, set it as default_model, default_openai_model, or
-    # default_google_model above, or specify it in the entity configuration
-    # via PINECONE_INDEXES.
+    # MINIMAX MODELS (Anthropic-compatible API):
+    #   - MiniMax-M3
+    #   - MiniMax-M2.5
+    #   - MiniMax-M2.5-lightning
+    #   - MiniMax-M1
+    #   - MiniMax-M1-40k
+    #
+    # To use a model, set it as default_model, default_openai_model,
+    # default_google_model, or default_minimax_model above, or specify it in
+    # the entity configuration via PINECONE_INDEXES.
     # =========================================================================
 
     # Context window limits (in tokens)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -36,6 +36,8 @@ MODEL_PROVIDER_MAP = {
     "claude-opus-4-7": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4.8 models
     "claude-opus-4-8": ModelProvider.ANTHROPIC,
+    # Anthropic Claude Fable 5 models
+    "claude-fable-5": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
     "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
     "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
@@ -70,12 +72,14 @@ MODEL_PROVIDER_MAP = {
     "MiniMax-M1-40k": ModelProvider.MINIMAX,
     "MiniMax-M2.5": ModelProvider.MINIMAX,
     "MiniMax-M2.5-lightning": ModelProvider.MINIMAX,
+    "MiniMax-M3": ModelProvider.MINIMAX,
 }
 
 
 # Available models by provider
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
+        {"id": "claude-fable-5", "name": "Claude Fable 5"},
         {"id": "claude-opus-4-8", "name": "Claude Opus 4.8"},
         {"id": "claude-opus-4-7", "name": "Claude Opus 4.7"},
         {"id": "claude-opus-4-6", "name": "Claude Opus 4.6"},
@@ -108,6 +112,7 @@ AVAILABLE_MODELS = {
         {"id": "gemini-2.0-flash-lite", "name": "Gemini 2.0 Flash Lite"},
     ],
     ModelProvider.MINIMAX: [
+        {"id": "MiniMax-M3", "name": "MiniMax M3"},
         {"id": "MiniMax-M2.5", "name": "MiniMax M2.5"},
         {"id": "MiniMax-M2.5-lightning", "name": "MiniMax M2.5 Lightning"},
         {"id": "MiniMax-M1", "name": "MiniMax M1"},

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -18,10 +18,25 @@ class TestModelProviderMapping:
             "claude-haiku-4-5-20251001",
             "claude-sonnet-4-20250514",
             "claude-opus-4-20250514",
+            "claude-opus-4-8",
+            "claude-fable-5",
         ]
 
         for model in claude_models:
             assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.ANTHROPIC
+
+    def test_minimax_models_map_to_minimax(self):
+        """Test that MiniMax models map to MiniMax provider."""
+        minimax_models = [
+            "MiniMax-M1",
+            "MiniMax-M1-40k",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-lightning",
+            "MiniMax-M3",
+        ]
+
+        for model in minimax_models:
+            assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.MINIMAX
 
     def test_gpt_models_map_to_openai(self):
         """Test that GPT models map to OpenAI provider."""

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,6 +137,7 @@
                 <div class="form-group" id="model-group">
                     <label for="model-select">Model</label>
                     <select id="model-select">
+                        <option value="claude-fable-5">Claude Fable 5</option>
                         <option value="claude-opus-4-8">Claude Opus 4.8</option>
                         <option value="claude-opus-4-7">Claude Opus 4.7</option>
                         <option value="claude-opus-4-6">Claude Opus 4.6</option>


### PR DESCRIPTION
## Summary
Adds support for two new LLM models: Claude Fable 5 (Anthropic) and MiniMax M3 (MiniMax provider). Updates model mappings, configuration documentation, available models lists, and frontend UI.

## Changes
- **Backend model registry** (`llm_service.py`):
  - Added `claude-fable-5` to `MODEL_PROVIDER_MAP` and `AVAILABLE_MODELS` for Anthropic
  - Added `MiniMax-M3` to `MODEL_PROVIDER_MAP` and `AVAILABLE_MODELS` for MiniMax provider
  
- **Configuration** (`config.py`):
  - Updated model documentation comments to include Claude Fable 5 and MiniMax M3
  - Added MiniMax models section to configuration comments with all supported variants
  - Updated usage instructions to mention `default_minimax_model`

- **Frontend** (`index.html`):
  - Added Claude Fable 5 option to model selector dropdown (placed first in Anthropic models list)

- **Tests** (`test_llm_service.py`):
  - Added `claude-opus-4-8` and `claude-fable-5` to Claude model test cases
  - Added new test method `test_minimax_models_map_to_minimax()` covering all five MiniMax model variants

## Implementation Details
- Claude Fable 5 is routed through the existing Anthropic provider infrastructure
- MiniMax M3 joins the existing MiniMax models (M1, M1-40k, M2.5, M2.5-lightning) already routed through `AnthropicService` with the Anthropic-compatible API endpoint
- Model ordering in `AVAILABLE_MODELS` places newer/more capable models first for better UX
- All changes follow existing patterns for model registration and provider routing

https://claude.ai/code/session_01G5RM4hnqvjMMw16C5KRhp2