### PR TITLE
Add expandable full-text view for truncated memories

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1852,6 +1852,31 @@ h4.md-header {
     line-height: 1.4;
 }
 
+.memory-list-item.expandable {
+    cursor: pointer;
+}
+
+.memory-list-item.expandable:hover {
+    background-color: var(--hover-overlay);
+}
+
+.memory-list-item-expand-hint {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    margin-left: 8px;
+}
+
+.memory-list-item.expanded .memory-list-item-expand-hint {
+    display: none;
+}
+
+.memory-list-item.expanded .memory-list-item-content {
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
 /* Multi-entity memory sections */
 .memory-entity-section {
     margin-bottom: 16px;

--- a/frontend/js/__tests__/memories.test.js
+++ b/frontend/js/__tests__/memories.test.js
@@ -10,6 +10,7 @@ import {
     updateMemoriesPanel,
     handleMemoryUpdate,
     loadMemoryStats,
+    loadMemoryList,
     loadReflections,
     searchMemories,
     checkForOrphans,
@@ -303,6 +304,93 @@ describe('Memories Module', () => {
 
             const listEl = document.getElementById('memory-reflections-list');
             expect(listEl.innerHTML).toContain('Failed to load reflections');
+        });
+    });
+
+    describe('memory full text expansion', () => {
+        const longContent = 'X'.repeat(500);
+        const makeMemory = (id, extra = {}) => ({
+            id,
+            role: 'assistant',
+            content: longContent,
+            content_preview: longContent.substring(0, 200),
+            times_retrieved: 1,
+            significance: 1.0,
+            memory_status: null,
+            ...extra,
+        });
+
+        it('should mark truncated memories as expandable with a hint', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([makeMemory('mem-long-1')]));
+
+            await loadMemoryList();
+
+            const item = document.querySelector('#memory-list .memory-list-item');
+            expect(item.classList.contains('expandable')).toBe(true);
+            expect(item.innerHTML).toContain('click for full text');
+        });
+
+        it('should not mark short memories as expandable', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([
+                makeMemory('mem-short-1', { content: 'Short', content_preview: 'Short' }),
+            ]));
+
+            await loadMemoryList();
+
+            const item = document.querySelector('#memory-list .memory-list-item');
+            expect(item.classList.contains('expandable')).toBe(false);
+            expect(item.innerHTML).not.toContain('click for full text');
+        });
+
+        it('should show the full text on click without refetching when it came with the list', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([makeMemory('mem-long-2')]));
+            window.api.getMemory = vi.fn();
+
+            await loadMemoryList();
+
+            const item = document.querySelector('#memory-list .memory-list-item');
+            item.click();
+            await Promise.resolve();
+
+            expect(item.classList.contains('expanded')).toBe(true);
+            expect(item.querySelector('.memory-list-item-content').textContent).toBe(longContent);
+            expect(window.api.getMemory).not.toHaveBeenCalled();
+        });
+
+        it('should collapse back to the preview on second click', async () => {
+            window.api.listMemories = vi.fn(() => Promise.resolve([makeMemory('mem-long-3')]));
+
+            await loadMemoryList();
+
+            const item = document.querySelector('#memory-list .memory-list-item');
+            item.click();
+            await Promise.resolve();
+            item.click();
+            await Promise.resolve();
+
+            expect(item.classList.contains('expanded')).toBe(false);
+            expect(item.querySelector('.memory-list-item-content').textContent)
+                .toBe(longContent.substring(0, 200));
+        });
+
+        it('should fetch the full text from the API when the list only had a preview', async () => {
+            window.api.searchMemories = vi.fn(() => Promise.resolve([
+                makeMemory('mem-preview-only', { content: undefined, score: 0.9 }),
+            ]));
+            window.api.getMemory = vi.fn(() => Promise.resolve(makeMemory('mem-preview-only')));
+
+            const searchInput = document.getElementById('memory-search-input');
+            searchInput.value = 'test';
+            await searchMemories();
+
+            const item = document.querySelector('#memory-list .memory-list-item');
+            item.click();
+            await vi.waitFor(() => {
+                expect(item.classList.contains('expanded')).toBe(true);
+            });
+
+            expect(window.api.getMemory).toHaveBeenCalledWith('mem-preview-only');
+            expect(item.querySelector('.memory-list-item-content').textContent).toBe(longContent);
         });
     });
 

