### PR TITLE
Make memory browser search semantic, matching memory_query retrieval

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -334,7 +334,11 @@ class Settings(BaseSettings):
     # Memory retrieval defaults
     initial_retrieval_top_k: int = 5  # First retrieval in a conversation
     retrieval_top_k: int = 5  # Subsequent retrievals
-    similarity_threshold: float = 0.4  # Tuned for llama-text-embed-v2
+    similarity_threshold: float = 0.4  # Automatic retrieval from chat messages; tuned for llama-text-embed-v2
+    # Deliberate queries (memory_query tool, memory browser search) use short
+    # search strings whose semantic content is sparse compared to full chat
+    # messages, so they need a lower similarity floor
+    query_similarity_threshold: float = 0.2
     retrieval_candidate_multiplier: int = 2  # Fetch this many times top_k, then re-rank by significance
 
     # Significance calculation

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from typing import Optional, List
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -11,7 +13,13 @@ from app.models import Message, MessageRole, Conversation
 from app.services import memory_service
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/memories", tags=["memories"])
+
+# The post-search SQL enrichment is a few primary-key lookups; if it takes this
+# long the database is stuck and we fail the request instead of hanging it
+SEARCH_ENRICHMENT_TIMEOUT_SECONDS = 15
 
 # Only these roles are vectorized into Pinecone; tool exchanges and system
 # messages live in SQL for conversation replay but are never memories, so the
