### PR TITLE
Add bot-wall retry logic to web_fetch with Playwright fallback

### DIFF
--- a/backend/app/services/web_tools.py
+++ b/backend/app/services/web_tools.py
@@ -35,6 +35,30 @@ logger = logging.getLogger(__name__)
 
 # Constants
 BRAVE_SEARCH_API_URL = "https://api.search.brave.com/res/v1/web/search"
+
+# User-Agent for both httpx and Playwright fetches. Bot walls (Cloudflare
+# et al.) reject anything that self-identifies as a non-browser client, so we
+# present as an ordinary browser — this tool is an entity reading the web,
+# not a crawler.
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Statuses bot walls use to turn away plain HTTP clients. Worth retrying with
+# a real headless browser before giving up.
+BOT_BLOCK_STATUS_CODES = {403, 429}
+
+# Phrases that mark an anti-bot interstitial rather than real page content
+BLOCK_PAGE_INDICATORS = [
+    "access denied",
+    "just a moment",
+    "attention required",
+    "verify you are human",
+    "you have been blocked",
+    "enable javascript and cookies",
+    "checking your browser",
+]
 SEARCH_TIMEOUT = 10.0  # seconds
 FETCH_TIMEOUT = 15.0  # seconds
 PLAYWRIGHT_TIMEOUT = 60000  # milliseconds (60 seconds for navigation)
@@ -122,6 +146,23 @@ def _needs_javascript_rendering(html_content: str, extracted_text: str) -> Tuple
     return False, "page appears to be static HTML"
 
 
+def _looks_like_block_page(text: str) -> bool:
+    """
+    Detect whether extracted text is an anti-bot block page rather than
+    real content.
+
+    Block interstitials are short; a page with substantial text is treated
+    as real content even if it happens to mention a blocked phrase.
+    """
+    stripped = text.strip()
+    if len(stripped) < MIN_CONTENT_LENGTH:
+        return True
+    if len(stripped) >= 2000:
+        return False
+    text_lower = stripped.lower()
+    return any(indicator in text_lower for indicator in BLOCK_PAGE_INDICATORS)
+
+
 def _fetch_with_playwright_sync(url: str) -> Tuple[Optional[str], Optional[str]]:
     """
     Synchronous Playwright fetch - runs in a separate thread.
@@ -190,7 +231,7 @@ def _fetch_with_playwright_sync(url: str) -> Tuple[Optional[str], Optional[str]]
                 # Create a new context with a reasonable viewport
                 context = browser.new_context(
                     viewport={"width": 1280, "height": 720},
-                    user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                    user_agent=BROWSER_USER_AGENT,
                 )
                 page = context.new_page()
 
@@ -464,13 +505,44 @@ async def web_fetch(url: str, max_length: int = DEFAULT_MAX_LENGTH) -> str:
             response = await client.get(
                 url,
                 headers={
-                    "User-Agent": "Mozilla/5.0 (compatible; HereIAm/1.0; Research Tool)",
+                    "User-Agent": BROWSER_USER_AGENT,
                     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,application/json,text/plain;q=0.8,*/*;q=0.5",
                 },
             )
 
-            if response.status_code == 403:
-                return f"Error: Access denied (403 Forbidden) for URL: {url}"
+            if response.status_code in BOT_BLOCK_STATUS_CODES:
+                # Likely a bot wall turning away the plain HTTP client; a real
+                # headless browser may be let through.
+                logger.info(
+                    f"Got {response.status_code} for {url}, retrying with headless browser"
+                )
+                rendered_html, error = await _fetch_with_playwright(url)
+
+                if error:
+                    return (
+                        f"Error: Access denied (status {response.status_code}) for URL: {url}. "
+                        f"Browser-based retry also failed: {error}"
+                    )
+
+                cleaned_text, title_text, _ = _extract_html_content(rendered_html, url)
+
+                if _looks_like_block_page(cleaned_text):
+                    return (
+                        f"Error: Access denied (status {response.status_code}) for URL: {url}. "
+                        f"The site's anti-bot protection also blocked the browser-based retry."
+                    )
+
+                if len(cleaned_text) > max_length:
+                    cleaned_text = cleaned_text[:max_length] + "\n...[truncated]"
+
+                logger.info(
+                    f"Browser retry succeeded for {url}: {len(cleaned_text)} chars "
+                    f"(after {response.status_code} from direct fetch)"
+                )
+                return (
+                    f"Content from: {url} [JavaScript rendered]\n"
+                    f"Title: {title_text}\n\n{cleaned_text}"
+                )
             elif response.status_code == 404:
                 return f"Error: Page not found (404) for URL: {url}"
             elif response.status_code != 200:

--- a/backend/tests/test_web_tools.py
+++ b/backend/tests/test_web_tools.py
@@ -361,7 +361,7 @@ class TestWebFetch:
 
     @pytest.mark.asyncio
     async def test_fetch_403_forbidden(self):
-        """Test handling of 403 Forbidden."""
+        """Test that 403 falls back to Playwright; error when that also fails."""
         with patch("httpx.AsyncClient") as mock_client:
             mock_response = MagicMock()
             mock_response.status_code = 403
@@ -372,10 +372,123 @@ class TestWebFetch:
             mock_instance.__aexit__ = AsyncMock(return_value=None)
             mock_client.return_value = mock_instance
 
-            result = await web_fetch("https://example.com")
+            with patch(
+                "app.services.web_tools._fetch_with_playwright",
+                new=AsyncMock(return_value=(None, "Playwright is not installed")),
+            ) as mock_playwright:
+                result = await web_fetch("https://example.com")
 
-            assert "Error" in result
-            assert "403" in result or "Forbidden" in result
+                mock_playwright.assert_awaited_once_with("https://example.com")
+                assert "Error" in result
+                assert "403" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_403_browser_retry_succeeds(self):
+        """Test that a 403 from the direct fetch is recovered via Playwright."""
+        rendered_html = """
+        <!DOCTYPE html>
+        <html>
+        <head><title>Real Article</title></head>
+        <body><main><h1>Real Article</h1><p>{}</p></main></body>
+        </html>
+        """.format("Substantive article text. " * 20)
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 403
+
+            mock_instance = AsyncMock()
+            mock_instance.get = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch(
+                "app.services.web_tools._fetch_with_playwright",
+                new=AsyncMock(return_value=(rendered_html, None)),
+            ):
+                result = await web_fetch("https://example.com")
+
+                assert "Error" not in result
+                assert "Real Article" in result
+                assert "[JavaScript rendered]" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_403_browser_retry_hits_block_page(self):
+        """Test that a block interstitial from the retry is reported as denial."""
+        block_html = """
+        <!DOCTYPE html>
+        <html>
+        <head><title>Just a moment...</title></head>
+        <body><p>Verify you are human by completing the action below.</p></body>
+        </html>
+        """
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 403
+
+            mock_instance = AsyncMock()
+            mock_instance.get = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch(
+                "app.services.web_tools._fetch_with_playwright",
+                new=AsyncMock(return_value=(block_html, None)),
+            ):
+                result = await web_fetch("https://example.com")
+
+                assert "Error" in result
+                assert "403" in result
+                assert "anti-bot" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_429_triggers_browser_retry(self):
+        """Test that 429 (rate-limit style bot wall) also triggers the retry."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+
+            mock_instance = AsyncMock()
+            mock_instance.get = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch(
+                "app.services.web_tools._fetch_with_playwright",
+                new=AsyncMock(return_value=(None, "timed out")),
+            ) as mock_playwright:
+                result = await web_fetch("https://example.com")
+
+                mock_playwright.assert_awaited_once()
+                assert "Error" in result
+                assert "429" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_sends_browser_user_agent(self):
+        """Test that the direct fetch presents a plain browser User-Agent."""
+        from app.services.web_tools import BROWSER_USER_AGENT
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "text/plain"}
+            mock_response.text = "hello"
+
+            mock_instance = AsyncMock()
+            mock_instance.get = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            await web_fetch("https://example.com")
+
+            headers = mock_instance.get.call_args.kwargs["headers"]
+            assert headers["User-Agent"] == BROWSER_USER_AGENT
+            assert "compatible" not in headers["User-Agent"]
 
     @pytest.mark.asyncio
     async def test_fetch_404_not_found(self):


