### PR TITLE
Restore per-entity memories in multi-entity session info

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -1154,14 +1154,36 @@ async def get_session_info(
     if not session:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    # Get memories currently in context (not all retrieved, just those in context)
+    # Get memories currently in context (not all retrieved, just those in context).
+    # The two memory systems track "in context" differently: the legacy memory
+    # block uses session.in_context_ids, while memory-in-context mode embeds
+    # memories in the conversation and tracks their positions in memory_tracker.
+    # Reading only in_context_ids returns an empty list in memory-in-context mode,
+    # which blanks the "Retrieved Memories" panel after switching conversations.
+    if session.use_memory_in_context:
+        in_context_ids = session.memory_tracker.get_in_context_memory_ids(
+            len(session.conversation_context)
+        )
+    else:
+        in_context_ids = session.in_context_ids
     in_context_memories = [
         session.session_memories[mid]
-        for mid in session.in_context_ids
+        for mid in in_context_ids
         if mid in session.session_memories
     ]
 
-    return {
+    def serialize_entry(m) -> dict:
+        return {
+            "id": m.id,
+            "content": m.content[:3000] if len(m.content) > 3000 else m.content,
+            "content_preview": m.content[:200] if len(m.content) > 200 else m.content,
+            "created_at": m.created_at,
+            "times_retrieved": m.times_retrieved,
+            "role": m.role,
+            "score": m.score,
+        }
+
+    response = {
         "conversation_id": session.conversation_id,
         "model": session.model,
         "temperature": session.temperature,
@@ -1170,19 +1192,76 @@ async def get_session_info(
         "entity_id": session.entity_id,
         "message_count": len(session.conversation_context),
         "memories_in_context": len(in_context_memories),
-        "memories": [
-            {
-                "id": m.id,
-                "content": m.content[:3000] if len(m.content) > 3000 else m.content,
-                "content_preview": m.content[:200] if len(m.content) > 200 else m.content,
-                "created_at": m.created_at,
-                "times_retrieved": m.times_retrieved,
-                "role": m.role,
-                "score": m.score,
-            }
-            for m in in_context_memories
-        ],
+        "memories": [serialize_entry(m) for m in in_context_memories],
     }
+
+    # For multi-entity conversations, the in-memory session only holds the most
+    # recent responding entity's memories. The frontend panel groups retrieved
+    # memories per entity, so rebuild that grouping from the persisted
+    # ConversationMemoryLink records for every participant. Without this, the
+    # panel goes blank (or loses other entities) after switching conversations
+    # and back. See get_session_info's flat "memories" for the single-entity path.
+    if session.is_multi_entity:
+        memories_by_entity = await _build_memories_by_entity(conversation_id, db)
+        if memories_by_entity:
+            response["memories_by_entity"] = memories_by_entity
+
+    return response
+
+
+async def _build_memories_by_entity(
+    conversation_id: str,
+    db: AsyncSession,
+) -> dict:
+    """
+    Rebuild the per-entity retrieved-memory grouping for a multi-entity
+    conversation from persisted ConversationMemoryLink records.
+
+    Mirrors the reconstruction load_session_from_db performs, including the
+    archived-source filter, so the restored panel matches what retrieval would
+    actually surface. Memories from archived source conversations are skipped.
+
+    Returns a dict keyed by entity_id: {entity_id: {"label", "memories": [...]}}.
+    """
+    entity_ids = await get_multi_entity_ids(conversation_id, db)
+    if not entity_ids:
+        return {}
+
+    result: dict = {}
+    for entity_id in entity_ids:
+        archived_source_ids: set = set()
+        if memory_service.is_configured(entity_id=entity_id):
+            archived_source_ids = await memory_service.get_archived_conversation_ids(
+                db, entity_id=entity_id
+            )
+
+        retrieved_ids = await memory_service.get_retrieved_ids_for_conversation(
+            conversation_id, db, entity_id=entity_id
+        )
+
+        memories = []
+        for mem_id in retrieved_ids:
+            mem_data = await memory_service.get_full_memory_content(mem_id, db)
+            if not mem_data or mem_data["conversation_id"] in archived_source_ids:
+                continue
+            content = mem_data["content"]
+            memories.append({
+                "id": mem_data["id"],
+                "content": content[:3000] if len(content) > 3000 else content,
+                "content_preview": content[:200] if len(content) > 200 else content,
+                "created_at": mem_data["created_at"],
+                "times_retrieved": mem_data["times_retrieved"],
+                "role": mem_data["role"],
+                "score": None,
+            })
+
+        if memories:
+            result[entity_id] = {
+                "label": get_entity_label(entity_id) or entity_id,
+                "memories": memories,
+            }
+
+    return result
 
 
 @router.delete("/session/{conversation_id}")

--- a/backend/tests/test_session_info_memories.py
+++ b/backend/tests/test_session_info_memories.py
@@ -1,0 +1,203 @@
+"""
+Tests for per-entity memory reconstruction in the session-info endpoint.
+
+When the user leaves a multi-entity conversation and returns, the in-memory
+session only retains the most recent responding entity's memories. The
+"Retrieved Memories" panel groups memories per entity, so the backend rebuilds
+that grouping from the persisted ConversationMemoryLink records. These tests
+cover that reconstruction (_build_memories_by_entity).
+"""
+import uuid
+from datetime import datetime
+from unittest.mock import patch, AsyncMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.main import app
+from app.database import get_db
+from app.models import (
+    Conversation,
+    ConversationEntity,
+    ConversationMemoryLink,
+    Message,
+    MessageRole,
+    ConversationType,
+)
+from app.routes.chat import _build_memories_by_entity
+from app.services import session_manager
+from app.services.conversation_session import MemoryEntry
+
+
+@pytest.fixture
+async def async_client(test_engine):
+    """Async test client with the DB dependency pointed at the in-memory engine."""
+    async_session = async_sessionmaker(
+        test_engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def _seed_multi_entity(db, *, entity_ids):
+    conv = Conversation(
+        id=str(uuid.uuid4()),
+        entity_id="multi-entity",
+        conversation_type=ConversationType.MULTI_ENTITY,
+    )
+    db.add(conv)
+    await db.flush()
+
+    for order, eid in enumerate(entity_ids):
+        db.add(ConversationEntity(
+            conversation_id=conv.id,
+            entity_id=eid,
+            display_order=order,
+        ))
+    await db.commit()
+    return conv
+
+
+async def _add_memory(db, *, conversation_id, entity_id, content, role=MessageRole.HUMAN,
+                      times_retrieved=1, source_conversation=None):
+    """Create a source message and a link recording its retrieval by an entity."""
+    source_conv_id = source_conversation or conversation_id
+    msg = Message(
+        id=str(uuid.uuid4()),
+        conversation_id=source_conv_id,
+        role=role,
+        content=content,
+        times_retrieved=times_retrieved,
+    )
+    db.add(msg)
+    await db.flush()
+    db.add(ConversationMemoryLink(
+        conversation_id=conversation_id,
+        message_id=msg.id,
+        entity_id=entity_id,
+        retrieved_at=datetime.utcnow(),
+    ))
+    await db.commit()
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_build_groups_memories_per_entity(db_session):
+    conv = await _seed_multi_entity(db_session, entity_ids=["entity-a", "entity-b"])
+
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-a",
+                      content="A's memory one")
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-b",
+                      content="B's memory one", role=MessageRole.ASSISTANT)
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-b",
+                      content="B's memory two")
+
+    with patch("app.routes.chat.memory_service.is_configured", return_value=False), \
+         patch("app.routes.chat.get_entity_label", side_effect=lambda eid: f"Label::{eid}"):
+        grouped = await _build_memories_by_entity(conv.id, db_session)
+
+    assert set(grouped.keys()) == {"entity-a", "entity-b"}
+    assert grouped["entity-a"]["label"] == "Label::entity-a"
+    assert len(grouped["entity-a"]["memories"]) == 1
+    assert len(grouped["entity-b"]["memories"]) == 2
+    contents = {m["content"] for m in grouped["entity-b"]["memories"]}
+    assert contents == {"B's memory one", "B's memory two"}
+
+
+@pytest.mark.asyncio
+async def test_build_excludes_entities_with_no_memories(db_session):
+    conv = await _seed_multi_entity(db_session, entity_ids=["entity-a", "entity-b"])
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-a",
+                      content="only A retrieved")
+
+    with patch("app.routes.chat.memory_service.is_configured", return_value=False), \
+         patch("app.routes.chat.get_entity_label", side_effect=lambda eid: f"Label::{eid}"):
+        grouped = await _build_memories_by_entity(conv.id, db_session)
+
+    # entity-b never retrieved anything, so it is omitted rather than shown empty.
+    assert set(grouped.keys()) == {"entity-a"}
+
+
+@pytest.mark.asyncio
+async def test_build_skips_memories_from_archived_source_conversations(db_session):
+    conv = await _seed_multi_entity(db_session, entity_ids=["entity-a"])
+
+    # One memory whose source conversation is archived, one that is live.
+    archived_src = str(uuid.uuid4())
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-a",
+                      content="from archived source", source_conversation=archived_src)
+    await _add_memory(db_session, conversation_id=conv.id, entity_id="entity-a",
+                      content="from live source")
+
+    with patch("app.routes.chat.memory_service.is_configured", return_value=True), \
+         patch("app.routes.chat.memory_service.get_archived_conversation_ids",
+               new=AsyncMock(return_value={archived_src})), \
+         patch("app.routes.chat.get_entity_label", side_effect=lambda eid: f"Label::{eid}"):
+        grouped = await _build_memories_by_entity(conv.id, db_session)
+
+    memories = grouped["entity-a"]["memories"]
+    assert len(memories) == 1
+    assert memories[0]["content"] == "from live source"
+
+
+@pytest.mark.asyncio
+async def test_session_info_returns_memories_in_memory_in_context_mode(async_client):
+    """Regression: memory-in-context mode tracks in-context memories via the
+    memory_tracker, not session.in_context_ids. The session-info endpoint must
+    read the right source, otherwise the panel blanks after switching away and
+    back from a single-entity conversation.
+    """
+    conversation_id = str(uuid.uuid4())
+    session = session_manager.create_session(
+        conversation_id=conversation_id,
+        model="claude-sonnet-4-5-20250929",
+        entity_id="test-entity",
+    )
+    session.use_memory_in_context = True
+
+    memory = MemoryEntry(
+        id=str(uuid.uuid4()),
+        conversation_id=conversation_id,
+        role="human",
+        content="a remembered thing",
+        created_at=datetime.utcnow().isoformat(),
+        times_retrieved=3,
+        score=0.88,
+    )
+    inserted, _ = session.insert_memory_into_context(memory)
+    assert inserted
+    # The legacy set stays empty in this mode - the bug was reading from it.
+    assert session.in_context_ids == set()
+
+    try:
+        response = await async_client.get(f"/api/chat/session/{conversation_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["memories_in_context"] == 1
+        assert [m["id"] for m in data["memories"]] == [memory.id]
+        assert data["memories"][0]["content"] == "a remembered thing"
+    finally:
+        session_manager.close_session(conversation_id)
+
+
+@pytest.mark.asyncio
+async def test_build_returns_empty_for_non_multi_entity(db_session):
+    # A conversation with no participant rows yields no groups.
+    conv = Conversation(id=str(uuid.uuid4()), entity_id="solo")
+    db_session.add(conv)
+    await db_session.commit()
+
+    with patch("app.routes.chat.memory_service.is_configured", return_value=False), \
+         patch("app.routes.chat.get_entity_label", side_effect=lambda eid: f"Label::{eid}"):
+        grouped = await _build_memories_by_entity(conv.id, db_session)
+
+    assert grouped == {}

--- a/frontend/js/__tests__/conversations.test.js
+++ b/frontend/js/__tests__/conversations.test.js
@@ -276,6 +276,26 @@ describe('Conversations Module', () => {
             expect(state.retrievedMemories).toEqual(memories);
         });
 
+        it('should repopulate per-entity memories for multi-entity conversations', async () => {
+            const memoriesByEntity = {
+                'entity-1': { label: 'Claude', memories: [{ id: 'm1', role: 'human', times_retrieved: 1 }] },
+                'entity-2': { label: 'GPT', memories: [{ id: 'm2', role: 'assistant', times_retrieved: 4 }] },
+            };
+            window.api.getConversation = vi.fn(() => Promise.resolve({ id: 'conv-123' }));
+            window.api.getConversationMessages = vi.fn(() => Promise.resolve([]));
+            window.api.getSessionInfo = vi.fn(() => Promise.resolve({
+                memories: [],
+                memories_by_entity: memoriesByEntity,
+            }));
+
+            await loadConversation('conv-123');
+
+            // Grouped map drives the panel; the flat list stays empty so the
+            // panel renders entity sections rather than an ungrouped list.
+            expect(state.retrievedMemoriesByEntity).toEqual(memoriesByEntity);
+            expect(state.retrievedMemories).toEqual([]);
+        });
+
         it('should still load when session info is unavailable', async () => {
             window.api.getConversation = vi.fn(() => Promise.resolve({ id: 'conv-123' }));
             window.api.getConversationMessages = vi.fn(() => Promise.resolve([]));

--- a/frontend/js/modules/conversations.js
+++ b/frontend/js/modules/conversations.js
@@ -296,8 +296,15 @@ export async function loadConversation(id) {
 
         // Repopulate the "memories retrieved in this session" panel so it
         // reflects the loaded conversation instead of staying empty until the
-        // next message is sent.
-        state.retrievedMemories = sessionInfo?.memories || [];
+        // next message is sent. Multi-entity conversations group memories per
+        // entity (memories_by_entity); single-entity uses the flat list. The
+        // panel prefers the grouped map when present, so only populate one.
+        if (sessionInfo?.memories_by_entity) {
+            state.retrievedMemoriesByEntity = sessionInfo.memories_by_entity;
+            state.retrievedMemories = [];
+        } else {
+            state.retrievedMemories = sessionInfo?.memories || [];
+        }
 
         // Update multi-entity state
         if (conversation.conversation_type === 'multi_entity' && conversation.entities) {


### PR DESCRIPTION
## Summary

Fixes the "Retrieved Memories" panel going blank or losing other entities' memories after switching away from and back to a multi-entity conversation. The in-memory session only retains the most recent responding entity's memories, so the backend now rebuilds the per-entity grouping from persisted `ConversationMemoryLink` records for the session-info endpoint.

## Key Changes

- **Backend (`app/routes/chat.py`)**
  - Fixed `get_session_info` to read in-context memory IDs from the correct source: `session.memory_tracker` for memory-in-context mode (which embeds memories in conversation), and `session.in_context_ids` for legacy memory-block mode. Reading only `in_context_ids` returns empty in memory-in-context mode, blanking the panel.
  - Added `_build_memories_by_entity()` helper to reconstruct per-entity memory grouping from `ConversationMemoryLink` records for multi-entity conversations. Mirrors the archived-source filtering that `load_session_from_db` performs, so the restored panel matches what retrieval would surface.
  - Response now includes `memories_by_entity` (keyed by entity_id with label and memories list) for multi-entity conversations, while single-entity conversations continue using the flat `memories` list.
  - Extracted memory serialization into a `serialize_entry()` helper to reduce duplication.

- **Frontend (`frontend/js/modules/conversations.js`)**
  - Updated `loadConversation()` to populate `state.retrievedMemoriesByEntity` when `memories_by_entity` is present in session info, and clear the flat `retrievedMemories` list. The panel prefers the grouped map when available, so only one is populated to avoid rendering both.

- **Tests (`backend/tests/test_session_info_memories.py`)**
  - Added comprehensive test suite for `_build_memories_by_entity`:
    - Groups memories per entity correctly
    - Excludes entities with no retrieved memories
    - Filters out memories from archived source conversations
    - Regression test for memory-in-context mode reading from the correct tracker
    - Returns empty dict for non-multi-entity conversations
  - Added frontend test verifying per-entity memories repopulate on conversation load.

## Implementation Details

- The `_build_memories_by_entity` function queries `memory_service.get_retrieved_ids_for_conversation()` per entity and filters by archived sources using `memory_service.get_archived_conversation_ids()`, ensuring consistency with the retrieval pipeline.
- Memory content is truncated to 3000 chars (full) and 200 chars (preview) to match the single-entity serialization.
- The fix handles both memory systems transparently: legacy memory-block mode and the newer memory-in-context embedding approach.

https://claude.ai/code/session_01CnbtSMDajy989vZFTErkVp