### PR TITLE
Add prompt cache diagnostics and notes injection for single-entity conversations

### DIFF
--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -617,8 +617,17 @@ class AnthropicService:
         date_block += "[/DATE CONTEXT]"
         final_parts.append(date_block)
 
-        # Entity notes (index.md) - inject if notes are enabled and entity has an index file
-        if settings.notes_enabled and responding_entity_label:
+        # Entity notes (index.md):
+        # For single-entity conversations the notes are injected ONCE at the front of
+        # the cached conversation history (see SessionManager session build), so they
+        # are paid for once and then read from cache instead of being re-sent uncached
+        # in every turn's final message.
+        #
+        # For multi-entity conversations the responding entity — and therefore the
+        # relevant notes — changes turn to turn, while the cached history is shared
+        # across all participants. Pinning one entity's notes into that shared cached
+        # block would be wrong, so multi-entity keeps notes in the per-turn message.
+        if settings.notes_enabled and responding_entity_label and is_multi_entity:
             # Get the entity's index.md content
             entity_notes = notes_service.get_index_content(responding_entity_label)
             if entity_notes:

--- a/backend/app/services/conversation_session.py
+++ b/backend/app/services/conversation_session.py
@@ -451,13 +451,29 @@ class ConversationSession:
                 self.conversation_context.pop(0)
                 removed_count += 1
 
-        # If using memory-in-context and we removed messages, update memory tracking
-        if self.use_memory_in_context and removed_count > 0:
-            rolled_out = self.memory_tracker.handle_context_rollout(
-                num_messages_removed=removed_count,
-                conversation_context=self.conversation_context,
-            )
-            if rolled_out:
-                logger.info(f"[MEMORY] Context trimming rolled out {len(rolled_out)} memories")
+        if removed_count > 0:
+            # Keep the cache breakpoint aligned with the messages that remain.
+            # Front-trimming shifts every index down by removed_count, so the
+            # breakpoint must shift with it; if the breakpoint was inside the
+            # trimmed region it collapses to 0. Without this, cached_context
+            # would point at the wrong messages, the [CONVERSATION HISTORY]
+            # header would land on a different message, and every subsequent
+            # turn would be a full cache miss.
+            old_cache_len = self.last_cached_context_length
+            self.last_cached_context_length = max(0, old_cache_len - removed_count)
+            if self.last_cached_context_length != old_cache_len:
+                logger.info(
+                    f"[CACHE] Context trim removed {removed_count} msgs; "
+                    f"cache breakpoint {old_cache_len}->{self.last_cached_context_length}"
+                )
+
+            # If using memory-in-context, update memory tracking for rolled-out memories
+            if self.use_memory_in_context:
+                rolled_out = self.memory_tracker.handle_context_rollout(
+                    num_messages_removed=removed_count,
+                    conversation_context=self.conversation_context,
+                )
+                if rolled_out:
+                    logger.info(f"[MEMORY] Context trimming rolled out {len(rolled_out)} memories")
 
         return removed_count

--- a/backend/app/services/conversation_session.py
+++ b/backend/app/services/conversation_session.py
@@ -106,6 +106,13 @@ class ConversationSession:
     # Cache tracking for conversation history (single breakpoint)
     last_cached_context_length: int = 0  # Frozen history length for cache stability
 
+    # Length (in messages) of the cached prefix sent on the previous API call.
+    # Used only for diagnostics: comparing it to the current cached prefix length
+    # lets us tell an expected cache write (boundary grew/shifted) from an
+    # unexpected miss (boundary stable but the prefix still failed to match).
+    # -1 means "no API call has been made yet this session".
+    last_api_cache_breakpoint: int = -1
+
     # ===== Legacy memory block methods (to be deprecated) =====
     
     def add_memory(self, memory: MemoryEntry) -> Tuple[bool, bool]:

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -98,6 +98,43 @@ class SessionManager:
         self._sessions[conversation_id] = session
         return session
 
