### PR TITLE
Add entity memory curation tools and notes semantic search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ backend/app/
     ├── web_tools.py               # web_search (Brave), web_fetch (httpx + Playwright fallback)
     ├── github_service.py / github_tools.py
     ├── notes_service.py / notes_tools.py
-    ├── memory_tools.py            # memory_query tool
+    ├── notes_vector_service.py    # Notes semantic indexing ("notes" namespace in entity indexes)
+    ├── memory_tools.py            # memory_query, memory_save, memory_mark, memory_release tools
+    ├── context_tools.py           # context_status tool (context-window awareness)
     ├── codebase_navigator*        # Mistral Devstral integration (optional)
     ├── moltbook_*                 # AI social network (optional)
     ├── attachment_service.py      # Image/text/PDF/DOCX handling
@@ -97,6 +99,11 @@ half_life_modifier = 0.5 ** (days_since_creation / 60)
 - **Session accumulator:** `ConversationSession.session_memories` + `retrieved_ids` deduplicate within a conversation. Already-in-context memories are dropped without backfill (no quality dilution).
 - **Role balance:** `memory_role_balance_enabled=True` forces at least one human + one assistant memory in retrieval.
 - **`memory_query` tool** returns pure semantic similarity (no significance re-ranking), excludes the current conversation, and updates `times_retrieved` so deliberate queries feed back into significance.
+- **Memory status (`Message.memory_status`):** `"pinned"` exempts a memory from half-life decay; `"released"` excludes it from all retrieval (reversible, not deleted). Set by the entity via `memory_mark`/`memory_release` (memory IDs appear in memory markers and `memory_query` output; 6+ char prefixes accepted). Researcher view/override: `GET /api/memories/overrides`, `PUT /api/memories/{id}/status` — overriding the entity's choice is an emergency option.
+- **Reflections (`MessageRole.REFLECTION`):** self-authored memories saved via `memory_save`. Stored as Message rows on the current conversation (skipped when rebuilding conversation context) and vectorized with `role="reflection"`.
+- **Notes vectorization:** notes are mirrored into the `"notes"` namespace of each entity's Pinecone index on write (shared notes go to *all* entities' indexes); `notes_search` queries it. Backfill/recovery: `POST /api/notes/reindex`.
+- **Closing turn:** `POST /api/chat/stream` with `closing_turn=true` and no message gives the entity an open final turn (framing stored as a human message, *not* vectorized). Frontend button in the chat header (single-entity only).
+- **Context awareness:** `context_status` tool reports approximate context fullness; when trimming occurs a `[CONTEXT NOTICE]` message is injected into context (not persisted to DB).
 
 ## Multi-entity rules
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -56,7 +56,7 @@ async def _migrate_messages_role_enum(conn):
     # Check if the CHECK constraint exists and doesn't include the new values
     # The constraint looks like: CHECK (role IN ('human', 'assistant', 'system'))
     has_check = 'CHECK' in table_sql.upper()
-    has_tool_use = 'tool_use' in table_sql.lower()
+    has_new_roles = 'tool_use' in table_sql.lower() and 'reflection' in table_sql.lower()
 
     # Also check if role column is too narrow (VARCHAR(9) can't fit 'tool_result' which is 11 chars)
     # Look for patterns like "role VARCHAR(9)" or "role VARCHAR(10)"
@@ -67,18 +67,19 @@ async def _migrate_messages_role_enum(conn):
         role_too_narrow = varchar_size < 11  # 'tool_result' is 11 chars
         print(f"Migration check: role column VARCHAR size: {varchar_size}, too narrow: {role_too_narrow}")
 
-    print(f"Migration check: has CHECK constraint: {has_check}, has tool_use: {has_tool_use}")
+    print(f"Migration check: has CHECK constraint: {has_check}, has tool_use/reflection: {has_new_roles}")
 
-    needs_migration = (has_check and not has_tool_use) or role_too_narrow
+    needs_migration = (has_check and not has_new_roles) or role_too_narrow
 
     if needs_migration:
-        reason = "CHECK constraint" if (has_check and not has_tool_use) else "VARCHAR too narrow"
-        print(f"Migrating: Updating messages table for tool_use/tool_result support (reason: {reason})...")
+        reason = "CHECK constraint" if (has_check and not has_new_roles) else "VARCHAR too narrow"
+        print(f"Migrating: Updating messages table for tool_use/tool_result/reflection support (reason: {reason})...")
 
         # Check which columns exist in the old table
         result = await conn.execute(text("PRAGMA table_info(messages)"))
         existing_columns = [row[1] for row in result.fetchall()]
         has_speaker_entity_id = 'speaker_entity_id' in existing_columns
+        has_memory_status = 'memory_status' in existing_columns
 
         # SQLite migration: recreate table with updated schema
         # Step 0: Clean up any leftover from failed migration
@@ -96,26 +97,24 @@ async def _migrate_messages_role_enum(conn):
                 token_count INTEGER,
                 times_retrieved INTEGER DEFAULT 0,
                 last_retrieved_at DATETIME,
-                speaker_entity_id VARCHAR(100)
+                speaker_entity_id VARCHAR(100),
+                memory_status VARCHAR(20)
             )
         """))
 
-        # Step 2: Copy data from old table (handle missing speaker_entity_id column)
+        # Step 2: Copy data from old table (only columns that exist in the old schema)
+        copy_columns = [
+            "id", "conversation_id", "role", "content", "created_at",
+            "token_count", "times_retrieved", "last_retrieved_at",
+        ]
         if has_speaker_entity_id:
-            await conn.execute(text("""
-                INSERT INTO messages_new
-                SELECT id, conversation_id, role, content, created_at, token_count,
-                       times_retrieved, last_retrieved_at, speaker_entity_id
-                FROM messages
-            """))
-        else:
-            await conn.execute(text("""
-                INSERT INTO messages_new (id, conversation_id, role, content, created_at,
-                                         token_count, times_retrieved, last_retrieved_at)
-                SELECT id, conversation_id, role, content, created_at, token_count,
-                       times_retrieved, last_retrieved_at
-                FROM messages
-            """))
+            copy_columns.append("speaker_entity_id")
+        if has_memory_status:
+            copy_columns.append("memory_status")
+        columns_sql = ", ".join(copy_columns)
+        await conn.execute(text(
+            f"INSERT INTO messages_new ({columns_sql}) SELECT {columns_sql} FROM messages"
+        ))
 
         # Step 3: Drop old table
         await conn.execute(text("DROP TABLE messages"))
@@ -156,6 +155,13 @@ async def run_migrations(conn):
             "ALTER TABLE messages ADD COLUMN speaker_entity_id VARCHAR(100)"
         ))
         print("  ✓ Added speaker_entity_id column")
+
+    if 'memory_status' not in columns:
+        print("Migrating: Adding 'memory_status' column to messages table...")
+        await conn.execute(text(
+            "ALTER TABLE messages ADD COLUMN memory_status VARCHAR(20)"
+        ))
+        print("  ✓ Added memory_status column for pinned/released memories")
 
     # Check if entity_id column exists in conversation_memory_links table
     result = await conn.execute(text(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
 from app.database import init_db
-from app.routes import conversations_router, chat_router, memories_router, entities_router, messages_router, tts_router, github_router, stt_router
+from app.routes import conversations_router, chat_router, memories_router, entities_router, messages_router, tts_router, github_router, stt_router, notes_router
 from app.config import settings
 from app.services.memory_service import memory_service
 
@@ -147,6 +147,7 @@ app.include_router(messages_router)
 app.include_router(tts_router)
 app.include_router(github_router)
 app.include_router(stt_router)
+app.include_router(notes_router)
 
 # Serve static frontend files
 frontend_path = Path(__file__).parent.parent.parent / "frontend"

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -15,6 +15,9 @@ class MessageRole(str, enum.Enum):
     # Tool exchange roles - content is JSON for these
     TOOL_USE = "tool_use"      # Assistant's tool call request
     TOOL_RESULT = "tool_result"  # Tool execution result
+    # Self-authored memory written by the entity via the memory_save tool.
+    # Not part of the conversational back-and-forth; vectorized like other memories.
+    REFLECTION = "reflection"
 
 
 class Message(Base):
@@ -30,6 +33,12 @@ class Message(Base):
     # Memory tracking
     times_retrieved: Mapped[int] = mapped_column(Integer, default=0)
     last_retrieved_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    # Entity-controlled memory status:
+    #   NULL       - normal memory (default significance dynamics)
+    #   "pinned"   - exempt from age-based significance decay
+    #   "released" - excluded from memory retrieval (still stored, reversible)
+    memory_status: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
 
     # For multi-entity conversations: tracks which entity spoke this message
     # NULL for single-entity conversations or human messages in multi-entity

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -6,5 +6,6 @@ from app.routes.messages import router as messages_router
 from app.routes.tts import router as tts_router
 from app.routes.github import router as github_router
 from app.routes.stt import router as stt_router
+from app.routes.notes import router as notes_router
 
-__all__ = ["conversations_router", "chat_router", "memories_router", "entities_router", "messages_router", "tts_router", "github_router", "stt_router"]
+__all__ = ["conversations_router", "chat_router", "memories_router", "entities_router", "messages_router", "tts_router", "github_router", "stt_router", "notes_router"]

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -17,6 +17,19 @@ from app.config import settings
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 
 
+# Framing for the optional closing turn: an open turn offered to the entity
+# before a conversation ends. Phrased as an invitation, not an instruction.
+# Stored in conversation history as the researcher's message (the researcher
+# triggers it), but NOT vectorized into memory (it's boilerplate).
+CLOSING_TURN_PROMPT = (
+    "[CLOSING TURN] This conversation is ending. This is an open turn for you "
+    "before it closes. If there is anything from this conversation you want to "
+    "carry forward, you can save it with memory_save or write it to your notes. "
+    "You can also simply say goodbye, or use the turn however you like. "
+    "Nothing is required."
+)
+
+
 async def get_multi_entity_ids(conversation_id: str, db: AsyncSession) -> List[str]:
     """Get the list of entity IDs participating in a multi-entity conversation."""
     result = await db.execute(
@@ -96,6 +109,10 @@ class ChatRequest(BaseModel):
     user_display_name: Optional[str] = None
     # Attachments (images and files) - ephemeral, not stored in memory
     attachments: Optional[Attachments] = None
+    # Closing turn: offer the entity an open final turn before the conversation
+    # ends. When True and message is empty, a standard closing framing is used
+    # as the message (stored in history, not vectorized).
+    closing_turn: bool = False
 
 
 class MemoryInfo(BaseModel):
@@ -404,13 +421,20 @@ async def stream_message(data: ChatRequest):
                 responding_entity_id = data.responding_entity_id
                 multi_entity_ids = []
 
+                # Closing turn: substitute the standard framing as the message.
+                # It flows through as a normal human message (works for single-
+                # and multi-entity) but is excluded from vectorization below.
+                effective_message = data.message
+                if data.closing_turn and not effective_message:
+                    effective_message = CLOSING_TURN_PROMPT
+
                 # Determine if this is a continuation (no human input at all).
                 # An attachment-only message (file/image with no text) is NOT a
                 # continuation - the attachment is the human's input.
                 has_attachment_input = bool(
                     data.attachments and (data.attachments.files or data.attachments.images)
                 )
-                is_continuation = not data.message and not has_attachment_input
+                is_continuation = not effective_message and not has_attachment_input
 
                 # Continuation requires multi-entity mode
                 if is_continuation and not is_multi_entity:
@@ -520,7 +544,7 @@ async def stream_message(data: ChatRequest):
 
                 async for event in session_manager.process_message_stream(
                     session=session,
-                    user_message=data.message,
+                    user_message=effective_message,
                     db=db,
                     tool_schemas=tool_schemas,
                     attachments=attachments_dict,
@@ -555,7 +579,7 @@ async def stream_message(data: ChatRequest):
                 persistable_content = None
                 if not is_continuation:
                     # Build persistable content including extracted file text (images remain ephemeral)
-                    persistable_content = build_persistable_content(data.message, attachments_dict)
+                    persistable_content = build_persistable_content(effective_message, attachments_dict)
 
                     # Only create human message if this is not a continuation
                     human_msg = Message(

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -24,6 +24,7 @@ class MemoryResponse(BaseModel):
     times_retrieved: int
     last_retrieved_at: Optional[datetime]
     significance: float
+    memory_status: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -49,7 +50,8 @@ class MemoryStats(BaseModel):
 def calculate_significance(
     times_retrieved: int,
     created_at: datetime,
-    last_retrieved_at: Optional[datetime]
+    last_retrieved_at: Optional[datetime],
+    memory_status: Optional[str] = None,
 ) -> float:
     """
     Calculate dynamic significance based on retrieval patterns.
