### PR TITLE
Invalidate stale per-entity model selections on .env default change

### DIFF
--- a/frontend/js/__tests__/state.test.js
+++ b/frontend/js/__tests__/state.test.js
@@ -13,6 +13,7 @@ import {
     saveSelectedVoiceToStorage,
     loadResearcherName,
     saveResearcherName,
+    getValidSavedEntityModel,
 } from '../modules/state.js';
 
 describe('State Module', () => {
@@ -277,6 +278,65 @@ describe('State Module', () => {
 
             state.audioCache.delete('key');
             expect(state.audioCache.has('key')).toBe(false);
+        });
+    });
+
+    describe('getValidSavedEntityModel', () => {
+        const minimaxEntity = {
+            index_name: 'minimax-research',
+            llm_provider: 'minimax',
+            default_model: 'MiniMax-M3',
+        };
+
+        beforeEach(() => {
+            localStorage.clear();
+            state.entityModels = {};
+            state.entityModelDefaults = {};
+            state.availableModels = [
+                { id: 'MiniMax-M3', name: 'MiniMax M3', provider: 'minimax' },
+                { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', provider: 'minimax' },
+                { id: 'claude-fable-5', name: 'Claude Fable 5', provider: 'anthropic' },
+            ];
+        });
+
+        it('returns null when nothing is saved', () => {
+            expect(getValidSavedEntityModel(minimaxEntity)).toBe(null);
+        });
+
+        it('honors a saved selection that matches its recorded .env default', () => {
+            state.entityModels['minimax-research'] = 'MiniMax-M2.5';
+            state.entityModelDefaults['minimax-research'] = 'MiniMax-M3';
+            expect(getValidSavedEntityModel(minimaxEntity)).toBe('MiniMax-M2.5');
+        });
+
+        it('drops a saved selection when the entity .env default_model changed', () => {
+            // Saved against an older default; .env now configures MiniMax-M3.
+            state.entityModels['minimax-research'] = 'MiniMax-M2.5';
+            state.entityModelDefaults['minimax-research'] = 'MiniMax-M2.5';
+            expect(getValidSavedEntityModel(minimaxEntity)).toBe(null);
+            // Stale entry is removed so callers fall through to the new default.
+            expect(state.entityModels['minimax-research']).toBeUndefined();
+            expect(state.entityModelDefaults['minimax-research']).toBeUndefined();
+        });
+
+        it('treats a pre-baseline saved entry (no recorded default) as stale', () => {
+            state.entityModels['minimax-research'] = 'MiniMax-M2.5';
+            // No entityModelDefaults entry (saved before the baseline existed).
+            expect(getValidSavedEntityModel(minimaxEntity)).toBe(null);
+            expect(state.entityModels['minimax-research']).toBeUndefined();
+        });
+
+        it('drops a saved selection that is no longer valid for the provider', () => {
+            state.entityModels['minimax-research'] = 'gpt-4o';
+            state.entityModelDefaults['minimax-research'] = 'MiniMax-M3';
+            expect(getValidSavedEntityModel(minimaxEntity)).toBe(null);
+        });
+
+        it('honors a saved selection for an entity with no configured default', () => {
+            const entity = { index_name: 'claude-main', llm_provider: 'anthropic', default_model: null };
+            state.entityModels['claude-main'] = 'claude-fable-5';
+            state.entityModelDefaults['claude-main'] = null;
+            expect(getValidSavedEntityModel(entity)).toBe('claude-fable-5');
         });
     });
 });

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -4,7 +4,7 @@
  */
 
 // Import modules
-import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
+import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, getValidSavedEntityModel, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
 import { showToast, showLoading, setToastContainer, escapeHtml, renderMarkdown, truncateText, stripMarkdown } from './modules/utils.js';
 import { loadTheme, getCurrentTheme, setTheme } from './modules/theme.js';
 import { setElements as setModalElements, showModal, hideModal, closeActiveModal, isModalOpen, closeAllDropdowns } from './modules/modals.js';
