### PR TITLE
Add reflections panel to memory browser UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -401,6 +401,22 @@
                     <!-- Memories will load here -->
                 </div>
 
+                <!-- Reflections Section -->
+                <div class="memory-reflections">
+                    <details class="maintenance-section" id="memory-reflections-section">
+                        <summary>Reflections</summary>
+                        <div class="maintenance-content">
+                            <p class="maintenance-description">
+                                Self-authored memories the entity saved deliberately via the
+                                memory_save tool, shown newest first.
+                            </p>
+                            <div class="memory-reflections-list" id="memory-reflections-list">
+                                <!-- Reflections will load here -->
+                            </div>
+                        </div>
+                    </details>
+                </div>
+
                 <!-- Pinned & Released Memories Section -->
                 <div class="memory-overrides">
                     <details class="maintenance-section" id="memory-overrides-section">

--- a/frontend/js/__tests__/memories.test.js
+++ b/frontend/js/__tests__/memories.test.js
@@ -10,6 +10,7 @@ import {
     updateMemoriesPanel,
     handleMemoryUpdate,
     loadMemoryStats,
+    loadReflections,
     searchMemories,
     checkForOrphans,
     cleanupOrphans,
@@ -44,6 +45,10 @@ describe('Memories Module', () => {
         const memorySearchInput = document.createElement('input');
         memorySearchInput.id = 'memory-search-input';
         document.body.appendChild(memorySearchInput);
+
+        const reflectionsList = document.createElement('div');
+        reflectionsList.id = 'memory-reflections-list';
+        document.body.appendChild(reflectionsList);
 
         const orphanStatus = document.createElement('div');
         orphanStatus.id = 'orphan-status';
@@ -226,6 +231,78 @@ describe('Memories Module', () => {
 
             const statsEl = document.getElementById('memory-stats');
             expect(statsEl.innerHTML).toContain('100');
+        });
+    });
+
+    describe('loadReflections', () => {
+        it('should request reflection memories for the selected entity', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([]));
+
+            await loadReflections();
+
+            expect(window.api.listMemories).toHaveBeenCalledWith({
+                limit: 50,
+                role: 'reflection',
+                sortBy: 'created_at',
+                entityId: 'entity-1',
+            });
+        });
+
+        it('should show empty state when there are no reflections', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([]));
+
+            await loadReflections();
+
+            const listEl = document.getElementById('memory-reflections-list');
+            expect(listEl.innerHTML).toContain('No reflections saved yet');
+        });
+
+        it('should render reflection items', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([
+                {
+                    id: 'ref-1',
+                    content_preview: 'A saved reflection about memory',
+                    role: 'reflection',
+                    created_at: '2026-01-15T10:00:00Z',
+                    times_retrieved: 3,
+                    significance: 1.42,
+                    memory_status: null,
+                },
+            ]));
+
+            await loadReflections();
+
+            const listEl = document.getElementById('memory-reflections-list');
+            expect(listEl.innerHTML).toContain('A saved reflection about memory');
+            expect(listEl.innerHTML).toContain('reflection');
+        });
+
+        it('should show a status badge on pinned reflections', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([
+                {
+                    id: 'ref-1',
+                    content_preview: 'Pinned reflection',
+                    role: 'reflection',
+                    created_at: '2026-01-15T10:00:00Z',
+                    times_retrieved: 0,
+                    significance: 1.0,
+                    memory_status: 'pinned',
+                },
+            ]));
+
+            await loadReflections();
+
+            const listEl = document.getElementById('memory-reflections-list');
+            expect(listEl.querySelector('.memory-status-badge.pinned')).not.toBeNull();
+        });
+
+        it('should show an error message when the API fails', async () => {
+            window.api.listMemories = vi.fn(() => Promise.reject(new Error('boom')));
+
+            await loadReflections();
+
+            const listEl = document.getElementById('memory-reflections-list');
+            expect(listEl.innerHTML).toContain('Failed to load reflections');
         });
     });
 

--- a/frontend/js/modules/memories.js
+++ b/frontend/js/modules/memories.js
@@ -205,6 +205,7 @@ export async function showMemoriesModal() {
     showModal('memoriesModal');
     await loadMemoryStats();
     await loadMemoryList();
+    await loadReflections();
     await loadMemoryOverrides();
 }
 
@@ -308,6 +309,52 @@ export async function searchMemories() {
     } catch (error) {
         showToast('Memory search not available', 'warning');
         console.error('Failed to search memories:', error);
+    }
+}
+
+// =========================================================================
+// Reflections (self-authored memories saved via memory_save)
+// =========================================================================
+
+/**
+ * Load reflection memories — those the entity saved deliberately via memory_save
+ */
+export async function loadReflections() {
+    const listEl = document.getElementById('memory-reflections-list');
+    if (!listEl) return;
+
+    try {
+        const reflections = await api.listMemories({
+            limit: 50,
+            role: 'reflection',
+            sortBy: 'created_at',
+            entityId: state.selectedEntityId
+        });
+
+        if (reflections.length === 0) {
+            listEl.innerHTML = '<div style="color: var(--text-muted);">No reflections saved yet</div>';
+            return;
+        }
+
+        listEl.innerHTML = reflections.map(mem => `
+            <div class="memory-list-item" data-memory-id="${mem.id}">
+                <div class="memory-list-item-header">
+                    <span class="memory-list-item-role">
+                        reflection
+                        ${mem.memory_status ? `<span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>` : ''}
+                    </span>
+                    <span class="memory-list-item-stats">
+                        ${new Date(mem.created_at).toLocaleDateString()} &middot;
+                        Retrieved ${mem.times_retrieved}&times; &middot;
+                        Significance: ${mem.significance.toFixed(2)}
+                    </span>
+                </div>
+                <div class="memory-list-item-content">${escapeHtml(mem.content_preview)}</div>
+            </div>
+        `).join('');
+    } catch (error) {
+        listEl.innerHTML = '<div style="color: var(--text-muted);">Failed to load reflections</div>';
+        console.error('Failed to load reflections:', error);
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a dedicated "Reflections" section to the memory browser modal that displays self-authored memories saved via the `memory_save` tool. Reflections are now loaded and rendered alongside other memory types when the modal opens.

## Changes
- **Frontend UI:** Added a new collapsible "Reflections" section in the memory browser modal (`index.html`) with description and placeholder for reflection items
- **Memory module:** Implemented `loadReflections()` function that:
  - Queries memories with `role="reflection"` sorted by creation date (newest first)
  - Renders reflection items with content preview, creation date, retrieval count, and significance score
  - Displays status badges for pinned reflections
  - Shows empty state when no reflections exist
  - Handles API errors gracefully
- **Modal initialization:** Integrated `loadReflections()` into `showMemoriesModal()` so reflections load automatically when the modal opens
- **Tests:** Added comprehensive test suite for `loadReflections()` covering:
  - API call with correct parameters (limit, role, sortBy, entityId)
  - Empty state rendering
  - Reflection item rendering with metadata
  - Status badge display for pinned reflections
  - Error handling

## Implementation Details
- Reflections are queried with a limit of 50 items, sorted by `created_at` descending
- Uses the same memory list item styling as other memory types for visual consistency
- Significance values displayed to 2 decimal places
- Follows existing error handling patterns with user-friendly fallback messages

https://claude.ai/code/session_01WwZWJ5FFtt67ByAH8deqRK