+    def _build_notes_context_message(
+        self, entity_label: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Build a single cached-history context message holding the entity's notes.
+
+        Combines the entity's index.md and any shared notes into one user-role
+        message wrapped in [ENTITY NOTES]/[SHARED NOTES] markers. Returns None when
+        there are no notes to inject. Marked with is_notes=True for identification.
+        """
+        from app.services.notes_service import notes_service
+
+        parts: List[str] = []
+
+        entity_notes = notes_service.get_index_content(entity_label)
+        if entity_notes:
+            parts.append(f"[ENTITY NOTES]\n{entity_notes}\n[/ENTITY NOTES]")
+            logger.info(
+                f"[NOTES] Injected index.md for entity '{entity_label}' into cached history ({len(entity_notes)} chars)"
+            )
+
+        shared_notes = notes_service.get_shared_index_content()
+        if shared_notes:
+            parts.append(f"[SHARED NOTES]\n{shared_notes}\n[/SHARED NOTES]")
+            logger.info(
+                f"[NOTES] Injected shared index.md into cached history ({len(shared_notes)} chars)"
+            )
+
+        if not parts:
+            return None
+
+        return {
+            "role": "user",
+            "content": "\n\n".join(parts),
+            "is_notes": True,
+        }
+
     async def load_session_from_db(
         self,
         conversation_id: str,
@@ -308,6 +345,19 @@ class SessionManager:
             logger.info(
                 f"[MEMORY] Skipped {skipped_archived} memories from archived source conversations during session load"
             )
+
+        # Inject the entity's notes (index.md + shared notes) ONCE at the front of the
+        # conversation context for single-entity conversations. This keeps the notes in
+        # the cached history block — paid for once, then read from cache — instead of
+        # being re-sent uncached in every turn's final message. Changes the AI makes to
+        # its notes mid-conversation flow through the notes tool exchanges already stored
+        # in history, like any other tool-call data, so they remain cacheable at their
+        # position. Multi-entity conversations keep notes in the per-turn message because
+        # the responding entity (and thus the relevant notes) changes turn to turn.
+        if settings.notes_enabled and responding_entity_label and not is_multi_entity:
+            notes_message = self._build_notes_context_message(responding_entity_label)
+            if notes_message:
+                session.conversation_context.append(notes_message)
 
         # Build conversation context, interleaving memories at their original positions
         memory_insert_count = 0

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -135,6 +135,64 @@ class SessionManager:
             "is_notes": True,
         }
 
+    def _log_cache_efficiency(
+        self,
+        session: ConversationSession,
+        cached_breakpoint: int,
+        usage: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        Classify the prompt-cache result of an API call for diagnostics.
+
+        Distinguishes an *expected* large cache write — the cached prefix grew or
+        shifted this turn (bootstrap, consolidation, or context trim), so the new
+        region legitimately had to be written — from an *unexpected* miss, where the
+        cached boundary was stable but a large write/small read shows the prefix
+        failed to match anyway (a sign the context construction changed the cached
+        prefix between turns).
+
+        Uses message-count boundary deltas as a cheap proxy; `cached_breakpoint` is
+        the number of messages in the cached prefix that was sent on this call.
+        """
+        if not usage:
+            return
+
+        write = usage.get("cache_creation_input_tokens", 0) or 0
+        read = usage.get("cache_read_input_tokens", 0) or 0
+        prev = session.last_api_cache_breakpoint
+
+        # Only worth classifying when the write dominates the read (the prefix was
+        # largely not reused). A small write below the cache minimum is noise.
+        if write >= 1024 and write > read:
+            if prev < 0:
+                logger.info(
+                    f"[CACHE] Large write EXPECTED (bootstrap / first cached turn): "
+                    f"write={write}, read={read}, boundary={cached_breakpoint} msgs"
+                )
+            elif cached_breakpoint > prev:
+                logger.info(
+                    f"[CACHE] Large write EXPECTED (consolidation grew boundary "
+                    f"{prev}->{cached_breakpoint} msgs): write={write}, read={read}"
+                )
+            elif cached_breakpoint < prev:
+                logger.info(
+                    f"[CACHE] Large write EXPECTED (context trim shifted boundary "
+                    f"{prev}->{cached_breakpoint} msgs): write={write}, read={read}"
+                )
+            else:
+                logger.warning(
+                    f"[CACHE] UNEXPECTED cache miss: write={write} >> read={read} "
+                    f"with a stable boundary ({cached_breakpoint} msgs). The cached "
+                    f"prefix changed since the last turn — check context construction."
+                )
+        else:
+            logger.info(
+                f"[CACHE] Cache OK: read={read}, write={write}, "
+                f"boundary={cached_breakpoint} msgs"
+            )
+
+        session.last_api_cache_breakpoint = cached_breakpoint
+
     async def load_session_from_db(
         self,
         conversation_id: str,
@@ -753,6 +811,10 @@ class SessionManager:
         )
 
         # Step 8: Update conversation context and cache state
+        # Classify the cache result against the prefix we sent (before the boundary moves).
+        self._log_cache_efficiency(
+            session, len(cache_content["cached_context"]), response.get("usage")
+        )
         session.add_exchange(user_message, response["content"])
 
         # Update cache state for conversation history (memories don't affect cache hits)
@@ -1167,6 +1229,11 @@ class SessionManager:
         TOOL_CACHE_TOKEN_THRESHOLD = 2048  # Move breakpoint after N new tokens
         iteration = 0
         max_iterations = settings.tool_use_max_iterations
+        # Cache metrics from iteration 1, which is the only call built with the
+        # conversation-history cache structure (later tool iterations use the
+        # separate tool-breakpoint scheme). We classify against these so the
+        # diagnostic reflects the durable conversation-history cache.
+        first_iteration_usage: Optional[Dict[str, Any]] = None
 
         while iteration < max_iterations:
             iteration += 1
@@ -1249,10 +1316,20 @@ class SessionManager:
                     stop_reason = event.get("stop_reason")
                     iteration_content_blocks = event.get("content_blocks", [])
                     iteration_tool_use = event.get("tool_use")
+                    if iteration == 1:
+                        first_iteration_usage = event.get("usage")
 
                     # If no tool use, this is the final response
                     if stop_reason != "tool_use" or not iteration_tool_use:
                         full_content += iteration_content
+
+                        # Classify the cache result of the conversation-history call
+                        # (iteration 1) against the prefix we sent, before the boundary moves.
+                        self._log_cache_efficiency(
+                            session,
+                            len(cache_content["cached_context"]),
+                            first_iteration_usage,
+                        )
 
                         # Update conversation context and cache state
                         # Include tool exchanges so they're persisted in conversation history
@@ -1388,6 +1465,9 @@ class SessionManager:
 
         # If we've exhausted iterations, yield what we have
         logger.warning(f"[TOOLS] Max iterations ({max_iterations}) reached")
+        self._log_cache_efficiency(
+            session, len(cache_content["cached_context"]), first_iteration_usage
+        )
         session.add_exchange(
             user_message,
             full_content,

--- a/backend/tests/test_conversation_session.py
+++ b/backend/tests/test_conversation_session.py
@@ -397,3 +397,37 @@ class TestConversationSessionSharedMethods:
             count_tokens_fn=lambda x: 999,  # Always over limit
         )
         assert len(session.conversation_context) >= 1
+
+    def test_trim_context_shifts_cache_breakpoint(self):
+        """Front-trimming must shift last_cached_context_length so the cache
+        breakpoint keeps pointing at the same messages. Otherwise the cached
+        prefix changes and every subsequent turn is a full cache miss."""
+        session = ConversationSession(conversation_id="conv-1")
+        session.conversation_context = [
+            {"role": "user", "content": f"m{i}"} for i in range(10)
+        ]
+        session.last_cached_context_length = 6
+
+        # Over limit until only 6 messages remain (removes the first 4).
+        removed = session.trim_context_to_limit(
+            max_tokens=50,
+            count_tokens_fn=lambda text: 1000 if len(session.conversation_context) > 6 else 10,
+        )
+        assert removed == 4
+        # Breakpoint shifts down by the number removed from the front.
+        assert session.last_cached_context_length == 2
+
+    def test_trim_context_collapses_breakpoint_inside_trimmed_region(self):
+        """If the breakpoint was inside the trimmed region it collapses to 0."""
+        session = ConversationSession(conversation_id="conv-1")
+        session.conversation_context = [
+            {"role": "user", "content": f"m{i}"} for i in range(10)
+        ]
+        session.last_cached_context_length = 2
+
+        removed = session.trim_context_to_limit(
+            max_tokens=50,
+            count_tokens_fn=lambda text: 1000 if len(session.conversation_context) > 3 else 10,
+        )
+        assert removed > 2
+        assert session.last_cached_context_length == 0


### PR DESCRIPTION
## Summary

This PR adds two complementary improvements to the session manager:

1. **Cache efficiency diagnostics** — A new `_log_cache_efficiency()` method that classifies prompt cache results (writes vs. reads) to distinguish expected cache behavior (bootstrap, consolidation, boundary shifts) from unexpected misses that indicate context construction changes.

2. **Notes injection into cached history** — For single-entity conversations, entity notes (index.md + shared notes) are now injected once at the front of the cached conversation history instead of being re-sent uncached in every turn. This reduces token usage by paying for notes once and then reading them from cache. Multi-entity conversations keep notes in the per-turn message since the responding entity (and thus relevant notes) changes turn to turn.

## Key Changes

- **`SessionManager._build_notes_context_message()`** — New helper that combines entity index.md and shared notes into a single user-role message with `is_notes=True` marker, wrapped in `[ENTITY NOTES]`/`[SHARED NOTES]` markers.

- **`SessionManager._log_cache_efficiency()`** — New diagnostic method that:
  - Compares `cache_creation_input_tokens` vs. `cache_read_input_tokens` to detect large writes
  - Uses message-count boundary deltas (`last_api_cache_breakpoint`) to classify writes as expected (bootstrap, consolidation, trim) or unexpected (stable boundary but cache miss)
  - Logs at INFO level for expected behavior, WARNING for unexpected misses

- **`ConversationSession.last_api_cache_breakpoint`** — New field tracking the cached prefix length (in messages) from the previous API call, initialized to -1. Used only for diagnostics.

- **`ConversationSession.trim_context_to_limit()`** — Updated to shift `last_cached_context_length` when front-trimming messages, keeping the cache breakpoint aligned with the remaining messages. Prevents the cached prefix from pointing at wrong messages after context trim.

- **`SessionManager.load_session_from_db()`** — Notes message is injected once at the front of conversation context for single-entity conversations (when `settings.notes_enabled` and `not is_multi_entity`).

- **`SessionManager.process_message()` and `process_message_stream()`** — Both now call `_log_cache_efficiency()` to classify cache results. In streaming, only the first iteration's usage is captured (the only call built with conversation-history cache structure).

- **`AnthropicService`** — Updated comment clarifying that multi-entity conversations keep notes in the per-turn message because the responding entity changes turn to turn.

- **Tests** — Added two new test cases for cache breakpoint shifting during context trim.

## Implementation Details

- Notes injection happens during session load, before the conversation context is built, so notes land in the cached history block and remain cacheable at their position.
- Cache diagnostics use message-count boundaries as a cheap proxy for detecting prefix changes; a stable boundary with a large write indicates the cached prefix changed between turns (a sign context construction was altered).
- The `first_iteration_usage` variable in `process_message_stream()` captures metrics from iteration 1 only, since later tool iterations use a separate tool-breakpoint cache scheme and would skew diagnostics.

https://claude.ai/code/session_01BkL9HQ19uR9RCR1tgbXxPt