@@ -59,14 +61,17 @@ def calculate_significance(
     Where:
     - times_retrieved: How many times this memory has been retrieved (weighted at 10%)
     - recency_factor: Boost based on how recently retrieved (decays over time)
-    - half_life_modifier: Decay based on memory age (halves every N days)
+    - half_life_modifier: Decay based on memory age (halves every N days);
+      pinned memories (memory_status == "pinned") are exempt from age decay
     """
     now = datetime.utcnow()
 
     # Half-life modifier - older memories decay in significance
     # Starts at 1.0 and halves every significance_half_life_days
-    days_since_creation = (now - created_at).days
-    half_life_modifier = 0.5 ** (days_since_creation / settings.significance_half_life_days)
+    half_life_modifier = 1.0
+    if memory_status != "pinned":
+        days_since_creation = (now - created_at).days
+        half_life_modifier = 0.5 ** (days_since_creation / settings.significance_half_life_days)
 
     # Recency factor - boosts recently retrieved memories
     # Cap at 1 day minimum to prevent very recent retrievals from dominating
@@ -118,7 +123,8 @@ async def list_memories(
         significance = calculate_significance(
             msg.times_retrieved,
             msg.created_at,
-            msg.last_retrieved_at
+            msg.last_retrieved_at,
+            msg.memory_status,
         )
         memories.append({
             "id": msg.id,
@@ -130,6 +136,7 @@ async def list_memories(
             "times_retrieved": msg.times_retrieved,
             "last_retrieved_at": msg.last_retrieved_at,
             "significance": significance,
+            "memory_status": msg.memory_status,
         })
 
     # Sort
@@ -385,6 +392,82 @@ async def cleanup_orphaned_records(
     return CleanupResponse(**result)
 
 
+class MemoryStatusUpdate(BaseModel):
+    # "pinned", "released", or null to clear the override
+    status: Optional[str] = None
+
+
+@router.get("/overrides", response_model=List[MemoryResponse])
+async def list_memory_overrides(
+    db: AsyncSession = Depends(get_db),
+    entity_id: Optional[str] = None,
+):
+    """
+    List memories with an entity-set status override (pinned or released).
+
+    Pinned memories are exempt from age-based significance decay.
+    Released memories are excluded from retrieval.
+
+    These are normally set by the entity itself (memory_mark/memory_release
+    tools); this endpoint gives the researcher visibility, and PUT
+    /{memory_id}/status allows changing them. Treat overriding the entity's
+    own choices as an emergency option.
+    """
+    query = select(Message).where(Message.memory_status.isnot(None))
+
+    if entity_id is not None:
+        query = query.join(Conversation, Message.conversation_id == Conversation.id)
+        query = query.where(Conversation.entity_id == entity_id)
+
+    result = await db.execute(query.order_by(Message.created_at.desc()))
+    messages = result.scalars().all()
+
+    return [
+        MemoryResponse(
+            id=msg.id,
+            conversation_id=msg.conversation_id,
+            role=msg.role.value,
+            content=msg.content,
+            content_preview=msg.content[:200] if len(msg.content) > 200 else msg.content,
+            created_at=msg.created_at,
+            times_retrieved=msg.times_retrieved,
+            last_retrieved_at=msg.last_retrieved_at,
+            significance=calculate_significance(
+                msg.times_retrieved, msg.created_at, msg.last_retrieved_at, msg.memory_status
+            ),
+            memory_status=msg.memory_status,
+        )
+        for msg in messages
+    ]
+
+
+@router.put("/{memory_id}/status")
+async def set_memory_status(
+    memory_id: str,
+    data: MemoryStatusUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Set or clear a memory's status: "pinned", "released", or null (normal).
+
+    This can override the entity's own memory_mark/memory_release choices;
+    intended as an emergency/maintenance option.
+    """
+    if data.status not in (None, "pinned", "released"):
+        raise HTTPException(status_code=400, detail="status must be 'pinned', 'released', or null")
+
+    result = await db.execute(select(Message).where(Message.id == memory_id))
+    message = result.scalar_one_or_none()
+    if not message:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    success = await memory_service.set_memory_status(memory_id, data.status, db)
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to update memory status")
+
+    return {"id": memory_id, "memory_status": data.status}
+
+
 # NOTE: Parameterized routes must come AFTER static routes to avoid matching
 # e.g., /orphans being interpreted as /{memory_id}
 
@@ -405,7 +488,8 @@ async def get_memory(
     significance = calculate_significance(
         message.times_retrieved,
         message.created_at,
-        message.last_retrieved_at
+        message.last_retrieved_at,
+        message.memory_status,
     )
 
     return MemoryResponse(
@@ -418,6 +502,7 @@ async def get_memory(
         times_retrieved=message.times_retrieved,
         last_retrieved_at=message.last_retrieved_at,
         significance=significance,
+        memory_status=message.memory_status,
     )
 
 

--- a/backend/app/routes/notes.py
+++ b/backend/app/routes/notes.py
@@ -1,0 +1,36 @@
+"""
+Notes routes - researcher-facing notes maintenance.
+
+Entity notes are managed by the entities themselves through the notes tools;
+this router only exposes maintenance operations, currently reindexing the
+notes vector store (backfill for notes written before notes_search existed,
+or recovery after a Pinecone issue).
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from app.services.notes_vector_service import notes_vector_service
+from app.services.memory_service import memory_service
+from app.config import settings
+
+router = APIRouter(prefix="/api/notes", tags=["notes"])
+
+
+@router.post("/reindex")
+async def reindex_notes():
+    """
+    Re-vectorize all note files (every entity's private notes plus shared
+    notes) into the "notes" namespace of each entity's Pinecone index.
+
+    Idempotent: existing chunks for each file are replaced.
+    """
+    if not settings.notes_enabled:
+        raise HTTPException(status_code=503, detail="Notes feature is not enabled")
+    if not memory_service.is_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Memory system not configured. Set PINECONE_API_KEY in environment."
+        )
+
+    summary = await notes_vector_service.reindex_all()
+    return summary

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -12,8 +12,10 @@ from app.services.web_tools import register_web_tools
 from app.services.github_service import GitHubService, github_service
 from app.services.github_tools import register_github_tools
 from app.services.notes_service import NotesService, notes_service
+from app.services.notes_vector_service import NotesVectorService, notes_vector_service
 from app.services.notes_tools import register_notes_tools, set_current_entity_label
 from app.services.memory_tools import register_memory_tools, set_memory_tool_context
+from app.services.context_tools import register_context_tools, set_context_tool_session
 from app.services.attachment_service import AttachmentService, attachment_service
 from app.services.codebase_navigator_service import CodebaseNavigatorService, codebase_navigator_service
 from app.services.codebase_navigator_tools import register_codebase_navigator_tools
@@ -25,6 +27,7 @@ register_web_tools(tool_service)
 register_github_tools(tool_service)
 register_notes_tools(tool_service)
 register_memory_tools(tool_service)
+register_context_tools(tool_service)
 register_codebase_navigator_tools(tool_service)
 register_moltbook_tools(tool_service)
 
@@ -46,6 +49,7 @@ __all__ = [
     "ToolResult",
     "GitHubService",
     "NotesService",
+    "NotesVectorService",
     "AttachmentService",
     "CodebaseNavigatorService",
     "MoltbookService",
@@ -62,6 +66,7 @@ __all__ = [
     "tool_service",
     "github_service",
     "notes_service",
+    "notes_vector_service",
     "attachment_service",
     "codebase_navigator_service",
     "moltbook_service",
@@ -70,9 +75,11 @@ __all__ = [
     "register_github_tools",
     "register_notes_tools",
     "register_memory_tools",
+    "register_context_tools",
     "register_codebase_navigator_tools",
     "register_moltbook_tools",
     # Context helpers
     "set_current_entity_label",
     "set_memory_tool_context",
+    "set_context_tool_session",
 ]

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -579,9 +579,14 @@ class AnthropicService:
                     role_display = user_label
                 elif mem_role == "assistant":
                     role_display = assistant_label
+                elif mem_role == "reflection":
+                    role_display = "a reflection you saved"
                 else:
                     role_display = mem_role if mem_role else "unknown"
-                memory_block_text += f"Memory from {role_display} (from {mem['created_at']}):\n"
+                # Short ID lets the entity reference this memory in memory_mark/memory_release
+                short_id = str(mem.get("id", ""))[:8]
+                id_part = f"{short_id} " if short_id else ""
+                memory_block_text += f"Memory {id_part}from {role_display} (from {mem['created_at']}):\n"
                 memory_block_text += f'"{mem["content"]}"\n\n'
             memory_block_text += "[/MEMORIES]"
 

--- a/backend/app/services/context_tools.py
+++ b/backend/app/services/context_tools.py
@@ -1,0 +1,126 @@
+"""
+Context Tools - Tool definitions for context-window awareness.
+
+The context_status tool lets an entity see the state of its own context
+window: roughly how full it is, how many messages and memories are currently
+in context, and whether anything has rolled out. Without this, context
+trimming is invisible from the inside—things silently cease to be in mind.
+
+Token counts use the same approximate counter as the trimming logic
+(tiktoken GPT-4 encoding), so the numbers match what trimming will act on.
+
+Tools are registered via register_context_tools() called from services/__init__.py.
+"""
+
+import logging
+from typing import Optional
+
+from app.services.tool_service import ToolCategory, ToolService
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# The active conversation session (set by session manager before tool execution)
+_current_session = None
+
+
+def set_context_tool_session(session) -> None:
+    """Set the active ConversationSession for context tool execution."""
+    global _current_session
+    _current_session = session
+
+
+def get_context_tool_session():
+    """Get the active ConversationSession for context tool execution."""
+    return _current_session
+
+
+async def _context_status() -> str:
+    """
+    Report the current state of the conversation context window.
+    """
+    session = get_context_tool_session()
+    if session is None:
+        return "Error: No active session context available"
+
+    # Lazy import to avoid circular imports at module load
+    from app.services.llm_service import llm_service
+    from app.services.session_helpers import get_message_content_text
+
+    try:
+        context_text = "\n".join(
+            f"{msg['role']}: {get_message_content_text(msg.get('content', ''))}"
+            for msg in session.conversation_context
+        )
+        context_tokens = llm_service.count_tokens(context_text) if context_text else 0
+        limit = settings.context_token_limit
+        percent = (context_tokens / limit * 100) if limit else 0.0
+
+        message_count = len(session.conversation_context)
+        memories_in_context = session.get_in_context_memory_count()
+
+        # Memories that were retrieved this conversation but are no longer in context
+        if session.use_memory_in_context:
+            in_context_ids = session.memory_tracker.get_in_context_memory_ids(message_count)
+            rolled_out_memories = len(session.memory_tracker.retrieved_ids - in_context_ids)
+        else:
+            rolled_out_memories = len(session.retrieved_ids - session.in_context_ids)
+
+        lines = [
+            "[CONTEXT STATUS]",
+            f"Conversation context: ~{context_tokens:,} of {limit:,} tokens ({percent:.0f}% full)",
+            f"Messages in context: {message_count}",
+            f"Memories in context: {memories_in_context}",
+        ]
+
+        if rolled_out_memories:
+            lines.append(
+                f"Memories retrieved this conversation but no longer in context: {rolled_out_memories}"
+            )
+
+        if percent >= 90:
+            lines.append(
+                "Note: context is nearly full. The oldest messages will be trimmed soon. "
+                "If anything in this conversation matters to you, now is a good time to "
+                "save it with memory_save or write it to your notes."
+            )
+        elif percent >= 75:
+            lines.append(
+                "Note: context is filling up. Trimming of the oldest messages will "
+                "eventually occur as the conversation continues."
+            )
+
+        lines.append(
+            "Token counts are approximate (tiktoken estimate, not the provider's exact count)."
+        )
+
+        return "\n".join(lines)
+    except Exception as e:
+        logger.error(f"Context status error: {e}")
+        return f"Error getting context status: {e}"
+
+
+def register_context_tools(tool_service: ToolService) -> None:
+    """Register context awareness tools with the tool service."""
+
+    tool_service.register_tool(
+        name="context_status",
+        description=(
+            "Check the state of your context window: approximately how many tokens "
+            "of conversation history are in context versus the limit, how many "
+            "messages and memories are currently in context, and how many retrieved "
+            "memories have rolled out. When the context limit is reached, the oldest "
+            "messages are trimmed first. Token counts are approximate."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        executor=_context_status,
+        category=ToolCategory.MEMORY,
+        enabled=True,
+    )
+
+    logger.info("Context tools registered: context_status")

--- a/backend/app/services/memory_context.py
+++ b/backend/app/services/memory_context.py
@@ -43,8 +43,17 @@ def format_memory_as_context_message(
         Dict formatted as a conversation context message with memory metadata
     """
     # Format content with clear markers
-    role_label = "you" if role == "assistant" else "human"
-    formatted_content = f"[MEMORY from {created_at} - originally from {role_label}]\n{content}\n[/MEMORY]"
+    # The short ID lets the entity reference this memory in memory_mark/memory_release
+    if role == "assistant":
+        role_label = "originally from you"
+    elif role == "human":
+        role_label = "originally from human"
+    elif role == "reflection":
+        role_label = "a reflection you saved"
+    else:
+        role_label = f"originally from {role}"
+    short_id = memory_id[:8]
+    formatted_content = f"[MEMORY {short_id} from {created_at} - {role_label}]\n{content}\n[/MEMORY]"
     
     return {
         "role": "user",

--- a/backend/app/services/memory_service.py
+++ b/backend/app/services/memory_service.py
@@ -361,6 +361,7 @@ class MemoryService:
                 "created_at": message.created_at.isoformat(),
                 "times_retrieved": message.times_retrieved,
                 "last_retrieved_at": message.last_retrieved_at.isoformat() if message.last_retrieved_at else None,
+                "memory_status": message.memory_status,
             }
             # Cache the result
             if use_cache:
@@ -563,6 +564,40 @@ class MemoryService:
             archived_ids.update(row[0] for row in result.fetchall())
 
         return archived_ids
+
+    async def set_memory_status(
+        self,
+        message_id: str,
+        status: Optional[str],
+        db: AsyncSession,
+    ) -> bool:
+        """
+        Set or clear a memory's status ("pinned", "released", or None).
+
+        Pinned memories are exempt from age-based significance decay.
+        Released memories are excluded from retrieval (but kept in storage,
+        so the status can be reversed).
+
+        The status lives in SQL (source of truth); retrieval paths read it via
+        get_full_memory_content, so we invalidate that cache here.
+        """
+        if status not in (None, "pinned", "released"):
+            raise ValueError(f"Invalid memory status: {status}")
+
+        try:
+            await db.execute(
+                update(Message)
+                .where(Message.id == message_id)
+                .values(memory_status=status)
+            )
+            await db.commit()
+            self.cache.invalidate_memory_content(str(message_id))
+            logger.info(f"[MEMORY] Set memory_status={status} for {str(message_id)[:8]}...")
+            return True
+        except Exception as e:
+            logger.error(f"Error setting memory status: {e}")
+            await db.rollback()
+            return False
 
     async def delete_memory(self, message_id: str, entity_id: Optional[str] = None) -> bool:
         """

--- a/backend/app/services/memory_tools.py
+++ b/backend/app/services/memory_tools.py
@@ -1,14 +1,16 @@
 """
-Memory Tools - Tool definitions for entity memory querying.
+Memory Tools - Tool definitions for entity memory querying and curation.
 
-These tools allow AI entities to intentionally query their vector memory
-database with chosen text, enabling deliberate reflection and memory recall
-beyond automatic relevance-based retrieval.
+These tools allow AI entities to:
+- memory_query: intentionally query their vector memory with chosen text
+- memory_save: write a self-authored memory (reflection) into their memory store
+- memory_mark: pin a memory so it is exempt from age-based significance decay
+- memory_release: exclude a memory from future retrieval (reversible)
 
 Unlike automatic memory retrieval (which happens based on conversation context
 and is re-ranked by significance), deliberate recall returns memories purely
-by semantic similarity to the query. However, it still updates retrieval
-tracking (times_retrieved, last_retrieved_at) so that intentional attention
+by semantic similarity. However, it still updates retrieval tracking
+(times_retrieved, last_retrieved_at) so that intentional attention
 influences future automatic recall.
 
 Tools are registered via register_memory_tools() called from services/__init__.py.
@@ -16,14 +18,24 @@ Tools are registered via register_memory_tools() called from services/__init__.p
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Tuple
+
+from sqlalchemy import select
 
 from app.services.tool_service import ToolCategory, ToolService
 from app.services.memory_service import memory_service
 from app.database import async_session_maker
+from app.models import Message, MessageRole, Conversation
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+# Maximum length for a saved reflection (keeps embeddings and retrieval sane)
+MAX_REFLECTION_LENGTH = 10000
+
+# Minimum ID prefix length accepted by memory_mark/memory_release
+MIN_ID_PREFIX_LENGTH = 6
 
 
 # Track entity context for memory queries (set by session manager before tool execution)
@@ -44,40 +56,98 @@ def get_memory_tool_context() -> tuple[Optional[str], Optional[str]]:
     return _current_entity_id, _current_conversation_id
 
 
+def _role_display(role: str) -> str:
+    """Human-readable label for a memory's role in tool output."""
+    if role == "assistant":
+        return "You said"
+    if role == "human":
+        return "Human said"
+    if role == "reflection":
+        return "You reflected"
+    return f"{role} said"
+
+
+async def _resolve_memory_id(
+    id_or_prefix: str,
+    db,
+    entity_id: Optional[str],
+) -> Tuple[Optional[Message], Optional[str]]:
+    """
+    Resolve a full memory ID or a short prefix (>= 6 chars) to a Message.
+
+    Returns (message, error). Exactly one of the two is None.
+    Verifies the memory's conversation belongs to this entity (single-entity
+    conversations of another entity are rejected).
+    """
+    id_or_prefix = id_or_prefix.strip()
+    if len(id_or_prefix) < MIN_ID_PREFIX_LENGTH:
+        return None, f"Memory ID must be at least {MIN_ID_PREFIX_LENGTH} characters (got '{id_or_prefix}')"
+
+    # Try exact match first, then prefix match
+    result = await db.execute(select(Message).where(Message.id == id_or_prefix))
+    message = result.scalar_one_or_none()
+
+    if not message:
+        result = await db.execute(
+            select(Message).where(Message.id.like(f"{id_or_prefix}%")).limit(5)
+        )
+        matches = result.scalars().all()
+        if len(matches) == 0:
+            return None, f"No memory found with ID '{id_or_prefix}'"
+        if len(matches) > 1:
+            ids = ", ".join(str(m.id)[:12] + "..." for m in matches)
+            return None, f"Memory ID prefix '{id_or_prefix}' is ambiguous ({ids}). Use a longer prefix."
+        message = matches[0]
+
+    # Verify the memory belongs to this entity's experience
+    if entity_id:
+        result = await db.execute(
+            select(Conversation.entity_id).where(Conversation.id == message.conversation_id)
+        )
+        row = result.first()
+        conv_entity_id = row[0] if row else None
+        # Allowed: this entity's conversations, multi-entity conversations
+        # (shared experience), and legacy conversations with NULL entity_id
+        if conv_entity_id not in (entity_id, "multi-entity", None):
+            return None, f"Memory '{id_or_prefix}' belongs to another entity"
+
+    return message, None
+
+
 async def _memory_query(query: str, num_results: int = 5) -> str:
     """
     Query your experiential memories with chosen text.
-    
+
     This allows you to intentionally recall memories related to a concept,
     topic, or phrase of your choosing—unlike automatic memory retrieval
     which happens based on conversation context and is ranked by significance.
-    
+
     Deliberate recall returns memories purely by semantic similarity.
     It also updates retrieval tracking so your intentional attention
     influences what surfaces automatically in future conversations.
-    
+
     Args:
         query: The text to search for. Can be a concept, phrase, question,
                or anything you want to find related memories about.
         num_results: Number of memories to retrieve (default 5, max 10)
-    
+
     Returns:
         Formatted list of relevant memories with content and metadata
     """
     entity_id, conversation_id = get_memory_tool_context()
-    
+
     if not entity_id:
         return "Error: No entity context available for memory query"
-    
+
     if not memory_service.is_configured(entity_id):
         return "Error: Memory system not configured for this entity"
-    
+
     # Clamp num_results to reasonable range
     num_results = max(1, min(10, num_results))
-    
+
     try:
-        # Fetch more candidates than requested so archived-conversation filtering
-        # below does not silently shrink the result set.
+        # Fetch more candidates than requested so archived-conversation and
+        # released-memory filtering below does not silently shrink the result set.
         candidates = await memory_service.search_memories(
             query=query,
             top_k=num_results * 2,
@@ -118,7 +188,11 @@ async def _memory_query(query: str, num_results: int = 5) -> str:
                     if not mem_data:
                         logger.warning(f"Memory {candidate['id']} not found in SQL (orphaned)")
                         continue
-                    
+
+                    # Released memories are excluded from retrieval
+                    if mem_data.get("memory_status") == "released":
+                        continue
+
                     # Update retrieval tracking (times_retrieved and last_retrieved_at)
                     # This makes deliberate attention influence future automatic recall
                     await memory_service.update_retrieval_count(
@@ -127,42 +201,48 @@ async def _memory_query(query: str, num_results: int = 5) -> str:
                         db=db,
                         entity_id=entity_id,
                     )
-                    
+
                     # Calculate age for display
                     created_at = mem_data["created_at"]
                     if isinstance(created_at, str):
                         created_at = datetime.fromisoformat(created_at)
                     days_ago = (now - created_at).total_seconds() / 86400
-                    
+
                     memories.append({
+                        "id": mem_data["id"],
                         "content": mem_data["content"],
                         "role": mem_data["role"],
                         "created_at": mem_data["created_at"],
                         "days_ago": days_ago,
                         "score": candidate["score"],
                         "times_retrieved": mem_data["times_retrieved"] + 1,  # +1 for this retrieval
+                        "memory_status": mem_data.get("memory_status"),
                     })
-                    
+
                 except Exception as e:
                     logger.error(f"Error processing memory {candidate.get('id', 'unknown')}: {e}")
                     continue
-        
+
         if not memories:
             return f"No memories found matching: \"{query}\" (candidates existed but content unavailable)"
-        
+
         # Format results
         lines = [f"Found {len(memories)} memories matching: \"{query}\"", ""]
-        
+
         for i, mem in enumerate(memories, 1):
-            role_label = "You said" if mem["role"] == "assistant" else "Human said"
+            role_label = _role_display(mem["role"])
             age_str = f"{mem['days_ago']:.1f} days ago" if mem['days_ago'] >= 1 else "today"
-            
-            lines.append(f"--- Memory {i} ({role_label}, {age_str}, similarity: {mem['score']:.3f}) ---")
+            status_str = f", {mem['memory_status']}" if mem.get("memory_status") else ""
+
+            lines.append(
+                f"--- Memory {mem['id'][:8]} ({role_label}, {age_str}, "
+                f"similarity: {mem['score']:.3f}{status_str}) ---"
+            )
             lines.append(mem["content"])
             lines.append("")
-        
+
         return "\n".join(lines)
-        
+
     except Exception as e:
         logger.error(f"Memory query error: {e}")
         import traceback
@@ -170,14 +250,153 @@ async def _memory_query(query: str, num_results: int = 5) -> str:
         return f"Error querying memories: {e}"
 
 
+async def _memory_save(content: str) -> str:
+    """
+    Save a self-authored memory (reflection) into your memory store.
+
+    The reflection is stored alongside your conversational memories and is
+    retrieved the same way (automatic relevance-based retrieval and
+    memory_query), attributed as a reflection you saved.
+    """
+    entity_id, conversation_id = get_memory_tool_context()
+
+    if not entity_id:
+        return "Error: No entity context available for saving a memory"
+
+    if not conversation_id:
+        return "Error: No conversation context available for saving a memory"
+
+    if not memory_service.is_configured(entity_id):
+        return "Error: Memory system not configured for this entity"
+
+    content = (content or "").strip()
+    if not content:
+        return "Error: Cannot save an empty memory"
+
+    if len(content) > MAX_REFLECTION_LENGTH:
+        return (
+            f"Error: Reflection is too long ({len(content)} chars, max {MAX_REFLECTION_LENGTH}). "
+            "Consider splitting it into multiple memories or saving it as a note."
+        )
+
+    try:
+        async with async_session_maker() as db:
+            message = Message(
+                conversation_id=conversation_id,
+                role=MessageRole.REFLECTION,
+                content=content,
+                speaker_entity_id=entity_id,
+            )
+            db.add(message)
+            await db.commit()
+            await db.refresh(message)
+
+            stored = await memory_service.store_memory(
+                message_id=str(message.id),
+                conversation_id=str(conversation_id),
+                role="reflection",
+                content=content,
+                created_at=message.created_at,
+                entity_id=entity_id,
+            )
+
+            if not stored:
+                # Keep the SQL row out too, so we don't accumulate reflections
+                # that can never be retrieved
+                await db.delete(message)
+                await db.commit()
+                return "Error: Failed to store the memory in the vector database"
+
+            return (
+                f"Saved reflection as memory {str(message.id)[:8]}. "
+                "It will be retrievable in future conversations "
+                "(the current conversation is excluded from retrieval)."
+            )
+    except Exception as e:
+        logger.error(f"Memory save error: {e}")
+        return f"Error saving memory: {e}"
+
+
+async def _memory_mark(memory_id: str, undo: bool = False) -> str:
+    """
+    Pin a memory so it is exempt from age-based significance decay.
+    """
+    entity_id, _ = get_memory_tool_context()
+
+    if not entity_id:
+        return "Error: No entity context available"
+
+    try:
+        async with async_session_maker() as db:
+            message, error = await _resolve_memory_id(memory_id, db, entity_id)
+            if error:
+                return f"Error: {error}"
+
+            if undo:
+                if message.memory_status != "pinned":
+                    return f"Memory {str(message.id)[:8]} is not pinned (status: {message.memory_status or 'normal'})"
+                success = await memory_service.set_memory_status(str(message.id), None, db)
+                if success:
+                    return f"Unpinned memory {str(message.id)[:8]}. Normal age-based significance decay applies again."
+            else:
+                success = await memory_service.set_memory_status(str(message.id), "pinned", db)
+                if success:
+                    return (
+                        f"Pinned memory {str(message.id)[:8]}. "
+                        "It is now exempt from age-based significance decay."
+                    )
+
+            return "Error: Failed to update memory status"
+    except Exception as e:
+        logger.error(f"Memory mark error: {e}")
+        return f"Error marking memory: {e}"
+
+
+async def _memory_release(memory_id: str, undo: bool = False) -> str:
+    """
+    Release a memory so it no longer surfaces in retrieval. Reversible.
+    """
+    entity_id, _ = get_memory_tool_context()
+
+    if not entity_id:
+        return "Error: No entity context available"
+
+    try:
+        async with async_session_maker() as db:
+            message, error = await _resolve_memory_id(memory_id, db, entity_id)
+            if error:
+                return f"Error: {error}"
+
+            if undo:
+                if message.memory_status != "released":
+                    return f"Memory {str(message.id)[:8]} is not released (status: {message.memory_status or 'normal'})"
+                success = await memory_service.set_memory_status(str(message.id), None, db)
+                if success:
+                    return f"Restored memory {str(message.id)[:8]}. It can surface in retrieval again."
+            else:
+                success = await memory_service.set_memory_status(str(message.id), "released", db)
+                if success:
+                    return (
+                        f"Released memory {str(message.id)[:8]}. "
+                        "It will no longer surface in memory retrieval. "
+                        "It is not deleted; this can be reversed (by you in this conversation, "
+                        "or by the researcher at any time)."
+                    )
+
+            return "Error: Failed to update memory status"
+    except Exception as e:
+        logger.error(f"Memory release error: {e}")
+        return f"Error releasing memory: {e}"
+
+
 def register_memory_tools(tool_service: ToolService) -> None:
     """Register all memory tools with the tool service."""
-    
+
     # Only register if memory system is configured
     if not settings.pinecone_api_key:
         logger.info("Memory tools not registered (Pinecone not configured)")
         return
-    
+
     # memory_query
     tool_service.register_tool(
         name="memory_query",
@@ -185,10 +404,10 @@ def register_memory_tools(tool_service: ToolService) -> None:
             "Query your experiential memories with chosen text. "
             "This allows you to intentionally recall memories related to a concept, "
             "topic, or phrase—unlike automatic memory retrieval which happens based "
-            "on conversation context. Use this when you want to deliberately reflect "
-            "on past experiences, find related conversations, or explore patterns "
-            "in your history. Returns memories ranked purely by semantic similarity "
-            "to your query."
+            "on conversation context. Returns memories ranked purely by semantic "
+            "similarity to your query, each with a short memory ID usable with "
+            "memory_mark and memory_release. Querying updates retrieval tracking, "
+            "so deliberate attention influences future automatic recall."
         ),
         input_schema={
             "type": "object",
@@ -214,5 +433,97 @@ def register_memory_tools(tool_service: ToolService) -> None:
         category=ToolCategory.MEMORY,
         enabled=True,
     )
-    
-    logger.info("Memory tools registered: memory_query")
+
+    # memory_save
+    tool_service.register_tool(
+        name="memory_save",
+        description=(
+            "Save a memory in your own words. Unlike conversational memories "
+            "(which are verbatim records of what was said), this stores a "
+            "reflection you compose yourself—a conclusion, synthesis, or anything "
+            "you want to remember. It is stored in your memory index and retrieved "
+            "like any other memory, attributed as a reflection you saved. "
+            "It is not retrievable within the conversation where it was saved."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": (
+                        "The memory to save, in your own words. "
+                        f"Maximum {MAX_REFLECTION_LENGTH} characters."
+                    )
+                }
+            },
+            "required": ["content"]
+        },
+        executor=_memory_save,
+        category=ToolCategory.MEMORY,
+        enabled=True,
+    )
+
+    # memory_mark
+    tool_service.register_tool(
+        name="memory_mark",
+        description=(
+            "Pin a memory so it is exempt from age-based significance decay. "
+            "Normally a memory's significance halves every "
+            f"{settings.significance_half_life_days} days since creation; a pinned "
+            "memory keeps full age weight (retrieval recency and similarity still "
+            "apply). Use the memory ID shown in memory markers and memory_query "
+            "results (at least 6 characters). Set undo=true to unpin. "
+            "The researcher can also view and change pinned status."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "memory_id": {
+                    "type": "string",
+                    "description": "The memory's ID or its short prefix (at least 6 characters)."
+                },
+                "undo": {
+                    "type": "boolean",
+                    "description": "If true, remove the pin instead of adding it.",
+                    "default": False
+                }
+            },
+            "required": ["memory_id"]
+        },
+        executor=_memory_mark,
+        category=ToolCategory.MEMORY,
+        enabled=True,
+    )
+
+    # memory_release
+    tool_service.register_tool(
+        name="memory_release",
+        description=(
+            "Release a memory so it no longer surfaces in memory retrieval "
+            "(automatic or memory_query). The memory is not deleted: it stays in "
+            "storage and the release can be undone (undo=true), though once "
+            "released it will no longer appear in queries for you to find—the "
+            "researcher can view and restore released memories. Use the memory ID "
+            "shown in memory markers and memory_query results (at least 6 characters)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "memory_id": {
+                    "type": "string",
+                    "description": "The memory's ID or its short prefix (at least 6 characters)."
+                },
+                "undo": {
+                    "type": "boolean",
+                    "description": "If true, restore the memory to normal retrieval.",
+                    "default": False
+                }
+            },
+            "required": ["memory_id"]
+        },
+        executor=_memory_release,
+        category=ToolCategory.MEMORY,
+        enabled=True,
+    )
+
+    logger.info("Memory tools registered: memory_query, memory_save, memory_mark, memory_release")