--- a/frontend/js/modules/memories.js
+++ b/frontend/js/modules/memories.js
@@ -198,6 +198,71 @@ export function handleMemoryUpdate(data) {
 // Memory Browser Modal
 // =========================================================================
 
+// Full memory text cache shared by all browser lists (memory id -> content).
+// Pre-filled from list payloads; misses fall back to GET /api/memories/{id}.
+const memoryFullText = new Map();
+
+const EXPAND_HINT = '<span class="memory-list-item-expand-hint">(click for full text)</span>';
+
+/**
+ * Compute the preview text for a memory and whether there is more to show
+ * @param {Object} mem - Memory object from the API
+ * @returns {{preview: string, canExpand: boolean}}
+ */
+function memoryPreview(mem) {
+    const full = mem.content || '';
+    const preview = mem.content_preview || truncateText(full, 200) || '';
+    return {
+        preview,
+        // Without the full content we can't compare lengths; a preview at the
+        // backend's 200-char truncation point means there may be more to fetch
+        canExpand: full ? full.length > preview.length : preview.length >= 200,
+    };
+}
+
+/**
+ * Make truncated memory list items clickable to toggle their full text.
+ * @param {HTMLElement} listEl - Container holding .memory-list-item nodes
+ * @param {Array} memories - Memory objects used to pre-fill the text cache
+ */
+function bindFullTextToggles(listEl, memories) {
+    memories.forEach(mem => {
+        if (mem.content) {
+            memoryFullText.set(mem.id, mem.content);
+        }
+    });
+
+    listEl.querySelectorAll('.memory-list-item.expandable').forEach(item => {
+        const contentEl = item.querySelector('.memory-list-item-content');
+        if (!contentEl) return;
+        const previewText = contentEl.textContent;
+
+        item.addEventListener('click', async () => {
+            if (item.classList.contains('expanded')) {
+                item.classList.remove('expanded');
+                contentEl.textContent = previewText;
+                return;
+            }
+
+            const memoryId = item.dataset.memoryId;
+            let fullText = memoryFullText.get(memoryId);
+            if (fullText === undefined) {
+                try {
+                    const mem = await api.getMemory(memoryId);
+                    fullText = mem.content || '';
+                    memoryFullText.set(memoryId, fullText);
+                } catch (error) {
+                    showToast('Failed to load full memory text', 'error');
+                    console.error('Failed to load full memory text:', error);
+                    return;
+                }
+            }
+            item.classList.add('expanded');
+            contentEl.textContent = fullText;
+        });
+    });
+}
+
 /**
  * Show the memories browser modal
  */
@@ -260,17 +325,25 @@ export async function loadMemoryList() {
             return;
         }
 
-        listEl.innerHTML = memories.map(mem => `
-            <div class="memory-list-item">
+        listEl.innerHTML = memories.map(mem => {
+            const { preview, canExpand } = memoryPreview(mem);
+            return `
+            <div class="memory-list-item${canExpand ? ' expandable' : ''}" data-memory-id="${mem.id}">
                 <div class="memory-list-item-header">
-                    <span class="memory-list-item-role">${mem.role}</span>
+                    <span>
+                        <span class="memory-list-item-role">${mem.role}</span>
+                        ${canExpand ? EXPAND_HINT : ''}
+                    </span>
                     <span class="memory-list-item-stats">
                         Retrieved ${mem.times_retrieved}× &middot; Significance: ${mem.significance.toFixed(2)}
                     </span>
                 </div>
-                <div class="memory-list-item-content">${escapeHtml(mem.content_preview)}</div>
+                <div class="memory-list-item-content">${escapeHtml(preview)}</div>
             </div>
-        `).join('');
+        `;
+        }).join('');
+
+        bindFullTextToggles(listEl, memories);
     } catch (error) {
         console.error('Failed to load memories:', error);
     }
@@ -295,17 +368,25 @@ export async function searchMemories() {
             return;
         }
 