@@ -731,18 +731,13 @@ class App {
                 const provider = entity.llm_provider || 'anthropic';
                 updateModelSelectorForProvider(provider);
 
-                // Restore saved model for this entity, or use default
-                const savedModel = state.entityModels[state.selectedEntityId];
+                // Restore saved model for this entity, or use default. A saved
+                // UI selection is honored only while valid AND saved against the
+                // entity's current .env default_model; a changed default drops
+                // the stale value so the new .env default wins.
+                const savedModel = getValidSavedEntityModel(entity);
                 if (savedModel) {
-                    // Verify saved model is valid for this provider
-                    const isValidModel = state.availableModels.some(
-                        m => m.id === savedModel && m.provider === provider
-                    );
-                    if (isValidModel) {
-                        state.settings.model = savedModel;
-                    } else if (entity.default_model) {
-                        state.settings.model = entity.default_model;
-                    }
+                    state.settings.model = savedModel;
                 } else if (entity.default_model) {
                     state.settings.model = entity.default_model;
                 }

--- a/frontend/js/modules/entities.js
+++ b/frontend/js/modules/entities.js
@@ -3,7 +3,7 @@
  * Handles entity loading, selection, and multi-entity conversations
  */
 
-import { state } from './state.js';
+import { state, getValidSavedEntityModel } from './state.js';
 import { showToast, escapeHtml } from './utils.js';
 import { showModal, hideModal, closeAllDropdowns } from './modals.js';
 
@@ -188,19 +188,13 @@ export function handleEntityChange(entityId) {
             updateModelSelectorForProvider(provider);
         }
 
-        // Restore entity-specific model (saved user preference takes priority)
-        if (state.entityModels[entityId] !== undefined) {
-            // Verify the saved model is valid for this provider
-            const savedModel = state.entityModels[entityId];
-            const isValidModel = state.availableModels.some(
-                m => m.id === savedModel && m.provider === provider
-            );
-            if (isValidModel) {
-                state.settings.model = savedModel;
-            } else if (entity.default_model) {
-                // Saved model invalid for this provider, use default
-                state.settings.model = entity.default_model;
-            }
+        // Restore entity-specific model. A saved UI selection takes priority,
+        // but only while it stays valid AND was saved against the entity's
+        // current .env default_model — a changed default drops the stale value
+        // so the new .env default wins (getValidSavedEntityModel handles this).
+        const savedModel = getValidSavedEntityModel(entity);
+        if (savedModel) {
+            state.settings.model = savedModel;
         } else if (entity.default_model) {
             state.settings.model = entity.default_model;
         }

--- a/frontend/js/modules/settings.js
+++ b/frontend/js/modules/settings.js
@@ -3,7 +3,7 @@
  * Handles settings modal, configuration presets, and settings application
  */
 
-import { state, saveEntityModelsToStorage, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName } from './state.js';
+import { state, saveEntityModelsToStorage, getValidSavedEntityModel, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName } from './state.js';
 import { showToast } from './utils.js';
 import { showModal, hideModal } from './modals.js';
 import { setTheme } from './theme.js';
@@ -57,6 +57,10 @@ export async function applySettings() {
     // client-side preference in localStorage.
     if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
         state.entityModels[state.selectedEntityId] = state.settings.model;
+        // Record the configured default_model this selection was made against,
+        // so a later change to the entity's .env default invalidates it.
+        const selectedEntity = state.entities.find(e => e.index_name === state.selectedEntityId);
+        state.entityModelDefaults[state.selectedEntityId] = selectedEntity?.default_model ?? null;
 
         const entityId = state.selectedEntityId;
         const newPrompt = state.settings.systemPrompt;
@@ -308,13 +312,9 @@ function getModelDisplayName(modelId) {
 function resolveEntityModel(entity) {
     const provider = entity.llm_provider || 'anthropic';
 
-    // 1. Saved per-entity preference
-    const savedModel = state.entityModels[entity.index_name];
-    if (savedModel) {
-        const isValid = state.availableModels &&
-            state.availableModels.some(m => m.id === savedModel && m.provider === provider);
-        if (isValid) return savedModel;
-    }
+    // 1. Saved per-entity preference (ignored if stale against a changed .env default)
+    const savedModel = getValidSavedEntityModel(entity);
+    if (savedModel) return savedModel;
 
     // 2. Entity's configured default
     if (entity.default_model) return entity.default_model;

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -17,6 +17,11 @@ export const state = {
     entities: [],
     entitySystemPrompts: {},
     entityModels: {},  // Per-entity model selection persistence
+    // Configured default_model that was in effect when each entityModels entry
+    // was saved. Used to detect when an entity's .env default_model has changed
+    // so a now-stale saved selection can be dropped (letting the new .env
+    // default take effect) instead of silently shadowing it.
+    entityModelDefaults: {},
 
     // Multi-entity state
     isMultiEntityMode: false,
@@ -157,6 +162,10 @@ export function loadEntityModelsFromStorage() {
         if (saved) {
             state.entityModels = JSON.parse(saved);
         }
+        const savedDefaults = localStorage.getItem('entity_model_defaults');
+        if (savedDefaults) {
+            state.entityModelDefaults = JSON.parse(savedDefaults);
+        }
     } catch (e) {
         console.warn('Failed to load entity models:', e);
     }
@@ -168,9 +177,56 @@ export function loadEntityModelsFromStorage() {
 export function saveEntityModelsToStorage() {
     try {
         localStorage.setItem('entity_models', JSON.stringify(state.entityModels));
+        localStorage.setItem('entity_model_defaults', JSON.stringify(state.entityModelDefaults));
     } catch (e) {
         console.warn('Failed to save entity models:', e);
     }
+}
+
+/**
+ * Resolve the persisted per-entity model selection for an entity, honoring the
+ * researcher's UI choice while keeping the .env config authoritative.
+ *
+ * The per-entity model the researcher picks in the UI is persisted to
+ * localStorage so it survives restarts. But that saved value must not
+ * permanently shadow the entity's configured `default_model`: when the
+ * researcher edits `default_model` in `.env` (PINECONE_INDEXES), the new
+ * default should take effect. We detect that by recording the configured
+ * default in effect when the selection was saved (entityModelDefaults). If the
+ * entity's current configured default differs, the saved selection is stale —
+ * we drop it (and its baseline) and return null so callers fall through to the
+ * new default.
+ *
+ * Entries saved before this baseline existed have no recorded default, so they
+ * are treated as stale on first load after upgrade — exactly the desired
+ * migration (the .env default wins, then the next deliberate pick re-saves a
+ * baseline).
+ *
+ * @param {Object} entity - Entity object (index_name, llm_provider, default_model)
+ * @returns {string|null} - A valid saved model id, or null if none/stale/invalid
+ */
+export function getValidSavedEntityModel(entity) {
+    if (!entity) return null;
+    const entityId = entity.index_name;
+    const savedModel = state.entityModels[entityId];
+    if (savedModel === undefined) return null;
+
+    // Drop a selection saved against a different (now-changed) .env default.
+    const currentDefault = entity.default_model ?? null;
+    const savedAgainstDefault = state.entityModelDefaults[entityId] ?? null;
+    if (savedAgainstDefault !== currentDefault) {
+        delete state.entityModels[entityId];
+        delete state.entityModelDefaults[entityId];
+        saveEntityModelsToStorage();
+        return null;
+    }
+
+    // Only honor the saved model if it is still valid for this provider.
+    const provider = entity.llm_provider || 'anthropic';
+    const isValid = state.availableModels?.some(
+        m => m.id === savedModel && m.provider === provider
+    );
+    return isValid ? savedModel : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

When a researcher changes an entity's `default_model` in `.env` (via `PINECONE_INDEXES`), previously saved per-entity model selections should not permanently shadow the new default. This PR adds baseline tracking to detect when a saved selection was made against a different configured default, and drops it so the new `.env` default takes effect.

## Key Changes

- **New state field `entityModelDefaults`**: Records the configured `default_model` in effect when each per-entity model selection was saved. Persisted to localStorage alongside `entityModels`.

- **New function `getValidSavedEntityModel(entity)`**: Centralizes validation logic:
  - Returns `null` if no saved selection exists
  - Compares the entity's current configured `default_model` against the baseline recorded when the selection was saved
  - If they differ (indicating `.env` was edited), deletes both the stale selection and its baseline, then returns `null` so the new default wins
  - Treats pre-baseline entries (no recorded default) as stale on first load after upgrade — desired migration behavior
  - Validates that the saved model is still available for the entity's provider

- **Updated `applySettings()`**: When a researcher picks a model in the UI, now records the entity's current `default_model` as the baseline for that selection.

- **Refactored model resolution in three places** (`entities.js`, `app-modular.js`, `settings.js`): Replaced inline validation logic with calls to `getValidSavedEntityModel()`, eliminating duplication and ensuring consistent behavior.

- **Comprehensive test suite**: 5 test cases covering null/missing saves, valid selections, stale selections (changed defaults), pre-baseline entries, invalid models, and entities with no configured default.

## Implementation Details

- The baseline is stored as `entityModelDefaults[entityId]` and persisted to `localStorage['entity_model_defaults']` alongside the existing `entity_models` key.
- Stale entries are cleaned up immediately (deleted from state and localStorage) when detected, rather than silently ignored, so the new `.env` default takes effect on next load.
- Null defaults (entities with `default_model: null`) are explicitly tracked as `null` in the baseline, allowing valid selections to be honored even when no default is configured.
- The function is exported and used by the settings, entities, and app modules to ensure a single source of truth for validation logic.

https://claude.ai/code/session_01JdZxyp95XLBtN2ro6kgaKu