### PR DESCRIPTION
## Summary

Enhance `web_fetch` to intelligently handle bot-wall responses (403 Forbidden, 429 Too Many Requests) by falling back to a headless browser via Playwright, while detecting and reporting anti-bot interstitials that block both direct and browser-based access.

## Key Changes

- **Bot-wall detection & retry:** When httpx receives 403 or 429, automatically retry with `_fetch_with_playwright` before failing. This allows the tool to bypass simple bot walls that reject non-browser clients.
- **Block page detection:** Added `_looks_like_block_page()` to identify anti-bot interstitials (Cloudflare, etc.) by checking for common phrases and content length. If the browser retry also hits a block page, report it as a denial rather than success.
- **Browser User-Agent:** Introduced `BROWSER_USER_AGENT` constant (standard Chrome on Windows) used by both httpx and Playwright. Bot walls reject anything self-identifying as a bot, so we present as an ordinary browser.
- **Status code constants:** Added `BOT_BLOCK_STATUS_CODES` (403, 429) and `BLOCK_PAGE_INDICATORS` for maintainability.
- **Logging & error messages:** Enhanced logging to track retry attempts and outcomes; error messages now distinguish between direct-fetch failures, browser-retry failures, and anti-bot blocks.

## Implementation Details

- Block page detection uses heuristics: pages under 200 chars are assumed to be interstitials; pages over 2000 chars are assumed real content; in between, check for indicator phrases (e.g., "just a moment", "verify you are human").
- On successful browser retry, the response is marked `[JavaScript rendered]` to indicate it required client-side execution.
- Playwright fetch errors (e.g., "Playwright is not installed") are reported in the error message so the user knows why the retry failed.
- Tests cover: 403 with failed browser retry, 403 with successful browser retry, 403 hitting a block page on retry, 429 triggering the retry, and User-Agent header validation.

https://claude.ai/code/session_01JppNPawp6vFS8UunyNnChv