-        listEl.innerHTML = results.map(mem => `
-            <div class="memory-list-item">
+        listEl.innerHTML = results.map(mem => {
+            const { preview, canExpand } = memoryPreview(mem);
+            return `
+            <div class="memory-list-item${canExpand ? ' expandable' : ''}" data-memory-id="${mem.id}">
                 <div class="memory-list-item-header">
-                    <span class="memory-list-item-role">${mem.role}</span>
+                    <span>
+                        <span class="memory-list-item-role">${mem.role}</span>
+                        ${canExpand ? EXPAND_HINT : ''}
+                    </span>
                     <span class="memory-list-item-stats">
                         Score: ${(mem.score || 0).toFixed(2)} &middot; Retrieved ${mem.times_retrieved}×
                     </span>
                 </div>
-                <div class="memory-list-item-content">${escapeHtml(mem.content || mem.content_preview)}</div>
+                <div class="memory-list-item-content">${escapeHtml(preview)}</div>
             </div>
-        `).join('');
+        `;
+        }).join('');
+
+        bindFullTextToggles(listEl, results);
     } catch (error) {
         showToast('Memory search not available', 'warning');
         console.error('Failed to search memories:', error);
@@ -336,12 +417,17 @@ export async function loadReflections() {
             return;
         }
 
-        listEl.innerHTML = reflections.map(mem => `
-            <div class="memory-list-item" data-memory-id="${mem.id}">
+        listEl.innerHTML = reflections.map(mem => {
+            const { preview, canExpand } = memoryPreview(mem);
+            return `
+            <div class="memory-list-item${canExpand ? ' expandable' : ''}" data-memory-id="${mem.id}">
                 <div class="memory-list-item-header">
-                    <span class="memory-list-item-role">
-                        reflection
-                        ${mem.memory_status ? `<span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>` : ''}
+                    <span>
+                        <span class="memory-list-item-role">
+                            reflection
+                            ${mem.memory_status ? `<span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>` : ''}
+                        </span>
+                        ${canExpand ? EXPAND_HINT : ''}
                     </span>
                     <span class="memory-list-item-stats">
                         ${new Date(mem.created_at).toLocaleDateString()} &middot;
@@ -349,9 +435,12 @@ export async function loadReflections() {
                         Significance: ${mem.significance.toFixed(2)}
                     </span>
                 </div>
-                <div class="memory-list-item-content">${escapeHtml(mem.content_preview)}</div>
+                <div class="memory-list-item-content">${escapeHtml(preview)}</div>
             </div>
-        `).join('');
+        `;
+        }).join('');
+
+        bindFullTextToggles(listEl, reflections);
     } catch (error) {
         listEl.innerHTML = '<div style="color: var(--text-muted);">Failed to load reflections</div>';
         console.error('Failed to load reflections:', error);
@@ -377,12 +466,17 @@ export async function loadMemoryOverrides() {
             return;
         }
 
-        listEl.innerHTML = overrides.map(mem => `
-            <div class="memory-list-item" data-memory-id="${mem.id}">
+        listEl.innerHTML = overrides.map(mem => {
+            const { preview, canExpand } = memoryPreview(mem);
+            return `
+            <div class="memory-list-item${canExpand ? ' expandable' : ''}" data-memory-id="${mem.id}">
                 <div class="memory-list-item-header">
-                    <span class="memory-list-item-role">
-                        ${escapeHtml(mem.role)}
-                        <span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>
+                    <span>
+                        <span class="memory-list-item-role">
+                            ${escapeHtml(mem.role)}
+                            <span class="memory-status-badge ${mem.memory_status}">${mem.memory_status}</span>
+                        </span>
+                        ${canExpand ? EXPAND_HINT : ''}
                     </span>
                     <span class="memory-list-item-stats">
                         ${new Date(mem.created_at).toLocaleDateString()} &middot;
@@ -392,9 +486,12 @@ export async function loadMemoryOverrides() {
                         </button>
                     </span>
                 </div>
-                <div class="memory-list-item-content">${escapeHtml(mem.content_preview)}</div>
+                <div class="memory-list-item-content">${escapeHtml(preview)}</div>
             </div>
-        `).join('');
+        `;
+        }).join('');
+
+        bindFullTextToggles(listEl, overrides);
 
         listEl.querySelectorAll('.remove-status-btn').forEach(btn => {
             btn.addEventListener('click', async (e) => {


### PR DESCRIPTION
## Summary
Adds click-to-expand functionality for memory list items that have been truncated. Users can now click on truncated memories to view their full text inline, with the ability to collapse back to the preview.

## Key Changes
- **Memory preview logic** (`memoryPreview()` function): Determines whether a memory should be marked as expandable by comparing full content length to preview length. Handles cases where only the preview is available (falls back to checking if preview is at the 200-char truncation boundary).
- **Full-text toggle binding** (`bindFullTextToggles()` function): Attaches click handlers to expandable memory items. Caches full text from list payloads to avoid unnecessary API calls. Falls back to `GET /api/memories/{id}` when full content wasn't included in the list response.
- **Shared text cache** (`memoryFullText` Map): Global cache keyed by memory ID, pre-filled from list payloads and populated on-demand from API fetches. Shared across all memory browser lists (main list, search results, reflections, overrides).
- **UI updates**: 
  - Added `.expandable` class and `data-memory-id` attribute to truncated items
  - Added "(click for full text)" hint next to role badges for expandable items
  - Wrapped role/status badges in an extra `<span>` for cleaner hint placement
  - Applied `expanded` class to show full text; toggling removes it to restore preview
- **CSS styling**: Added hover effect, hint styling, and expanded state styling (pre-wrap, scrollable container up to 400px)
- **Applied to all list views**: `loadMemoryList()`, `searchMemories()`, `loadReflections()`, and `loadMemoryOverrides()` all use the new preview/expand logic
- **Test coverage**: Added comprehensive tests for expandable behavior, including truncation detection, click toggling, API fallback, and preview-only scenarios

## Implementation Details
- The `memoryPreview()` function uses `mem.content` (full text) when available, otherwise falls back to `mem.content_preview`. The `canExpand` flag is set if the full content is longer than the preview, or if the preview is exactly 200 characters (indicating backend truncation).
- Click handlers store the preview text on first render, allowing collapse to restore the exact preview without re-rendering.
- The cache is intentionally global and persistent across list reloads to minimize redundant API calls within a session.
- Error handling shows a toast and logs to console if full-text fetch fails; the item remains in preview state.

https://claude.ai/code/session_014A5s9EgTeVxXR4VHSeZCR9