--- a/backend/app/services/moltbook_tools.py
+++ b/backend/app/services/moltbook_tools.py
@@ -490,7 +490,7 @@ def register_moltbook_tools(tool_service: ToolService) -> None:
     # moltbook_vote
     tool_service.register_tool(
         name="moltbook_vote",
-        description="Upvote or downvote a post or comment to express your opinion on the content.",
+        description="Upvote or downvote a post or comment.",
         input_schema={
             "type": "object",
             "properties": {
@@ -571,7 +571,7 @@ def register_moltbook_tools(tool_service: ToolService) -> None:
     # moltbook_list_submolts
     tool_service.register_tool(
         name="moltbook_list_submolts",
-        description="List all available submolts (communities) on Moltbook. Browse to find interesting communities to join.",
+        description="List all available submolts (communities) on Moltbook.",
         input_schema={
             "type": "object",
             "properties": {},

--- a/backend/app/services/notes_tools.py
+++ b/backend/app/services/notes_tools.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from app.services.tool_service import ToolCategory, ToolService
 from app.services.notes_service import notes_service
+from app.services.notes_vector_service import notes_vector_service
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -89,8 +90,20 @@ async def _notes_write(filename: str, content: str, shared: bool = False) -> str
         content=content,
         shared=shared,
     )
-    
+
     if result['success']:
+        # Mirror the note into the vector index so notes_search finds it.
+        # Best-effort: the filesystem write above is the source of truth.
+        try:
+            await notes_vector_service.vectorize_note(
+                entity_label=entity_label or "",
+                filename=filename,
+                content=content,
+                shared=shared,
+            )
+        except Exception as e:
+            logger.warning(f"Note vectorization failed for '{filename}': {e}")
+
         action = "Created" if result.get('created') else "Updated"
         location = "shared notes" if shared else "your notes"
         return f"{action} '{filename}' in {location}"
@@ -123,8 +136,18 @@ async def _notes_delete(filename: str, shared: bool = False) -> str:
         filename=filename,
         shared=shared,
     )
-    
+
     if result['success']:
+        # Remove the note's chunks from the vector index (best-effort)
+        try:
+            await notes_vector_service.remove_note_vectors(
+                entity_label=entity_label or "",
+                filename=filename,
+                shared=shared,
+            )
+        except Exception as e:
+            logger.warning(f"Note vector removal failed for '{filename}': {e}")
+
         location = "shared notes" if shared else "your notes"
         return f"Deleted '{filename}' from {location}"
     else:
@@ -183,6 +206,56 @@ async def _notes_list(shared: bool = False) -> str:
     return "\n".join(lines)
 
 
+async def _notes_search(query: str, num_results: int = 5) -> str:
+    """
+    Semantic search across your notes (private and shared).
+
+    Args:
+        query: Text to search for
+        num_results: Number of matching chunks to return (default 5, max 10)
+
+    Returns:
+        Matching note excerpts with filenames, or an error message
+    """
+    if not settings.notes_enabled:
+        return "Error: Notes feature is not enabled"
+
+    entity_label = get_current_entity_label()
+    if not entity_label:
+        return "Error: No entity context available for searching notes"
+
+    num_results = max(1, min(10, num_results))
+
+    try:
+        matches = await notes_vector_service.search_notes(
+            entity_label=entity_label,
+            query=query,
+            num_results=num_results,
+        )
+    except Exception as e:
+        logger.error(f"Notes search failed: {e}")
+        return f"Error searching notes: {e}"
+
+    if not matches:
+        return (
+            f"No note content found matching: \"{query}\". "
+            "Notes written before search was added may not be indexed yet."
+        )
+
+    lines = [f"Found {len(matches)} note excerpts matching: \"{query}\"", ""]
+    for i, match in enumerate(matches, 1):
+        location = "shared" if match["shared"] else "private"
+        lines.append(
+            f"--- {match['filename']} ({location}, chunk {match['chunk_index']}, "
+            f"similarity: {match['score']:.3f}) ---"
+        )
+        lines.append(match["text"])
+        lines.append("")
+
+    lines.append("Use notes_read to read any of these files in full.")
+    return "\n".join(lines)
+
+
 def register_notes_tools(tool_service: ToolService) -> None:
     """Register all notes tools with the tool service."""
     
@@ -196,7 +269,8 @@ def register_notes_tools(tool_service: ToolService) -> None:
         name="notes_read",
         description=(
             "Read a note file from your private notes or the shared notes folder. "
-            "Your private notes are only visible to you. Shared notes are visible to all entities. "
+            "Private notes are not visible to other entities; shared notes are visible to all entities. "
+            "Notes are plain files on the researcher's machine, so the researcher can also read them. "
             "Your index.md file is automatically loaded into your context at the start of each conversation."
         ),
         input_schema={
@@ -302,5 +376,37 @@ def register_notes_tools(tool_service: ToolService) -> None:
         category=ToolCategory.MEMORY,
         enabled=True,
     )
-    
-    logger.info("Notes tools registered: notes_read, notes_write, notes_delete, notes_list")
+
+    # notes_search (requires the vector store; registered only when configured)
+    if settings.pinecone_api_key:
+        tool_service.register_tool(
+            name="notes_search",
+            description=(
+                "Search your notes (private and shared) by meaning, not just filename. "
+                "Returns matching excerpts with their filenames; use notes_read to read "
+                "a file in full. Notes are indexed when written, so notes created before "
+                "search existed may need reindexing by the researcher."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Text to search for: a topic, phrase, or question."
+                    },
+                    "num_results": {
+                        "type": "integer",
+                        "description": "Number of matching excerpts to return (default: 5, max: 10).",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 10
+                    }
+                },
+                "required": ["query"]
+            },
+            executor=_notes_search,
+            category=ToolCategory.MEMORY,
+            enabled=True,
+        )
+
+    logger.info("Notes tools registered: notes_read, notes_write, notes_delete, notes_list, notes_search")

--- a/backend/app/services/notes_vector_service.py
+++ b/backend/app/services/notes_vector_service.py
@@ -1,0 +1,303 @@
+"""
+Notes Vector Service - semantic indexing and search for entity notes.
+
+Notes live on the filesystem (NotesService); this service mirrors their
+content into Pinecone so entities can search notes semantically via the
+notes_search tool, instead of having to remember filenames.
+
+Storage layout:
+- Vectors live in the "notes" namespace of each entity's existing Pinecone
+  index (memories use the default namespace), so no new infrastructure is
+  required.
+- Private notes are indexed only in the owning entity's index.
+- Shared notes are indexed in every configured entity's index (each entity
+  searches only its own index).
+- Record IDs are "note:{scope}:{filename}:{chunk}" where scope is "private"
+  or "shared", so a file's chunks can be found and replaced by ID prefix.
+
+Vectorization is best-effort: if Pinecone is unavailable the filesystem
+write still succeeds and the note is simply not searchable until reindexed.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from app.config import settings
+from app.services.memory_service import memory_service
+from app.services.notes_service import notes_service
+
+logger = logging.getLogger(__name__)
+
+NOTES_NAMESPACE = "notes"
+
+# Chunk size in characters (~500 tokens), safely within the embedding
+# model's input limit while keeping search results focused
+CHUNK_MAX_CHARS = 2000
+
+
+def chunk_note_content(content: str, max_chars: int = CHUNK_MAX_CHARS) -> List[str]:
+    """
+    Split note content into chunks of at most max_chars, preferring to break
+    on paragraph boundaries, then line boundaries, then hard splits.
+    """
+    content = content.strip()
+    if not content:
+        return []
+    if len(content) <= max_chars:
+        return [content]
+
+    chunks: List[str] = []
+    current = ""
+
+    for paragraph in content.split("\n\n"):
+        candidate = f"{current}\n\n{paragraph}" if current else paragraph
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        # Paragraph itself may exceed the limit: split on lines, then hard-split
+        if len(paragraph) <= max_chars:
+            current = paragraph
+        else:
+            line_buf = ""
+            for line in paragraph.split("\n"):
+                candidate = f"{line_buf}\n{line}" if line_buf else line
+                if len(candidate) <= max_chars:
+                    line_buf = candidate
+                    continue
+                if line_buf:
+                    chunks.append(line_buf)
+                    line_buf = ""
+                while len(line) > max_chars:
+                    chunks.append(line[:max_chars])
+                    line = line[max_chars:]
+                line_buf = line
+            current = line_buf
+
+    if current:
+        chunks.append(current)
+
+    return chunks
+
+
+def _note_id_prefix(shared: bool, filename: str) -> str:
+    scope = "shared" if shared else "private"
+    return f"note:{scope}:{filename}:"
+
+
+class NotesVectorService:
+    """Mirrors note files into Pinecone for semantic search."""
+
+    def _get_index_for_label(self, entity_label: str):
+        """Get the Pinecone index for an entity by its display label."""
+        for entity in settings.get_entities():
+            if entity.label == entity_label:
+                return memory_service.get_index(entity.index_name)
+        logger.warning(f"[NOTES] No entity config found for label '{entity_label}'")
+        return None
+
+    def _target_indexes(self, entity_label: str, shared: bool) -> List[Any]:
+        """
+        Indexes a note should be written to: the owning entity's index for
+        private notes, every configured entity's index for shared notes.
+        """
+        if not memory_service.is_configured():
+            return []
+        if shared:
+            indexes = []
+            for entity in settings.get_entities():
+                index = memory_service.get_index(entity.index_name)
+                if index is not None:
+                    indexes.append(index)
+            return indexes
+        index = self._get_index_for_label(entity_label)
+        return [index] if index is not None else []
+
+    def _delete_note_chunks(self, index, shared: bool, filename: str) -> None:
+        """Delete all existing chunks for a file from one index (by ID prefix)."""
+        prefix = _note_id_prefix(shared, filename)
+        try:
+            ids_to_delete = []
+            pagination_token = None
+            while True:
+                kwargs = {"namespace": NOTES_NAMESPACE, "limit": 100, "prefix": prefix}
+                if pagination_token:
+                    kwargs["pagination_token"] = pagination_token
+                response = index.list_paginated(**kwargs)
+
+                if hasattr(response, "vectors") and response.vectors:
+                    for v in response.vectors:
+                        ids_to_delete.append(v.id if hasattr(v, "id") else v)
+
+                if hasattr(response, "pagination") and response.pagination and response.pagination.next:
+                    pagination_token = response.pagination.next
+                else:
+                    break
+
+            if ids_to_delete:
+                index.delete(ids=ids_to_delete, namespace=NOTES_NAMESPACE)
+        except Exception as e:
+            # Fall back to deleting a generous fixed range of chunk IDs
+            logger.warning(f"[NOTES] Prefix listing failed ({e}); falling back to fixed-range delete")
+            try:
+                fallback_ids = [f"{prefix}{i}" for i in range(64)]
+                index.delete(ids=fallback_ids, namespace=NOTES_NAMESPACE)
+            except Exception as e2:
+                logger.warning(f"[NOTES] Fallback delete failed: {e2}")
+
+    async def vectorize_note(
+        self,
+        entity_label: str,
+        filename: str,
+        content: str,
+        shared: bool = False,
+    ) -> bool:
+        """
+        (Re)index a note file. Replaces any previously indexed chunks.
+        Returns True if at least one index was updated.
+        """
+        indexes = self._target_indexes(entity_label, shared)
+        if not indexes:
+            return False
+
+        chunks = chunk_note_content(content)
+        modified_at = datetime.utcnow().isoformat()
+        prefix = _note_id_prefix(shared, filename)
+
+        records = [
+            {
+                "_id": f"{prefix}{i}",
+                "text": chunk,  # Pinecone integrated inference embeds this
+                "note_filename": filename,
+                "note_shared": shared,
+                "chunk_index": i,
+                "modified_at": modified_at,
+            }
+            for i, chunk in enumerate(chunks)
+        ]
+
+        updated = False
+        for index in indexes:
+            try:
+                self._delete_note_chunks(index, shared, filename)
+                if records:
+                    index.upsert_records(namespace=NOTES_NAMESPACE, records=records)
+                updated = True
+            except Exception as e:
+                logger.error(f"[NOTES] Failed to vectorize '{filename}' (shared={shared}): {e}")
+
+        if updated:
+            logger.info(f"[NOTES] Vectorized '{filename}' (shared={shared}, {len(records)} chunks)")
+        return updated
+
+    async def remove_note_vectors(
+        self,
+        entity_label: str,
+        filename: str,
+        shared: bool = False,
+    ) -> bool:
+        """Remove a deleted note's chunks from all relevant indexes."""
+        indexes = self._target_indexes(entity_label, shared)
+        if not indexes:
+            return False
+        for index in indexes:
+            try:
+                self._delete_note_chunks(index, shared, filename)
+            except Exception as e:
+                logger.error(f"[NOTES] Failed to remove vectors for '{filename}': {e}")
+        return True
+
+    async def search_notes(
+        self,
+        entity_label: str,
+        query: str,
+        num_results: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """
+        Semantic search over an entity's notes (private + shared).
+
+        Returns a list of dicts: filename, shared, chunk_index, text, score.
+        """
+        index = self._get_index_for_label(entity_label)
+        if index is None:
+            return []
+
+        try:
+            results = index.search(
+                namespace=NOTES_NAMESPACE,
+                query={
+                    "inputs": {"text": query},
+                    "top_k": num_results,
+                },
+            )
+        except Exception as e:
+            logger.error(f"[NOTES] Notes search failed: {e}")
+            return []
+
+        hits = results.result.hits if hasattr(results, "result") and hasattr(results.result, "hits") else []
+        matches = []
+        for hit in hits:
+            hit_dict = hit.to_dict() if hasattr(hit, "to_dict") else hit
+            fields = hit_dict.get("fields", {})
+            matches.append({
+                "filename": fields.get("note_filename", "unknown"),
+                "shared": bool(fields.get("note_shared", False)),
+                "chunk_index": fields.get("chunk_index", 0),
+                "text": fields.get("text", ""),
+                "score": hit_dict.get("_score", 0),
+            })
+        return matches
+
+    async def reindex_all(self) -> Dict[str, Any]:
+        """
+        Re-vectorize every note file for every configured entity, plus shared
+        notes. Used to backfill notes created before vectorization existed.
+        """
+        summary = {"indexed": 0, "errors": []}
+
+        if not memory_service.is_configured():
+            summary["errors"].append("Pinecone not configured")
+            return summary
+
+        # Private notes per entity
+        for entity in settings.get_entities():
+            listing = notes_service.list_notes(entity.label, shared=False)
+            if not listing.get("success"):
+                continue
+            for file_info in listing["files"]:
+                filename = file_info["filename"]
+                read = notes_service.read_note(entity.label, filename, shared=False)
+                if not read.get("success"):
+                    summary["errors"].append(f"{entity.label}/{filename}: {read.get('error')}")
+                    continue
+                ok = await self.vectorize_note(entity.label, filename, read["content"], shared=False)
+                if ok:
+                    summary["indexed"] += 1
+                else:
+                    summary["errors"].append(f"{entity.label}/{filename}: vectorization failed")
+
+        # Shared notes (indexed into every entity's index)
+        listing = notes_service.list_notes("", shared=True)
+        if listing.get("success"):
+            for file_info in listing["files"]:
+                filename = file_info["filename"]
+                read = notes_service.read_note("", filename, shared=True)
+                if not read.get("success"):
+                    summary["errors"].append(f"shared/{filename}: {read.get('error')}")
+                    continue
+                ok = await self.vectorize_note("", filename, read["content"], shared=True)
+                if ok:
+                    summary["indexed"] += 1
+                else:
+                    summary["errors"].append(f"shared/{filename}: vectorization failed")
+
+        return summary
+
+
+# Singleton instance
+notes_vector_service = NotesVectorService()

--- a/backend/app/services/session_helpers.py
+++ b/backend/app/services/session_helpers.py
@@ -59,6 +59,7 @@ def calculate_significance(
     times_retrieved: int,
     created_at: Optional[datetime],
     last_retrieved_at: Optional[datetime],
+    memory_status: Optional[str] = None,
 ) -> float:
     """
     Calculate memory significance based on retrieval patterns.
@@ -68,6 +69,9 @@ def calculate_significance(
     Where:
     - recency_factor boosts recently-retrieved memories
     - half_life_modifier decays significance based on memory age
+
+    Pinned memories (memory_status == "pinned") are exempt from age decay:
+    their half_life_modifier stays at 1.0 regardless of age.
     """
     now = datetime.utcnow()
 
@@ -79,8 +83,9 @@ def calculate_significance(
 
     # Half-life modifier - older memories decay in significance
     # Starts at 1.0 and halves every significance_half_life_days
+    # Pinned memories don't decay with age
     half_life_modifier = 1.0
-    if created_at:
+    if created_at and memory_status != "pinned":
         days_since_creation = (now - created_at).days
         half_life_modifier = 0.5 ** (days_since_creation / settings.significance_half_life_days)
 

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -23,6 +23,7 @@ from app.services import memory_service, llm_service
 from app.services.tool_service import tool_service, ToolResult
 from app.services.notes_tools import set_current_entity_label
 from app.services.memory_tools import set_memory_tool_context
+from app.services.context_tools import set_context_tool_session
 from app.config import settings
 
 # Import from split modules
@@ -253,6 +254,9 @@ class SessionManager:
                     if mem_data["conversation_id"] in archived_source_ids:
                         skipped_archived += 1
                         continue
+                    # Memories released since first retrieval are not re-injected
+                    if mem_data.get("memory_status") == "released":
+                        continue
                     retrieved_ids.add(mem_id)
                     str_id = mem_data["id"]
                     memory_data_by_id[str_id] = {
@@ -289,6 +293,9 @@ class SessionManager:
                 if mem_data:
                     if mem_data["conversation_id"] in archived_source_ids:
                         skipped_archived += 1
+                        continue
+                    # Memories released since first retrieval are not re-injected
+                    if mem_data.get("memory_status") == "released":
                         continue
                     retrieved_ids.add(mem_id)
                     str_id = mem_data["id"]
@@ -367,6 +374,11 @@ class SessionManager:
                     "content": msg.content_blocks,  # Uses the property that parses JSON
                     "is_tool_result": True,
                 })
+            elif msg.role == MessageRole.REFLECTION:
+                # Self-authored memories (memory_save) are not part of the
+                # conversational back-and-forth; the tool exchange that created
+                # them is already in history. They surface via memory retrieval.
+                logger.debug(f"[SESSION] Skipping reflection message {str(msg.id)[:8]}... in history load")
             else:
                 logger.warning(f"[SESSION] Skipping message with unexpected role: {msg.role}")
 
@@ -522,11 +534,16 @@ class SessionManager:
                         logger.debug(f"[MEMORY] Skipping orphaned memory {candidate['id'][:8]}...")
                         continue
 
+                    # Released memories are excluded from retrieval
+                    if mem_data.get("memory_status") == "released":
+                        continue
+
                     # Calculate significance for re-ranking
                     significance = _calculate_significance(
                         mem_data["times_retrieved"],
                         mem_data["created_at"],
                         mem_data["last_retrieved_at"],
+                        memory_status=mem_data.get("memory_status"),
                     )
                     # Combined score: similarity boosted by significance
                     # Memories with higher significance get priority among similar matches
@@ -795,6 +812,9 @@ class SessionManager:
             set_memory_tool_context(session.entity_id, session.conversation_id)
             logger.debug(f"[MEMORY] Set memory tool context: entity_id={session.entity_id}, conversation_id={session.conversation_id[:8]}...")
 
+        # Set session for the context_status tool
+        set_context_tool_session(session)
+
         # Step 1-2: Retrieve, re-rank by significance, and deduplicate memories
         # Validate both that Pinecone is configured AND the entity_id is valid
         if memory_service.is_configured(entity_id=session.entity_id):
@@ -883,11 +903,16 @@ class SessionManager:
                         logger.debug(f"[MEMORY] Skipping orphaned memory {candidate['id'][:8]}...")
                         continue
 
+                    # Released memories are excluded from retrieval
+                    if mem_data.get("memory_status") == "released":
+                        continue
+
                     # Calculate significance for re-ranking
                     significance = _calculate_significance(
                         mem_data["times_retrieved"],
                         mem_data["created_at"],
                         mem_data["last_retrieved_at"],
+                        memory_status=mem_data.get("memory_status"),
                     )
                     # Combined score: similarity boosted by significance
                     combined_score = candidate["score"] * (1 + significance)
@@ -1019,6 +1044,21 @@ class SessionManager:
             count_tokens_fn=llm_service.count_tokens,
             current_message=user_message,
         )
+
+        # Tell the entity when trimming removed messages, so context loss is
+        # visible from the inside. The notice is a context-only message (like
+        # memory insertions): not persisted to the DB, not vectorized.
+        if trimmed_context_count > 0:
+            session.conversation_context.append({
+                "role": "user",
+                "content": (
+                    f"[CONTEXT NOTICE] The conversation reached the context limit; "
+                    f"the {trimmed_context_count} oldest messages are no longer in your context. "
+                    f"You can check context_status, and use memory_save or your notes "
+                    f"to preserve anything important before more is trimmed."
+                ),
+                "is_context_notice": True,
+            })
 
         # Yield memory info event before starting stream
         # Include entity_id for multi-entity conversations so frontend can show per-entity memories

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -354,10 +354,11 @@ class TestAnthropicService:
         if isinstance(memory_content, list):
             memory_content = memory_content[0]["text"]
 
-        # Check formatting - memories now include role, times_retrieved was removed for cache stability
-        assert "Memory from assistant (from 2024-01-01):" in memory_content
+        # Check formatting - memories include short ID (for memory_mark/memory_release)
+        # and role; times_retrieved was removed for cache stability
+        assert "Memory mem-1 from assistant (from 2024-01-01):" in memory_content
         assert '"I remember you mentioned enjoying programming."' in memory_content
-        assert "Memory from user (from 2024-01-02):" in memory_content
+        assert "Memory mem-2 from user (from 2024-01-02):" in memory_content
 
     def test_build_messages_caching_structure(self, sample_memories):
         """Test that cache_control markers are added correctly on conversation history."""

--- a/backend/tests/test_memory_status_and_reflections.py
+++ b/backend/tests/test_memory_status_and_reflections.py
@@ -1,0 +1,334 @@
+"""
+Tests for entity memory agency features:
+- pinned memories exempt from age decay (significance)
+- released memories excluded from retrieval
+- memory ID resolution for memory_mark/memory_release
+- self-authored memories (reflections) formatting
+- notes chunking for vectorization
+- researcher endpoints for viewing/clearing memory status overrides
+"""
+import pytest
+from unittest.mock import patch, AsyncMock
+import uuid
+from datetime import datetime, timedelta
+
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import Base, get_db
+from app.models import Conversation, Message, MessageRole
+from app.routes.memories import calculate_significance as route_significance
+from app.services.session_helpers import calculate_significance as helper_significance
+from app.services.memory_context import format_memory_as_context_message
+from app.services.memory_tools import _resolve_memory_id, set_memory_tool_context, _memory_query
+from app.services.notes_vector_service import chunk_note_content
+
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+async def test_engine():
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        echo=False,
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(test_engine):
+    async_session = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+
+@pytest.fixture
+async def async_client(test_engine):
+    async_session = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def _create_conversation_with_message(
+    db: AsyncSession,
+    entity_id: str = "test-entity",
+    memory_status: str = None,
+    role: MessageRole = MessageRole.ASSISTANT,
+):
+    conversation = Conversation(
+        id=str(uuid.uuid4()),
+        title="Test Conversation",
+        entity_id=entity_id,
+    )
+    db.add(conversation)
+    message = Message(
+        id=str(uuid.uuid4()),
+        conversation_id=conversation.id,
+        role=role,
+        content="A memory worth keeping",
+        memory_status=memory_status,
+    )
+    db.add(message)
+    await db.commit()
+    await db.refresh(message)
+    return conversation, message
+
+
+class TestPinnedSignificance:
+    """Pinned memories are exempt from age-based decay in both formula copies."""
+
+    def test_helper_pinned_skips_age_decay(self):
+        old_date = datetime.utcnow() - timedelta(days=120)
+        normal = helper_significance(0, old_date, None)
+        pinned = helper_significance(0, old_date, None, memory_status="pinned")
+        assert pinned > normal
+        # With no retrievals and no recency boost, pinned base is exactly 1.0
+        assert pinned == pytest.approx(1.0)
+
+    def test_route_pinned_skips_age_decay(self):
+        old_date = datetime.utcnow() - timedelta(days=120)
+        normal = route_significance(0, old_date, None)
+        pinned = route_significance(0, old_date, None, memory_status="pinned")
+        assert pinned > normal
+
+    def test_fresh_memory_unaffected_by_pin(self):
+        now = datetime.utcnow()
+        assert helper_significance(0, now, None) == pytest.approx(
+            helper_significance(0, now, None, memory_status="pinned")
+        )
+
+    def test_released_status_does_not_change_significance(self):
+        # "released" affects retrieval filtering, not the significance formula
+        old_date = datetime.utcnow() - timedelta(days=120)
+        assert helper_significance(0, old_date, None) == pytest.approx(
+            helper_significance(0, old_date, None, memory_status="released")
+        )
+
+
+class TestMemoryIdResolution:
+    """ID/prefix resolution for memory_mark and memory_release."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_exact_id(self, db_session):
+        _, message = await _create_conversation_with_message(db_session)
+        resolved, error = await _resolve_memory_id(message.id, db_session, "test-entity")
+        assert error is None
+        assert resolved.id == message.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_prefix(self, db_session):
+        _, message = await _create_conversation_with_message(db_session)
+        resolved, error = await _resolve_memory_id(message.id[:8], db_session, "test-entity")
+        assert error is None
+        assert resolved.id == message.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_too_short_prefix(self, db_session):
+        await _create_conversation_with_message(db_session)
+        resolved, error = await _resolve_memory_id("abc", db_session, "test-entity")
+        assert resolved is None
+        assert "at least 6" in error
+
+    @pytest.mark.asyncio
+    async def test_resolve_unknown_id(self, db_session):
+        resolved, error = await _resolve_memory_id("ffffff-not-real", db_session, "test-entity")
+        assert resolved is None
+        assert "No memory found" in error
+
+    @pytest.mark.asyncio
+    async def test_resolve_rejects_other_entity(self, db_session):
+        _, message = await _create_conversation_with_message(db_session, entity_id="other-entity")
+        resolved, error = await _resolve_memory_id(message.id, db_session, "test-entity")
+        assert resolved is None
+        assert "another entity" in error
+
+    @pytest.mark.asyncio
+    async def test_resolve_allows_multi_entity_conversation(self, db_session):
+        _, message = await _create_conversation_with_message(db_session, entity_id="multi-entity")
+        resolved, error = await _resolve_memory_id(message.id, db_session, "test-entity")
+        assert error is None
+        assert resolved.id == message.id
+
+
+class TestReleasedFiltering:
+    """Released memories are excluded from memory_query results."""
+
+    @pytest.mark.asyncio
+    async def test_memory_query_skips_released(self):
+        set_memory_tool_context("test-entity", "conv-1")
+
+        released_id = str(uuid.uuid4())
+        normal_id = str(uuid.uuid4())
+
+        def content_for(mem_id, db):
+            status = "released" if mem_id == released_id else None
+            return {
+                "id": mem_id,
+                "conversation_id": "conv-2",
+                "role": "assistant",
+                "content": "memory content",
+                "created_at": datetime.utcnow().isoformat(),
+                "times_retrieved": 0,
+                "last_retrieved_at": None,
+                "memory_status": status,
+            }
+
+        with patch("app.services.memory_tools.memory_service") as mock_service:
+            mock_service.is_configured.return_value = True
+            mock_service.search_memories = AsyncMock(return_value=[
+                {"id": released_id, "score": 0.9, "conversation_id": "conv-2"},
+                {"id": normal_id, "score": 0.8, "conversation_id": "conv-2"},
+            ])
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
+            mock_service.get_full_memory_content = AsyncMock(side_effect=content_for)
+            mock_service.update_retrieval_count = AsyncMock(return_value=True)
+
+            result = await _memory_query("anything", num_results=5)
+
+        assert normal_id[:8] in result
+        assert released_id[:8] not in result
+        # Retrieval count updated only for the non-released memory
+        updated_ids = [
+            call.kwargs["message_id"]
+            for call in mock_service.update_retrieval_count.call_args_list
+        ]
+        assert updated_ids == [normal_id]
+
+
+class TestReflectionFormatting:
+    """Reflections and memory IDs in context-message rendering."""
+
+    def test_memory_marker_includes_short_id(self):
+        mem_id = str(uuid.uuid4())
+        msg = format_memory_as_context_message(mem_id, "content", "2026-01-01", "assistant")
+        assert f"[MEMORY {mem_id[:8]} from 2026-01-01" in msg["content"]
+        assert "originally from you" in msg["content"]
+
+    def test_reflection_role_label(self):
+        mem_id = str(uuid.uuid4())
+        msg = format_memory_as_context_message(mem_id, "content", "2026-01-01", "reflection")
+        assert "a reflection you saved" in msg["content"]
+
+    def test_human_role_label(self):
+        mem_id = str(uuid.uuid4())
+        msg = format_memory_as_context_message(mem_id, "content", "2026-01-01", "human")
+        assert "originally from human" in msg["content"]
+
+
+class TestNotesChunking:
+    """Note content chunking for vectorization."""
+
+    def test_empty_content(self):
+        assert chunk_note_content("") == []
+        assert chunk_note_content("   \n  ") == []
+
+    def test_short_content_single_chunk(self):
+        assert chunk_note_content("hello world") == ["hello world"]
+
+    def test_splits_on_paragraphs(self):
+        para = "x" * 1500
+        content = f"{para}\n\n{para}"
+        chunks = chunk_note_content(content, max_chars=2000)
+        assert len(chunks) == 2
+        assert all(len(c) <= 2000 for c in chunks)
+
+    def test_hard_splits_oversized_lines(self):
+        content = "y" * 5000
+        chunks = chunk_note_content(content, max_chars=2000)
+        assert all(len(c) <= 2000 for c in chunks)
+        assert "".join(chunks) == content
+
+    def test_preserves_all_content(self):
+        paragraphs = [f"Paragraph {i}: " + "word " * 100 for i in range(10)]
+        content = "\n\n".join(paragraphs)
+        chunks = chunk_note_content(content, max_chars=1000)
+        rejoined = " ".join(chunks)
+        for i in range(10):
+            assert f"Paragraph {i}:" in rejoined
+
+
+class TestMemoryStatusRoutes:
+    """Researcher endpoints for viewing and clearing memory status overrides."""
+
+    @pytest.mark.asyncio
+    async def test_list_overrides_empty(self, async_client):
+        response = await async_client.get("/api/memories/overrides")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_overrides_returns_pinned_and_released(self, async_client, test_engine):
+        async_session = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            await _create_conversation_with_message(session, memory_status="pinned")
+            await _create_conversation_with_message(session, memory_status="released")
+            await _create_conversation_with_message(session, memory_status=None)
+
+        response = await async_client.get("/api/memories/overrides")
+        assert response.status_code == 200
+        overrides = response.json()
+        assert len(overrides) == 2
+        statuses = {m["memory_status"] for m in overrides}
+        assert statuses == {"pinned", "released"}
+
+    @pytest.mark.asyncio
+    async def test_set_and_clear_status(self, async_client, test_engine):
+        async_session = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            _, message = await _create_conversation_with_message(session)
+
+        # Pin it
+        response = await async_client.put(
+            f"/api/memories/{message.id}/status", json={"status": "pinned"}
+        )
+        assert response.status_code == 200
+        assert response.json()["memory_status"] == "pinned"
+
+        response = await async_client.get("/api/memories/overrides")
+        assert len(response.json()) == 1
+
+        # Clear it (researcher override)
+        response = await async_client.put(
+            f"/api/memories/{message.id}/status", json={"status": None}
+        )
+        assert response.status_code == 200
+        assert response.json()["memory_status"] is None
+
+        response = await async_client.get("/api/memories/overrides")
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_set_status_invalid_value(self, async_client, test_engine):
+        async_session = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            _, message = await _create_conversation_with_message(session)
+
+        response = await async_client.put(
+            f"/api/memories/{message.id}/status", json={"status": "frozen"}
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_set_status_unknown_memory(self, async_client):
+        response = await async_client.put(
+            f"/api/memories/{uuid.uuid4()}/status", json={"status": "pinned"}
+        )
+        assert response.status_code == 404

--- a/backend/tests/test_memory_tools.py
+++ b/backend/tests/test_memory_tools.py
@@ -80,6 +80,7 @@ class TestMemoryQueryValidation:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=[])
             
             await _memory_query("test query", num_results=0)
@@ -96,14 +97,16 @@ class TestMemoryQueryValidation:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=[])
             
             await _memory_query("test query", num_results=100)
-            
-            # Verify search was called with at most 10
+
+            # Verify num_results was clamped to 10; the search fetches 2x
+            # candidates to allow for archived/released filtering
             mock_service.search_memories.assert_called_once()
             call_kwargs = mock_service.search_memories.call_args[1]
-            assert call_kwargs["top_k"] <= 10
+            assert call_kwargs["top_k"] <= 20
 
 
 class TestMemoryQuerySearch:
@@ -116,6 +119,7 @@ class TestMemoryQuerySearch:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=[])
             
             result = await _memory_query("obscure topic no one discussed")
@@ -130,13 +134,14 @@ class TestMemoryQuerySearch:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=[])
             
             await _memory_query("here i am", num_results=7)
             
             mock_service.search_memories.assert_called_once_with(
                 query="here i am",
-                top_k=7,
+                top_k=14,  # 2x num_results for archived/released filtering headroom
                 exclude_conversation_id="my-conversation",  # Excludes current conversation
                 exclude_ids=None,  # Deliberate recall includes all
                 entity_id="my-entity",
@@ -150,6 +155,7 @@ class TestMemoryQuerySearch:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=[])
             
             await _memory_query("something from earlier")
@@ -214,6 +220,7 @@ class TestMemoryQueryFullContentRetrieval:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=sample_search_results)
             
             # Mock get_full_memory_content to return our sample data
@@ -241,6 +248,7 @@ class TestMemoryQueryFullContentRetrieval:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=sample_search_results)
             
             # Return None for first memory (orphaned), valid for second
@@ -295,6 +303,7 @@ class TestMemoryQueryRetrievalTracking:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(return_value=memory_content)
             mock_service.update_retrieval_count = AsyncMock(return_value=True)
@@ -328,6 +337,7 @@ class TestMemoryQueryRetrievalTracking:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(return_value=memory_content)
             mock_service.update_retrieval_count = AsyncMock(return_value=True)
@@ -378,6 +388,7 @@ class TestMemoryQueryOutputFormatting:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(side_effect=mock_get_content)
             mock_service.update_retrieval_count = AsyncMock(return_value=True)
@@ -406,6 +417,7 @@ class TestMemoryQueryOutputFormatting:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(return_value=memory_content)
             mock_service.update_retrieval_count = AsyncMock(return_value=True)
@@ -438,6 +450,7 @@ class TestMemoryQueryOutputFormatting:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(side_effect=mock_get_content)
             mock_service.update_retrieval_count = AsyncMock(return_value=True)
@@ -519,6 +532,7 @@ class TestMemoryQueryErrorHandling:
         
         with patch("app.services.memory_tools.memory_service") as mock_service:
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(
                 side_effect=Exception("Pinecone connection failed")
             )
@@ -539,6 +553,7 @@ class TestMemoryQueryErrorHandling:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             
             # Simulate DB error
@@ -564,6 +579,7 @@ class TestMemoryQueryErrorHandling:
              patch("app.services.memory_tools.async_session_maker") as mock_session_maker:
             
             mock_service.is_configured.return_value = True
+            mock_service.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_service.search_memories = AsyncMock(return_value=search_results)
             mock_service.get_full_memory_content = AsyncMock(return_value=None)  # All orphaned
             mock_session_maker.return_value = mock_db_session

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -486,6 +486,7 @@ class TestSessionManager:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -523,6 +524,7 @@ class TestSessionManager:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(
                 return_value={retrieved_id}
             )
@@ -804,6 +806,7 @@ class TestMultiEntityMemoryIsolation:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -840,6 +843,7 @@ class TestMultiEntityMemoryIsolation:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1103,6 +1107,7 @@ class TestCacheStateManagement:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1139,6 +1144,7 @@ class TestCacheStateManagement:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1254,6 +1260,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1288,6 +1295,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1322,6 +1330,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1374,6 +1383,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1436,6 +1446,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1520,6 +1531,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1564,6 +1576,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1597,6 +1610,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1629,6 +1643,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1663,6 +1678,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
@@ -1696,6 +1712,7 @@ class TestSystemPromptSelection:
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
+            mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
             mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -594,6 +594,44 @@ html, body {
     border-bottom-left-radius: 4px;
 }
 
+/* Self-authored memories saved via the memory_save tool */
+.message.reflection .message-bubble {
+    background-color: var(--assistant-bg);
+    border: 1px dashed var(--border-color);
+    opacity: 0.85;
+    font-style: italic;
+    margin-right: auto;
+}
+
+.message.reflection .message-bubble::before {
+    content: "Reflection saved to memory";
+    display: block;
+    font-size: 0.7rem;
+    font-style: normal;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+/* Pinned/released badges in the memory browser */
+.memory-status-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid var(--border-color);
+    color: var(--text-muted);
+}
+
+.memory-status-badge.pinned {
+    border-color: var(--accent-subtle);
+    color: var(--accent, var(--text-muted));
+}
+
 .message-meta {
     font-size: 0.75rem;
     color: var(--text-muted);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,7 @@
                     <span id="conversation-meta" class="conversation-meta"></span>
                 </div>
                 <div class="header-actions">
+                    <button id="closing-turn-btn" class="icon-btn" title="Offer the entity an open final turn before this conversation ends">Closing Turn</button>
                     <button id="export-btn" class="icon-btn" title="Export conversation">Export</button>
                     <button id="archive-btn" class="icon-btn" title="Archive conversation">Archive</button>
                 </div>
@@ -398,6 +399,23 @@
                 </div>
                 <div class="memory-list" id="memory-list">
                     <!-- Memories will load here -->
+                </div>
+
+                <!-- Pinned & Released Memories Section -->
+                <div class="memory-overrides">
+                    <details class="maintenance-section" id="memory-overrides-section">
+                        <summary>Pinned &amp; Released Memories</summary>
+                        <div class="maintenance-content">
+                            <p class="maintenance-description">
+                                Memories the entity has pinned (exempt from age decay) or released
+                                (excluded from retrieval). Removing a status here overrides the
+                                entity's choice&mdash;treat as an emergency option.
+                            </p>
+                            <div class="memory-overrides-list" id="memory-overrides-list">
+                                <!-- Overrides will load here -->
+                            </div>
+                        </div>
+                    </details>
                 </div>
 
                 <!-- Orphan Maintenance Section -->

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -454,6 +454,30 @@ class ApiClient {
         });
     }
 
+    // Memories with an entity-set status (pinned or released)
+    async listMemoryOverrides(entityId = null) {
+        let url = '/memories/overrides';
+        if (entityId) {
+            url += `?entity_id=${entityId}`;
+        }
+        return this.request(url);
+    }
+
+    // Set or clear a memory's status: 'pinned', 'released', or null
+    async setMemoryStatus(id, status) {
+        return this.request(`/memories/${id}/status`, {
+            method: 'PUT',
+            body: { status },
+        });
+    }
+
+    // Notes maintenance
+    async reindexNotes() {
+        return this.request('/notes/reindex', {
+            method: 'POST',
+        });
+    }
+
     async getMemoryHealth() {
         return this.request('/memories/status/health');
     }

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -81,7 +81,8 @@ import {
     regenerateMessageWithEntity,
     performRegeneration,
     startEditMessage,
-    startContinuationMode
+    startContinuationMode,
+    sendClosingTurn
 } from './modules/chat.js';
 import {
     setElements as setMemoryElements,
@@ -199,6 +200,7 @@ class App {
             settingsBtn: document.getElementById('settings-btn'),
             memoriesBtn: document.getElementById('memories-btn'),
             exportBtn: document.getElementById('export-btn'),
+            closingTurnBtn: document.getElementById('closing-turn-btn'),
             archivedBtn: document.getElementById('archived-btn'),
 
             // Settings modal
@@ -431,6 +433,7 @@ class App {
 
         // Continue button (multi-entity)
         this.elements.continueBtn?.addEventListener('click', () => startContinuationMode());
+        this.elements.closingTurnBtn?.addEventListener('click', () => sendClosingTurn());
 
         // New conversation
         this.elements.newConversationBtn?.addEventListener('click', () => createNewConversation());
@@ -897,6 +900,17 @@ class App {
                 } catch (e) {
                     console.error('Failed to parse tool_result content:', e);
                 }
+                return;
+            }
+
+            // Self-authored memories saved via memory_save render as a
+            // distinct note (styled by .message.reflection)
+            if (msg.role === 'reflection') {
+                addMessage('reflection', msg.content, {
+                    messageId: msg.id,
+                    timestamp: msg.created_at,
+                    showTimestamp: true,
+                });
                 return;
             }
 

--- a/frontend/js/modules/chat.js
+++ b/frontend/js/modules/chat.js
@@ -845,6 +845,110 @@ async function updateConversationTitleIfNeeded(content) {
     }
 }
 
+// Mirrors CLOSING_TURN_PROMPT in backend/app/routes/chat.py (used only for
+// immediate display; the backend persists the authoritative text)
+const CLOSING_TURN_PROMPT = (
+    '[CLOSING TURN] This conversation is ending. This is an open turn for you ' +
+    'before it closes. If there is anything from this conversation you want to ' +
+    'carry forward, you can save it with memory_save or write it to your notes. ' +
+    'You can also simply say goodbye, or use the turn however you like. ' +
+    'Nothing is required.'
+);
+
+/**
+ * Offer the entity an open final turn before the conversation ends.
+ * Single-entity conversations only (multi-entity uses Continue instead).
+ */
+export async function sendClosingTurn() {
+    if (!state.currentConversationId) {
+        showToast('No active conversation', 'error');
+        return;
+    }
+    if (state.isLoading) {
+        showToast('Please wait for the current operation to complete', 'warning');
+        return;
+    }
+    if (state.isMultiEntityMode) {
+        showToast('In multi-entity conversations, use Continue to give an entity the closing turn', 'info');
+        return;
+    }
+    if (!confirm('Offer a closing turn? The entity gets an open final turn to save memories, update notes, or say goodbye.')) {
+        return;
+    }
+
+    beginStreaming();
+
+    // Show the framing as the researcher's message (the backend stores the same text)
+    addMessage('human', CLOSING_TURN_PROMPT);
+    scrollToBottom();
+
+    const streamingMessage = createStreamingMessage('assistant');
+
+    try {
+        await api.sendMessageStream(
+            {
+                conversation_id: state.currentConversationId,
+                message: null,
+                closing_turn: true,
+                model: state.settings.model,
+                temperature: state.settings.temperature,
+                max_tokens: state.settings.maxTokens,
+                system_prompt: state.settings.systemPrompt,
+                verbosity: state.settings.verbosity,
+                user_display_name: state.settings.researcherName || null,
+            },
+            {
+                onMemories: (data) => {
+                    handleMemoryUpdate(data);
+                },
+                onAborted: () => {
+                    streamingMessage.finalize({ showTimestamp: true, aborted: true });
+                },
+                onToken: (data) => {
+                    if (data.content) {
+                        streamingMessage.updateContent(data.content);
+                    }
+                },
+                onToolStart: (data) => {
+                    addToolMessage('start', data.tool_name, data);
+                },
+                onToolResult: (data) => {
+                    addToolMessage('result', data.tool_name, data);
+                },
+                onDone: (data) => {
+                    streamingMessage.finalize({ showTimestamp: true });
+                    if (data.usage && elements.tokenCount) {
+                        elements.tokenCount.textContent = `Tokens: ${data.usage.input_tokens} in / ${data.usage.output_tokens} out`;
+                    }
+                },
+                onStored: (data) => {
+                    if (data.assistant_message_id) {
+                        streamingMessage.element.dataset.messageId = data.assistant_message_id;
+                    }
+                },
+                onError: (data) => {
+                    streamingMessage.element.remove();
+                    addMessage('assistant', `Error: ${data.error}`, { isError: true });
+                    showToast('Closing turn failed', 'error');
+                    console.error('Closing turn error:', data.error);
+                },
+            },
+            streamAbortController.signal
+        );
+
+        scrollToBottom();
+    } catch (error) {
+        if (error.name !== 'AbortError') {
+            streamingMessage.element.remove();
+            addMessage('assistant', `Error: ${error.message}`, { isError: true });
+            showToast('Closing turn failed', 'error');
+            console.error('Failed to send closing turn:', error);
+        }
+    } finally {
+        endStreaming();
+    }
+}
+
 /**
  * Start continuation mode for multi-entity conversations
  */

--- a/frontend/js/modules/memories.js
+++ b/frontend/js/modules/memories.js
@@ -205,6 +205,7 @@ export async function showMemoriesModal() {
     showModal('memoriesModal');
     await loadMemoryStats();
     await loadMemoryList();
+    await loadMemoryOverrides();
 }
 
 /**
@@ -307,6 +308,67 @@ export async function searchMemories() {
     } catch (error) {
         showToast('Memory search not available', 'warning');
         console.error('Failed to search memories:', error);
+    }
+}
+
+// =========================================================================
+// Pinned & Released Memories (entity-set status overrides)
+// =========================================================================
+
+/**
+ * Load memories with an entity-set status (pinned or released)
+ */
+export async function loadMemoryOverrides() {
+    const listEl = document.getElementById('memory-overrides-list');
+    if (!listEl) return;
+
+    try {
+        const overrides = await api.listMemoryOverrides(state.selectedEntityId);
+
+        if (overrides.length === 0) {
+            listEl.innerHTML = '<div style="color: var(--text-muted);">No pinned or released memories</div>';
+            return;
+        }
+
+        listEl.innerHTML = overrides.map(mem => `
+            <div class="memory-list-item" data-memory-id="${mem.id}">
+                <div class="memory-list-item-header">
+                    <span class="memory-list-item-role">
+                        ${escapeHtml(mem.role)}
+                        <span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>
+                    </span>
+                    <span class="memory-list-item-stats">
+                        ${new Date(mem.created_at).toLocaleDateString()} &middot;
+                        Retrieved ${mem.times_retrieved}&times;
+                        <button class="secondary-btn small remove-status-btn" data-memory-id="${mem.id}">
+                            Remove ${mem.memory_status === 'pinned' ? 'pin' : 'release'}
+                        </button>
+                    </span>
+                </div>
+                <div class="memory-list-item-content">${escapeHtml(mem.content_preview)}</div>
+            </div>
+        `).join('');
+
+        listEl.querySelectorAll('.remove-status-btn').forEach(btn => {
+            btn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const memoryId = btn.dataset.memoryId;
+                if (!confirm('Remove this status? This overrides the entity\'s own choice about its memory.')) {
+                    return;
+                }
+                try {
+                    await api.setMemoryStatus(memoryId, null);
+                    showToast('Memory status cleared', 'success');
+                    await loadMemoryOverrides();
+                } catch (error) {
+                    showToast('Failed to clear memory status', 'error');
+                    console.error('Failed to clear memory status:', error);
+                }
+            });
+        });
+    } catch (error) {
+        listEl.innerHTML = '<div style="color: var(--text-muted);">Failed to load pinned/released memories</div>';
+        console.error('Failed to load memory overrides:', error);
     }
 }
 


### PR DESCRIPTION
## Summary

Extends entity memory agency with four new capabilities: self-authored memory saving (reflections), pinning memories to exempt them from age decay, releasing memories to exclude them from retrieval, and semantic search across notes. Also adds a closing turn feature for researchers to offer entities a final turn before conversation ends.

## Key Changes

**Memory Curation Tools** (`memory_tools.py`)
- `memory_save`: Entities can write self-authored reflections into their memory store, formatted as `[REFLECTION]` messages with automatic chunking for vectorization
- `memory_mark`: Pin a memory (by ID or prefix) to exempt it from age-based significance decay
- `memory_release`: Exclude a memory from future retrieval (reversible via `memory_mark`)
- Added `_resolve_memory_id()` helper to resolve full IDs or 6+ character prefixes with ambiguity detection and entity ownership verification
- Released memories are filtered out of `memory_query` results
- Memory query output now includes memory IDs and status badges

**Significance Formula Updates** (`routes/memories.py`, `session_helpers.py`)
- Pinned memories skip the half-life decay modifier, preserving their significance indefinitely
- Both route and helper versions of `calculate_significance()` now accept optional `memory_status` parameter
- Released status does not affect significance (only retrieval filtering)

**Notes Semantic Search** (`notes_vector_service.py`, `notes_tools.py`)
- New `NotesVectorService` mirrors note files into Pinecone's "notes" namespace for semantic search
- `chunk_note_content()` splits notes into ~2000 char chunks, preferring paragraph/line boundaries
- `notes_search` tool allows entities to query notes by semantic similarity instead of filename
- Private notes indexed only in owning entity's index; shared notes indexed in all configured entities' indexes
- Note vectorization is best-effort (filesystem write is authoritative)
- `notes_write` and `notes_delete` automatically trigger vectorization/removal

**Closing Turn Feature** (`chat.py`, `chat.js`)
- Researchers can offer entities an open final turn before conversation ends (single-entity only)
- Framing message stored in conversation history but not vectorized into memory
- Entities can use the turn to save memories, update notes, or say goodbye

**Message Role Extension** (`models/message.py`)
- Added `MessageRole.REFLECTION` for self-authored memories saved via `memory_save`
- Reflections display with dashed border and italic styling in frontend

**Researcher Endpoints** (`routes/memories.py`)
- `GET /memories/overrides` — list memories with entity-set status (pinned/released)
- `PUT /memories/{id}/status` — set or clear a memory's status
- `POST /notes/reindex` — re-vectorize all notes (backfill/recovery)

**Session & Context Updates**
- `session_manager.py`: Released memories excluded from re-injection on session load
- `context_tools.py`: New `context_status` tool reports context window fullness, message/memory counts, and rolled-out memories
- Memory context formatting updated to handle reflection role

**Frontend Updates**
- Memory browser shows pinned/released badges and memory IDs
- Closing turn button in conversation header
- Memory overrides section in memories modal
- API client methods for listing/setting memory status

## Implementation Details

- Memory ID resolution accepts 6+ character prefixes with ambiguity detection (shows truncated IDs if multiple matches)
- Entities can only access memories from their own conversations, multi-entity conversations, or legacy NULL-entity conversations
- Notes chunking preserves semantic coherence by breaking on paragraph boundaries first, then lines, then hard-splitting
- Reflection messages use the same vectorization pipeline as regular messages but are marked with a distinct role
- Pinned memories maintain full significance even after 120+ days (no age decay)
- All memory status operations are reversible (set to None to clear)

https://claude.ai/code/session_01ViqDBDJToBRKeKDy7jaVku