### PR TITLE
Exclude tool/system messages from memory browser; add reflection role

### DIFF
--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -13,6 +13,11 @@ from app.config import settings
 
 router = APIRouter(prefix="/api/memories", tags=["memories"])
 
+# Only these roles are vectorized into Pinecone; tool exchanges and system
+# messages live in SQL for conversation replay but are never memories, so the
+# memory browser must not show them.
+MEMORY_ROLES = (MessageRole.HUMAN, MessageRole.ASSISTANT, MessageRole.REFLECTION)
+
 
 class MemoryResponse(BaseModel):
     id: str
@@ -103,10 +108,16 @@ async def list_memories(
     Args:
         entity_id: Optional filter by AI entity (Pinecone index name).
     """
-    query = select(Message)
+    query = select(Message).where(Message.role.in_(MEMORY_ROLES))
 
     if role:
-        role_enum = MessageRole.HUMAN if role == "human" else MessageRole.ASSISTANT
+        try:
+            role_enum = MessageRole(role)
+        except ValueError:
+            role_enum = None
+        if role_enum not in MEMORY_ROLES:
+            valid = ", ".join(r.value for r in MEMORY_ROLES)
+            raise HTTPException(status_code=400, detail=f"role must be one of: {valid}")
         query = query.where(Message.role == role_enum)
 
     # Filter by entity by joining with Conversation
@@ -209,8 +220,10 @@ async def get_memory_stats(
     Args:
         entity_id: Optional filter by AI entity (Pinecone index name).
     """
-    # Build base query with optional entity filter
+    # Build base query with optional entity filter; always restricted to
+    # roles that are actually vectorized as memories
     def apply_entity_filter(query):
+        query = query.where(Message.role.in_(MEMORY_ROLES))
         if entity_id is not None:
             return query.join(Conversation, Message.conversation_id == Conversation.id).where(
                 Conversation.entity_id == entity_id

--- a/backend/tests/test_memories_routes.py
+++ b/backend/tests/test_memories_routes.py
@@ -132,6 +132,32 @@ async def create_test_data(test_engine):
             session.add(msg)
             created_data["messages"].append(msg.id)
 
+        # A reflection - vectorized as a memory, should appear in the browser
+        reflection = Message(
+            id=str(uuid.uuid4()),
+            conversation_id=conv_id,
+            role=MessageRole.REFLECTION,
+            content="A self-authored reflection",
+        )
+        session.add(reflection)
+        created_data["reflection_id"] = reflection.id
+
+        # Tool exchange + system messages - stored in SQL for conversation
+        # replay but never vectorized, so they must NOT appear as memories
+        for role, content in [
+            (MessageRole.TOOL_USE, '[{"type": "tool_use", "name": "web_search"}]'),
+            (MessageRole.TOOL_RESULT, '[{"type": "tool_result", "content": "results"}]'),
+            (MessageRole.SYSTEM, "System message"),
+        ]:
+            msg = Message(
+                id=str(uuid.uuid4()),
+                conversation_id=conv_id,
+                role=role,
+                content=content,
+            )
+            session.add(msg)
+            created_data.setdefault("non_memory_ids", []).append(msg.id)
+
         await session.commit()
 
     return created_data
@@ -236,7 +262,8 @@ class TestListMemories:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 5
+        # 5 human/assistant + 1 reflection; tool_use/tool_result/system excluded
+        assert len(data) == 6
         # Should have significance calculated
         for memory in data:
             assert "significance" in memory
@@ -253,6 +280,43 @@ class TestListMemories:
         assert len(data) == 3
         for memory in data:
             assert memory["role"] == "human"
+
+    @pytest.mark.asyncio
+    async def test_list_memories_excludes_tool_and_system_messages(
+        self, async_client, create_test_data
+    ):
+        """Tool exchanges and system messages are not memories and must not
+        appear in the memory browser."""
+        response = await async_client.get("/api/memories/", params={"limit": 200})
+
+        assert response.status_code == 200
+        data = response.json()
+        listed_ids = {m["id"] for m in data}
+        for non_memory_id in create_test_data["non_memory_ids"]:
+            assert non_memory_id not in listed_ids
+        for memory in data:
+            assert memory["role"] in ("human", "assistant", "reflection")
+
+    @pytest.mark.asyncio
+    async def test_list_memories_filter_by_reflection_role(
+        self, async_client, create_test_data
+    ):
+        """Reflections are vectorized memories and filterable by role."""
+        response = await async_client.get("/api/memories/", params={"role": "reflection"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == create_test_data["reflection_id"]
+
+    @pytest.mark.asyncio
+    async def test_list_memories_rejects_non_memory_role_filter(
+        self, async_client, create_test_data
+    ):
+        """Filtering by a non-memory role (e.g. tool_use) is rejected."""
+        for bad_role in ("tool_use", "tool_result", "system", "bogus"):
+            response = await async_client.get("/api/memories/", params={"role": bad_role})
+            assert response.status_code == 400
 
     @pytest.mark.asyncio
     async def test_list_memories_sort_by_significance(self, async_client, create_test_data):
@@ -380,7 +444,8 @@ class TestMemoryStats:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["total_count"] == 5
+        # 5 human/assistant + 1 reflection; tool/system messages excluded
+        assert data["total_count"] == 6
         assert data["human_count"] == 3  # indices 0, 2, 4
         assert data["assistant_count"] == 2  # indices 1, 3
         assert "avg_times_retrieved" in data


### PR DESCRIPTION
## Summary
Refine the memory system to properly distinguish between vectorized memories and non-vectorized conversation artifacts. Tool exchanges (`tool_use`, `tool_result`) and system messages are stored in SQL for conversation replay but should never appear in the memory browser. Reflections are now properly supported as a vectorized memory role.

## Key Changes

- **Define `MEMORY_ROLES` constant** in `memories.py`: Only `HUMAN`, `ASSISTANT`, and `REFLECTION` are vectorized into Pinecone and eligible for the memory browser. Tool exchanges and system messages are excluded.

- **Filter list_memories endpoint** to always restrict results to `MEMORY_ROLES`, preventing tool/system messages from appearing in the browser regardless of other filters.

- **Validate role parameter** in list_memories: Reject requests filtering by non-memory roles (`tool_use`, `tool_result`, `system`, etc.) with a 400 error and helpful message listing valid roles.

- **Update memory stats endpoint** to apply the same `MEMORY_ROLES` filter, ensuring counts reflect only vectorized memories.

- **Extend test data** to include:
  - A reflection message (vectorized, should appear in browser)
  - Tool use, tool result, and system messages (non-vectorized, must not appear)
  - Tracking of non-memory IDs for validation

- **Add comprehensive test coverage**:
  - Verify reflections are included in memory counts and filterable by role
  - Confirm tool/system messages are excluded from all memory listings
  - Validate that filtering by non-memory roles is rejected with 400 status

## Implementation Details

The `MEMORY_ROLES` tuple is the single source of truth for what constitutes a "memory" in the system. This aligns with the architecture where only human, assistant, and reflection messages are sent to Pinecone for vectorization, while tool exchanges and system messages remain SQL-only for conversation context reconstruction.

https://claude.ai/code/session_01AbWiZHARdaJmg2oEMK6VHF