### PR TITLE
Add Enter-key behavior setting for message input

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -205,6 +205,14 @@
                     </select>
                 </div>
 
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="enter-inserts-newline">
+                        Enter key inserts a new line
+                    </label>
+                    <p class="form-help">When enabled, Enter and Shift+Enter both add a new line and messages are sent only with the Send button. Prevents accidentally sending incomplete prompts.</p>
+                </div>
+
                 <div class="form-group" id="tts-provider-group" style="display: none;">
                     <label>TTS Provider</label>
                     <div class="tts-provider-info" id="tts-provider-info">

--- a/frontend/js/__tests__/state.test.js
+++ b/frontend/js/__tests__/state.test.js
@@ -13,6 +13,8 @@ import {
     saveSelectedVoiceToStorage,
     loadResearcherName,
     saveResearcherName,
+    loadEnterInsertsNewline,
+    saveEnterInsertsNewline,
     getValidSavedEntityModel,
 } from '../modules/state.js';
 
@@ -244,6 +246,50 @@ describe('State Module', () => {
 
             expect(state.settings.researcherName).toBe('');
             expect(localStorage.setItem).toHaveBeenCalledWith('researcher_name', '');
+        });
+    });
+
+    describe('loadEnterInsertsNewline', () => {
+        it('should load true when saved as true', () => {
+            localStorage.setItem('enter_inserts_newline', 'true');
+
+            const result = loadEnterInsertsNewline();
+
+            expect(result).toBe(true);
+            expect(state.settings.enterInsertsNewline).toBe(true);
+        });
+
+        it('should default to false when nothing is saved', () => {
+            const result = loadEnterInsertsNewline();
+
+            expect(result).toBe(false);
+            expect(state.settings.enterInsertsNewline).toBe(false);
+        });
+    });
+
+    describe('saveEnterInsertsNewline', () => {
+        it('should save true to state and localStorage', () => {
+            saveEnterInsertsNewline(true);
+
+            expect(state.settings.enterInsertsNewline).toBe(true);
+            expect(localStorage.setItem).toHaveBeenCalledWith('enter_inserts_newline', 'true');
+        });
+
+        it('should save false to state and localStorage', () => {
+            state.settings.enterInsertsNewline = true;
+
+            saveEnterInsertsNewline(false);
+
+            expect(state.settings.enterInsertsNewline).toBe(false);
+            expect(localStorage.setItem).toHaveBeenCalledWith('enter_inserts_newline', 'false');
+        });
+
+        it('should use existing state value when argument is undefined', () => {
+            state.settings.enterInsertsNewline = true;
+
+            saveEnterInsertsNewline(undefined);
+
+            expect(localStorage.setItem).toHaveBeenCalledWith('enter_inserts_newline', 'true');
         });
     });
 

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -4,7 +4,7 @@
  */
 
 // Import modules
-import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, getValidSavedEntityModel, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
+import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, loadEnterInsertsNewline, getValidSavedEntityModel, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
 import { showToast, showLoading, setToastContainer, escapeHtml, renderMarkdown, truncateText, stripMarkdown } from './modules/utils.js';
 import { loadTheme, getCurrentTheme, setTheme } from './modules/theme.js';
 import { setElements as setModalElements, showModal, hideModal, closeActiveModal, isModalOpen, closeAllDropdowns } from './modules/modals.js';
@@ -217,6 +217,7 @@ class App {
             themeSelect: document.getElementById('theme-select'),
             verbositySelect: document.getElementById('verbosity-select'),
             researcherNameInput: document.getElementById('researcher-name-input'),
+            enterInsertsNewlineCheckbox: document.getElementById('enter-inserts-newline'),
             voiceSelect: document.getElementById('voice-select'),
             voiceSelectGroup: document.getElementById('voice-select-group'),
 
@@ -421,7 +422,7 @@ class App {
         // Send message
         this.elements.sendBtn?.addEventListener('click', () => sendMessage());
         this.elements.messageInput?.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
+            if (e.key === 'Enter' && !e.shiftKey && !state.settings.enterInsertsNewline) {
                 e.preventDefault();
                 sendMessage();
             }
@@ -579,6 +580,7 @@ class App {
         if (savedResearcherName) {
             state.settings.researcherName = savedResearcherName;
         }
+        loadEnterInsertsNewline();
 
         // Load chat config (available models)
         await this.loadChatConfig();

--- a/frontend/js/modules/settings.js
+++ b/frontend/js/modules/settings.js
@@ -3,7 +3,7 @@
  * Handles settings modal, configuration presets, and settings application
  */
 
-import { state, saveEntityModelsToStorage, getValidSavedEntityModel, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName } from './state.js';
+import { state, saveEntityModelsToStorage, getValidSavedEntityModel, saveSelectedVoiceToStorage, clearAudioCache, saveResearcherName, saveEnterInsertsNewline } from './state.js';
 import { showToast } from './utils.js';
 import { showModal, hideModal } from './modals.js';
 import { setTheme } from './theme.js';
@@ -51,6 +51,11 @@ export async function applySettings() {
     // Save researcher name
     state.settings.researcherName = elements.researcherNameInput.value.trim() || '';
     saveResearcherName(state.settings.researcherName);
+
+    // Save Enter-key behavior preference
+    if (elements.enterInsertsNewlineCheckbox) {
+        saveEnterInsertsNewline(elements.enterInsertsNewlineCheckbox.checked);
+    }
 
     // Persist the system prompt per-entity on the backend (the source of
     // truth) so it survives across sessions and browsers. The model stays a
@@ -379,6 +384,9 @@ export function initializeSettingsUI() {
     }
     if (elements.researcherNameInput) {
         elements.researcherNameInput.value = state.settings.researcherName || '';
+    }
+    if (elements.enterInsertsNewlineCheckbox) {
+        elements.enterInsertsNewlineCheckbox.checked = state.settings.enterInsertsNewline === true;
     }
 
     updateTemperatureControlState();

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -51,6 +51,7 @@ export const state = {
         conversationType: 'normal',
         verbosity: 'medium',
         researcherName: '',
+        enterInsertsNewline: false,
     },
 
     // Memory state
@@ -280,4 +281,25 @@ export function saveResearcherName(name) {
         state.settings.researcherName = name;
     }
     localStorage.setItem('researcher_name', state.settings.researcherName || '');
+}
+
+/**
+ * Load the Enter-key behavior preference from localStorage
+ * @returns {boolean} True if Enter should insert a newline instead of sending
+ */
+export function loadEnterInsertsNewline() {
+    const saved = localStorage.getItem('enter_inserts_newline');
+    state.settings.enterInsertsNewline = saved === 'true';
+    return state.settings.enterInsertsNewline;
+}
+
+/**
+ * Save the Enter-key behavior preference to localStorage
+ * @param {boolean} enabled - True if Enter should insert a newline instead of sending
+ */
+export function saveEnterInsertsNewline(enabled) {
+    if (enabled !== undefined) {
+        state.settings.enterInsertsNewline = !!enabled;
+    }
+    localStorage.setItem('enter_inserts_newline', state.settings.enterInsertsNewline ? 'true' : 'false');
 }


### PR DESCRIPTION
## Summary
Adds a user-configurable setting to control Enter-key behavior in the message input field. When enabled, both Enter and Shift+Enter insert newlines, and messages are sent only via the Send button. This prevents accidentally sending incomplete prompts.

## Changes
- **State management:** Added `enterInsertsNewline` boolean to `state.settings` with load/save functions (`loadEnterInsertsNewline`, `saveEnterInsertsNewline`) that persist to localStorage
- **Settings UI:** Added checkbox control in the Conversation Settings section with help text explaining the behavior
- **Settings application:** Integrated the setting into `applySettings()` and `initializeSettingsUI()` to sync checkbox state with application state
- **Message input handler:** Modified keydown listener to respect the setting — Enter without Shift only sends when `enterInsertsNewline` is false
- **App initialization:** Load the setting from localStorage on app startup

## Implementation details
- Setting defaults to `false` (current behavior: Enter sends, Shift+Enter adds newline)
- When `true`, both Enter and Shift+Enter add newlines; Send button becomes the only way to submit
- localStorage key: `enter_inserts_newline` (string: `'true'` or `'false'`)
- Follows existing patterns for settings persistence (e.g., `researcherName`, `selectedVoice`)

https://claude.ai/code/session_015sVtUbxd88UiVvS3jKHjgg