@@ -209,42 +217,70 @@ async def search_memories(
     if not candidates:
         return []
 
-    archived_ids = await memory_service.get_archived_conversation_ids(
-        db, entity_id=data.entity_id
-    )
+    logger.info(f"[MEMORY] Browser search: enriching {len(candidates)} candidates from SQL")
 
-    results = []
-    for candidate in candidates:
-        if len(results) >= data.top_k:
-            break
-
-        if candidate.get("conversation_id") in archived_ids:
-            continue
-
-        full_data = await memory_service.get_full_memory_content(candidate["id"], db)
-        if not full_data:
-            # Orphaned in Pinecone (no SQL row) — nothing to show
-            continue
-
-        if full_data.get("memory_status") == "released":
-            continue
-
-        significance = calculate_significance(
-            full_data["times_retrieved"],
-            datetime.fromisoformat(full_data["created_at"]),
-            datetime.fromisoformat(full_data["last_retrieved_at"]) if full_data["last_retrieved_at"] else None,
-            full_data.get("memory_status"),
+    async def _enrich() -> list:
+        archived_ids = await memory_service.get_archived_conversation_ids(
+            db, entity_id=data.entity_id
         )
-        item = {
-            **full_data,
-            "content_preview": full_data["content"][:200],
-            "score": candidate["score"],
-            "significance": significance,
-        }
-        if not data.include_content:
-            item.pop("content")
-        results.append(item)
+        logger.info(
+            f"[MEMORY] Browser search: filtering against {len(archived_ids)} archived conversation(s)"
+        )
 
+        results = []
+        for candidate in candidates:
+            if len(results) >= data.top_k:
+                break
+
+            if candidate.get("conversation_id") in archived_ids:
+                continue
+
+            full_data = await memory_service.get_full_memory_content(candidate["id"], db)
+            if not full_data:
+                # Orphaned in Pinecone (no SQL row) — nothing to show
+                continue
+
+            if full_data.get("memory_status") == "released":
+                continue
+
+            significance = calculate_significance(
+                full_data["times_retrieved"],
+                datetime.fromisoformat(full_data["created_at"]),
+                datetime.fromisoformat(full_data["last_retrieved_at"]) if full_data["last_retrieved_at"] else None,
+                full_data.get("memory_status"),
+            )
+            item = {
+                **full_data,
+                "content_preview": full_data["content"][:200],
+                "score": candidate["score"],
+                "significance": significance,
+            }
+            if not data.include_content:
+                item.pop("content")
+            results.append(item)
+
+        return results
+
+    # The SQL enrichment is a handful of primary-key lookups and should be
+    # near-instant; if the database blocks (e.g., connection pool exhausted,
+    # locked file), surface a clear error instead of hanging the request forever.
+    try:
+        results = await asyncio.wait_for(_enrich(), timeout=SEARCH_ENRICHMENT_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        logger.error(
+            f"[MEMORY] Browser search timed out after {SEARCH_ENRICHMENT_TIMEOUT_SECONDS}s "
+            "while loading memory content from SQL. The vector search succeeded, so the "
+            "database is not responding (locked file or exhausted connection pool?)."
+        )
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                "Memory search timed out while loading memory content from the "
+                "database (vector search succeeded). See server logs."
+            ),
+        )
+
+    logger.info(f"[MEMORY] Browser search: returning {len(results)} memories")
     return results
 
 

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -196,11 +196,14 @@ async def search_memories(
         )
 
     # Fetch more candidates than requested so archived-conversation,
-    # released-memory, and orphan filtering doesn't shrink the result set
+    # released-memory, and orphan filtering doesn't shrink the result set.
+    # Deliberate queries are short, semantically sparse strings, so they use
+    # a lower similarity floor than automatic chat-context retrieval.
     candidates = await memory_service.search_memories(
         query=data.query,
         top_k=data.top_k * settings.retrieval_candidate_multiplier,
         entity_id=data.entity_id,
+        similarity_threshold=settings.query_similarity_threshold,
     )
 
     if not candidates:
@@ -348,6 +351,7 @@ async def memory_health():
         "entities": [entity.to_dict() for entity in entities],
         "retrieval_top_k": settings.retrieval_top_k,
         "similarity_threshold": settings.similarity_threshold,
+        "query_similarity_threshold": settings.query_similarity_threshold,
         "recency_boost_strength": settings.recency_boost_strength,
     }
 

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -170,7 +170,12 @@ async def search_memories(
     db: AsyncSession = Depends(get_db)
 ):
     """
-    Semantic search over memories.
+    Semantic search over memories, mirroring the memory_query tool's retrieval:
+    results are ranked purely by similarity (no significance re-ranking),
+    memories from archived conversations and released memories are excluded,
+    and extra candidates are fetched so that filtering doesn't shrink the
+    result set. Unlike memory_query, browsing does NOT update retrieval
+    tracking — researcher searches shouldn't feed back into significance.
 
     Args:
         data.entity_id: Optional filter by AI entity (Pinecone index name).
@@ -181,30 +186,61 @@ async def search_memories(
             detail="Memory system not configured. Set PINECONE_API_KEY in environment."
         )
 
-    # Search vector database for the specified entity
-    results = await memory_service.search_memories(
+    if data.entity_id == "multi-entity":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Memory search requires a specific entity: multi-entity mode "
+                "has no memory index of its own. Select an entity and retry."
+            ),
+        )
+
+    # Fetch more candidates than requested so archived-conversation,
+    # released-memory, and orphan filtering doesn't shrink the result set
+    candidates = await memory_service.search_memories(
         query=data.query,
-        top_k=data.top_k,
+        top_k=data.top_k * settings.retrieval_candidate_multiplier,
         entity_id=data.entity_id,
     )
 
-    # Enrich with full content if requested
-    if data.include_content:
-        enriched = []
-        for result in results:
-            full_data = await memory_service.get_full_memory_content(result["id"], db)
-            if full_data:
-                significance = calculate_significance(
-                    full_data["times_retrieved"],
-                    datetime.fromisoformat(full_data["created_at"]),
-                    datetime.fromisoformat(full_data["last_retrieved_at"]) if full_data["last_retrieved_at"] else None
-                )
-                enriched.append({
-                    **full_data,
-                    "score": result["score"],
-                    "significance": significance,
-                })
-        return enriched
+    if not candidates:
+        return []
+
+    archived_ids = await memory_service.get_archived_conversation_ids(
+        db, entity_id=data.entity_id
+    )
+
+    results = []
+    for candidate in candidates:
+        if len(results) >= data.top_k:
+            break
+
+        if candidate.get("conversation_id") in archived_ids:
+            continue
+
+        full_data = await memory_service.get_full_memory_content(candidate["id"], db)
+        if not full_data:
+            # Orphaned in Pinecone (no SQL row) — nothing to show
+            continue
+
+        if full_data.get("memory_status") == "released":
+            continue
+
+        significance = calculate_significance(
+            full_data["times_retrieved"],
+            datetime.fromisoformat(full_data["created_at"]),
+            datetime.fromisoformat(full_data["last_retrieved_at"]) if full_data["last_retrieved_at"] else None,
+            full_data.get("memory_status"),
+        )
+        item = {
+            **full_data,
+            "content_preview": full_data["content"][:200],
+            "score": candidate["score"],
+            "significance": significance,
+        }
+        if not data.include_content:
+            item.pop("content")
+        results.append(item)
 
     return results
 

--- a/backend/app/services/memory_service.py
+++ b/backend/app/services/memory_service.py
@@ -170,6 +170,7 @@ class MemoryService:
         exclude_ids: Optional[set] = None,
         entity_id: Optional[str] = None,
         use_cache: bool = True,
+        similarity_threshold: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
         """
         Search for relevant memories using semantic similarity.
@@ -187,6 +188,11 @@ class MemoryService:
             exclude_ids: Set of message IDs to exclude (for deduplication)
             entity_id: The Pinecone index name. If None, uses default entity.
             use_cache: Whether to use cached results (default True)
+            similarity_threshold: Minimum score to include a result. Defaults
+                to settings.similarity_threshold (automatic retrieval from chat
+                messages); deliberate queries (memory_query tool, memory browser
+                search) pass the lower settings.query_similarity_threshold since
+                short search strings carry sparser semantic content.
 
         Returns:
             List of memory dicts with id, content, score, metadata
@@ -200,6 +206,8 @@ class MemoryService:
 
         top_k = top_k or settings.retrieval_top_k
         exclude_ids = exclude_ids or set()
+        if similarity_threshold is None:
+            similarity_threshold = settings.similarity_threshold
 
         # Normalize exclude_conversation_id to string for consistent comparison
         exclude_conv_id_normalized = str(exclude_conversation_id) if exclude_conversation_id else None
@@ -216,11 +224,12 @@ class MemoryService:
             if cached_results is not None:
                 logger.info(f"[MEMORY] Cache HIT for entity={entity_id}")
                 # Apply exclude_ids filter to cached results
+                # (cached results are pre-threshold, so a per-call threshold is safe)
                 filtered = []
                 for mem in cached_results:
                     if mem["id"] in exclude_ids:
                         continue
-                    if mem["score"] < settings.similarity_threshold:
+                    if mem["score"] < similarity_threshold:
                         continue
                     filtered.append(mem)
                     if len(filtered) >= top_k:
@@ -231,7 +240,7 @@ class MemoryService:
             # Query more than we need to allow for filtering by exclude_ids
             fetch_k = top_k * 2
 
-            logger.info(f"[MEMORY] Searching memories: threshold={settings.similarity_threshold}, top_k={top_k}, entity={entity_id}")
+            logger.info(f"[MEMORY] Searching memories: threshold={similarity_threshold}, top_k={top_k}, entity={entity_id}")
 
             # Build search query with optional metadata filter
             search_query = {
@@ -298,8 +307,8 @@ class MemoryService:
             # Now apply exclude_ids and threshold filtering
             memories = []
             for mem in all_memories:
-                if mem["score"] < settings.similarity_threshold:
-                    logger.debug(f"SKIP (score {mem['score']:.3f} < {settings.similarity_threshold}): {mem['id'][:8]}...")
+                if mem["score"] < similarity_threshold:
+                    logger.debug(f"SKIP (score {mem['score']:.3f} < {similarity_threshold}): {mem['id'][:8]}...")
                     continue
 
                 if mem["id"] in exclude_ids:

--- a/backend/app/services/memory_tools.py
+++ b/backend/app/services/memory_tools.py
@@ -155,6 +155,9 @@ async def _memory_query(query: str, num_results: int = 5) -> str:
             exclude_ids=None,  # Include all memories
             entity_id=entity_id,
             use_cache=True,
+            # Deliberate queries are short, semantically sparse strings, so they
+            # use a lower similarity floor than automatic chat-context retrieval
+            similarity_threshold=settings.query_similarity_threshold,
         )
 
         if not candidates:

--- a/backend/tests/test_memories_routes.py
+++ b/backend/tests/test_memories_routes.py
@@ -519,6 +519,33 @@ class TestSearchMemories:
         assert [m["id"] for m in data] == ["mem-ok"]
 
     @pytest.mark.asyncio
+    async def test_search_times_out_when_database_hangs(
+        self, async_client, mock_memory_service
+    ):
+        """A stuck database turns into a 504 instead of hanging the request."""
+        import asyncio as aio
+
+        mock_memory_service.search_memories.return_value = [
+            {"id": "mem-1", "score": 0.95, "conversation_id": "conv-mem-1"},
+        ]
+
+        async def never_returns(db, entity_id=None):
+            await aio.sleep(3600)
+
+        mock_memory_service.get_archived_conversation_ids = AsyncMock(
+            side_effect=never_returns
+        )
+
+        with patch("app.routes.memories.SEARCH_ENRICHMENT_TIMEOUT_SECONDS", 0.05):
+            response = await async_client.post(
+                "/api/memories/search",
+                json={"query": "test query", "top_k": 10}
+            )
+
+        assert response.status_code == 504
+        assert "timed out" in response.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_search_caps_results_at_top_k(self, async_client, mock_memory_service):
         """Over-fetched candidates are trimmed back to top_k."""
         mock_memory_service.search_memories.return_value = [

--- a/backend/tests/test_memories_routes.py
+++ b/backend/tests/test_memories_routes.py
@@ -50,6 +50,7 @@ def mock_settings():
         mock.significance_half_life_days = 60
         mock.recency_boost_strength = 1.2
         mock.significance_floor = 0.25
+        mock.retrieval_candidate_multiplier = 2
         yield mock
 
 
@@ -60,6 +61,7 @@ def mock_memory_service():
         mock.is_configured.return_value = True
         mock.search_memories = AsyncMock(return_value=[])
         mock.get_full_memory_content = AsyncMock(return_value=None)
+        mock.get_archived_conversation_ids = AsyncMock(return_value=set())
         mock.delete_memory = AsyncMock(return_value=True)
         mock.find_orphaned_records = AsyncMock(return_value=[])
         mock.cleanup_orphaned_records = AsyncMock(return_value={
@@ -384,13 +386,56 @@ class TestSearchMemories:
         assert response.status_code == 503
         assert "not configured" in response.json()["detail"].lower()
 
+    @staticmethod
+    def _full_content(memory_id: str, **overrides):
+        """Build a get_full_memory_content-style payload for a memory ID."""
+        data = {
+            "id": memory_id,
+            "conversation_id": f"conv-{memory_id}",
+            "role": "human",
+            "content": f"Content of {memory_id}",
+            "created_at": datetime.utcnow().isoformat(),
+            "times_retrieved": 1,
+            "last_retrieved_at": None,
+            "memory_status": None,
+        }
+        data.update(overrides)
+        return data
+
     @pytest.mark.asyncio
     async def test_search_basic(self, async_client, mock_memory_service):
-        """Test basic memory search."""
+        """Test basic memory search returns similarity-ordered results."""
         mock_memory_service.search_memories.return_value = [
-            {"id": "mem-1", "score": 0.95},
-            {"id": "mem-2", "score": 0.85},
+            {"id": "mem-1", "score": 0.95, "conversation_id": "conv-mem-1"},
+            {"id": "mem-2", "score": 0.85, "conversation_id": "conv-mem-2"},
         ]
+        mock_memory_service.get_full_memory_content = AsyncMock(
+            side_effect=lambda memory_id, db: TestSearchMemories._full_content(memory_id)
+        )
+
+        response = await async_client.post(
+            "/api/memories/search",
+            json={"query": "test query", "top_k": 10}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["id"] == "mem-1"
+        assert data[0]["score"] == 0.95
+        assert data[0]["content"] == "Content of mem-1"
+        assert "significance" in data[0]
+        mock_memory_service.search_memories.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_without_content(self, async_client, mock_memory_service):
+        """include_content=False omits full content but keeps the preview."""
+        mock_memory_service.search_memories.return_value = [
+            {"id": "mem-1", "score": 0.95, "conversation_id": "conv-mem-1"},
+        ]
+        mock_memory_service.get_full_memory_content = AsyncMock(
+            side_effect=lambda memory_id, db: TestSearchMemories._full_content(memory_id)
+        )
 
         response = await async_client.post(
             "/api/memories/search",
@@ -399,12 +444,13 @@ class TestSearchMemories:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
-        mock_memory_service.search_memories.assert_called_once()
+        assert len(data) == 1
+        assert "content" not in data[0]
+        assert data[0]["content_preview"] == "Content of mem-1"
 
     @pytest.mark.asyncio
     async def test_search_with_entity_filter(self, async_client, mock_memory_service):
-        """Test memory search with entity filter."""
+        """Test memory search with entity filter over-fetches candidates."""
         mock_memory_service.search_memories.return_value = []
 
         response = await async_client.post(
@@ -416,11 +462,79 @@ class TestSearchMemories:
         )
 
         assert response.status_code == 200
+        assert response.json() == []
+        # top_k is over-fetched by the candidate multiplier (10 * 2)
         mock_memory_service.search_memories.assert_called_with(
             query="test query",
-            top_k=10,
+            top_k=20,
             entity_id="specific-entity",
         )
+
+    @pytest.mark.asyncio
+    async def test_search_multi_entity_rejected(self, async_client, mock_memory_service):
+        """The multi-entity sentinel is not a searchable index."""
+        response = await async_client.post(
+            "/api/memories/search",
+            json={"query": "test query", "entity_id": "multi-entity"}
+        )
+
+        assert response.status_code == 400
+        assert "specific entity" in response.json()["detail"]
+        mock_memory_service.search_memories.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_filters_archived_released_and_orphans(
+        self, async_client, mock_memory_service
+    ):
+        """Archived-conversation, released, and orphaned memories are excluded."""
+        mock_memory_service.search_memories.return_value = [
+            {"id": "mem-archived", "score": 0.99, "conversation_id": "conv-archived"},
+            {"id": "mem-released", "score": 0.98, "conversation_id": "conv-mem-released"},
+            {"id": "mem-orphan", "score": 0.97, "conversation_id": "conv-mem-orphan"},
+            {"id": "mem-ok", "score": 0.90, "conversation_id": "conv-mem-ok"},
+        ]
+        mock_memory_service.get_archived_conversation_ids = AsyncMock(
+            return_value={"conv-archived"}
+        )
+
+        def full_content(memory_id, db):
+            if memory_id == "mem-orphan":
+                return None
+            if memory_id == "mem-released":
+                return TestSearchMemories._full_content(memory_id, memory_status="released")
+            return TestSearchMemories._full_content(memory_id)
+
+        mock_memory_service.get_full_memory_content = AsyncMock(side_effect=full_content)
+
+        response = await async_client.post(
+            "/api/memories/search",
+            json={"query": "test query", "top_k": 10}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [m["id"] for m in data] == ["mem-ok"]
+
+    @pytest.mark.asyncio
+    async def test_search_caps_results_at_top_k(self, async_client, mock_memory_service):
+        """Over-fetched candidates are trimmed back to top_k."""
+        mock_memory_service.search_memories.return_value = [
+            {"id": f"mem-{i}", "score": 0.9 - i * 0.01, "conversation_id": f"conv-mem-{i}"}
+            for i in range(6)
+        ]
+        mock_memory_service.get_full_memory_content = AsyncMock(
+            side_effect=lambda memory_id, db: TestSearchMemories._full_content(memory_id)
+        )
+
+        response = await async_client.post(
+            "/api/memories/search",
+            json={"query": "test query", "top_k": 3}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+        assert [m["id"] for m in data] == ["mem-0", "mem-1", "mem-2"]
 
 
 class TestMemoryStats:

--- a/backend/tests/test_memories_routes.py
+++ b/backend/tests/test_memories_routes.py
@@ -51,6 +51,7 @@ def mock_settings():
         mock.recency_boost_strength = 1.2
         mock.significance_floor = 0.25
         mock.retrieval_candidate_multiplier = 2
+        mock.query_similarity_threshold = 0.2
         yield mock
 
 
@@ -463,11 +464,13 @@ class TestSearchMemories:
 
         assert response.status_code == 200
         assert response.json() == []
-        # top_k is over-fetched by the candidate multiplier (10 * 2)
+        # top_k is over-fetched by the candidate multiplier (10 * 2), and
+        # deliberate queries use the lower query similarity threshold
         mock_memory_service.search_memories.assert_called_with(
             query="test query",
             top_k=20,
             entity_id="specific-entity",
+            similarity_threshold=0.2,
         )
 
     @pytest.mark.asyncio

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -252,6 +252,42 @@ class TestMemoryServiceSearch:
             assert len(results) == 0
 
     @pytest.mark.asyncio
+    async def test_search_memories_custom_threshold_overrides_settings(self, mock_pinecone_index):
+        """A per-call similarity_threshold (deliberate queries) overrides the settings default."""
+        with patch("app.services.memory_service.settings") as mock_settings:
+            mock_settings.pinecone_api_key = "test-key"
+            mock_settings.retrieval_top_k = 5
+            mock_settings.similarity_threshold = 0.95  # High default threshold
+            mock_settings.get_default_entity.return_value = MagicMock(index_name="default")
+
+            service = MemoryService()
+
+            # Mock cache service (set directly on _cache_service)
+            mock_cache = MagicMock()
+            mock_cache.get_search_results.return_value = None
+            service._cache_service = mock_cache
+
+            mock_hit = MagicMock()
+            mock_hit.to_dict.return_value = {
+                "_id": "low-score-memory",
+                "_score": 0.3,  # Below the 0.95 default, above the explicit 0.2
+                "fields": {"conversation_id": "conv-1", "created_at": "2024-01-01"},
+            }
+
+            mock_result = MagicMock()
+            mock_result.hits = [mock_hit]
+            mock_search_result = MagicMock()
+            mock_search_result.result = mock_result
+            mock_pinecone_index.search = MagicMock(return_value=mock_search_result)
+
+            service._indexes["default"] = mock_pinecone_index
+
+            results = await service.search_memories("Query", similarity_threshold=0.2)
+
+            assert len(results) == 1
+            assert results[0]["id"] == "low-score-memory"
+
+    @pytest.mark.asyncio
     async def test_search_memories_excludes_current_conversation(self, mock_pinecone_index):
         """Test that current conversation is excluded from results."""
         with patch("app.services.memory_service.settings") as mock_settings:

--- a/backend/tests/test_memory_tools.py
+++ b/backend/tests/test_memory_tools.py
@@ -16,6 +16,7 @@ from app.services.memory_tools import (
     _memory_query,
 )
 from app.services.tool_service import ToolService, ToolCategory
+from app.config import settings
 
 
 class TestMemoryToolContext:
@@ -146,6 +147,8 @@ class TestMemoryQuerySearch:
                 exclude_ids=None,  # Deliberate recall includes all
                 entity_id="my-entity",
                 use_cache=True,
+                # Deliberate queries use the lower query similarity threshold
+                similarity_threshold=settings.query_similarity_threshold,
             )
 
     @pytest.mark.asyncio

--- a/frontend/js/__tests__/memories.test.js
+++ b/frontend/js/__tests__/memories.test.js
@@ -404,6 +404,27 @@ describe('Memories Module', () => {
             expect(window.api.searchMemories).not.toHaveBeenCalled();
         });
 
+        it('should restore the default list when query is empty', async () => {
+            const searchInput = document.getElementById('memory-search-input');
+            searchInput.value = '';
+            window.api.listMemories = vi.fn(() => Promise.resolve([]));
+
+            await searchMemories();
+
+            expect(window.api.listMemories).toHaveBeenCalled();
+        });
+
+        it('should not search in multi-entity mode', async () => {
+            state.selectedEntityId = 'multi-entity';
+            const searchInput = document.getElementById('memory-search-input');
+            searchInput.value = 'test query';
+            window.api.searchMemories = vi.fn(() => Promise.resolve([]));
+
+            await searchMemories();
+
+            expect(window.api.searchMemories).not.toHaveBeenCalled();
+        });
+
         it('should call API with correct parameters', async () => {
             const searchInput = document.getElementById('memory-search-input');
             searchInput.value = 'test query';

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -487,6 +487,12 @@ class App {
         // Memories modal
         document.getElementById('close-memories')?.addEventListener('click', () => hideModal('memoriesModal'));
         document.getElementById('memory-search-btn')?.addEventListener('click', () => searchMemories());
+        document.getElementById('memory-search-input')?.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                searchMemories();
+            }
+        });
         document.getElementById('check-orphans-btn')?.addEventListener('click', () => checkForOrphans());
         document.getElementById('cleanup-orphans-btn')?.addEventListener('click', () => cleanupOrphans());
 

--- a/frontend/js/modules/memories.js
+++ b/frontend/js/modules/memories.js
@@ -350,12 +350,21 @@ export async function loadMemoryList() {
 }
 
 /**
- * Search memories
+ * Search memories semantically (same retrieval as the memory_query tool).
+ * An empty query restores the default significance-sorted list.
  */
 export async function searchMemories() {
     const input = document.getElementById('memory-search-input');
     const query = input?.value.trim();
-    if (!query) return;
+    if (!query) {
+        await loadMemoryList();
+        return;
+    }
+
+    if (state.selectedEntityId === 'multi-entity') {
+        showToast('Select a specific entity to search memories', 'warning');
+        return;
+    }
 
     try {
         const results = await api.searchMemories(query, 10, true, state.selectedEntityId);
@@ -378,7 +387,7 @@ export async function searchMemories() {
                         ${canExpand ? EXPAND_HINT : ''}
                     </span>
                     <span class="memory-list-item-stats">
-                        Score: ${(mem.score || 0).toFixed(2)} &middot; Retrieved ${mem.times_retrieved}×
+                        Similarity: ${(mem.score || 0).toFixed(2)} &middot; Retrieved ${mem.times_retrieved}×
                     </span>
                 </div>
                 <div class="memory-list-item-content">${escapeHtml(preview)}</div>
@@ -388,7 +397,7 @@ export async function searchMemories() {
 
         bindFullTextToggles(listEl, results);
     } catch (error) {
-        showToast('Memory search not available', 'warning');
+        showToast(error.message || 'Memory search not available', 'warning');
         console.error('Failed to search memories:', error);
     }
 }


### PR DESCRIPTION
## Summary

The memory browser's search box appeared to do nothing. This PR makes it work and makes it retrieve the same way the `memory_query` tool does, with a lower similarity floor suited to short search strings.

### Backend
- `POST /api/memories/search` now mirrors `memory_query` retrieval: pure semantic-similarity ranking (no significance re-ranking), over-fetched candidates (top_k × `retrieval_candidate_multiplier`), and exclusion of memories from archived conversations, released memories, and orphaned Pinecone records. Pinned status now factors into the displayed significance.
- Unlike `memory_query`, browsing does **not** update retrieval tracking — researcher searches shouldn't feed back into the entity's significance dynamics.
- The `multi-entity` sentinel is rejected with a clear 400 (it's not a real Pinecone index; previously it silently returned no results).
- New `query_similarity_threshold` setting (default **0.2**, env `QUERY_SIMILARITY_THRESHOLD`) applies to both deliberate-recall paths — the `memory_query` tool and the browser search. Automatic chat-context retrieval keeps `similarity_threshold` (0.4). Short search strings carry sparse semantic content compared to full chat messages, so they need a lower floor. The threshold is applied per call on both the cache-hit and fresh-query paths (search results are cached pre-filtering, so this is safe), and both thresholds are reported by `GET /api/memories/status/health`.
- Stage-boundary logging through the search route, and a 15s timeout on the post-search SQL enrichment that turns a stuck database into a 504 with a clear detail message instead of a request that never returns.

### Frontend
- Enter in the search box triggers the search (previously only the Search button was wired).
- An empty query restores the default significance-sorted list.
- Multi-entity mode shows an explicit "select a specific entity" toast.
- API error details surface in the error toast instead of a generic message.
- Search results are labeled "Similarity" instead of "Score".

## Testing
- Backend: 962 tests pass, including new coverage for archived/released/orphan filtering, the multi-entity 400, top_k capping, the per-call threshold override, and the enrichment-timeout 504.
- Frontend: 485 Vitest tests pass, including new tests for the empty-query and multi-entity behaviors.
- End-to-end: verified with a real uvicorn server (SQLite, faked Pinecone index) driving the actual frontend in Chromium — Enter triggers the search and results render with similarity scores; also exercised under concurrent requests, an event-loop-blocking Pinecone call, and the 60s cache-hit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWReseekgeNQkvgZrp7tcm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWReseekgeNQkvgZrp7tcm)_