### PR TITLE
Use query_similarity_threshold for notes_search tool

### DIFF
--- a/backend/app/services/notes_vector_service.py
+++ b/backend/app/services/notes_vector_service.py
@@ -227,12 +227,19 @@ class NotesVectorService:
         if index is None:
             return []
 
+        # notes_search is a deliberate query tool (like memory_query), so it
+        # uses the lower query_similarity_threshold rather than the stricter
+        # similarity_threshold that automatic chat-context retrieval applies.
+        similarity_threshold = settings.query_similarity_threshold
+
         try:
+            # Fetch extra candidates so threshold filtering below does not
+            # silently shrink the result set.
             results = index.search(
                 namespace=NOTES_NAMESPACE,
                 query={
                     "inputs": {"text": query},
-                    "top_k": num_results,
+                    "top_k": num_results * 2,
                 },
             )
         except Exception as e:
@@ -243,14 +250,19 @@ class NotesVectorService:
         matches = []
         for hit in hits:
             hit_dict = hit.to_dict() if hasattr(hit, "to_dict") else hit
+            score = hit_dict.get("_score", 0)
+            if score < similarity_threshold:
+                continue
             fields = hit_dict.get("fields", {})
             matches.append({
                 "filename": fields.get("note_filename", "unknown"),
                 "shared": bool(fields.get("note_shared", False)),
                 "chunk_index": fields.get("chunk_index", 0),
                 "text": fields.get("text", ""),
-                "score": hit_dict.get("_score", 0),
+                "score": score,
             })
+            if len(matches) >= num_results:
+                break
         return matches
 
     async def reindex_all(self) -> Dict[str, Any]:

--- a/backend/tests/test_notes_service.py
+++ b/backend/tests/test_notes_service.py
@@ -512,11 +512,70 @@ class TestNotesToolRegistration:
     def test_tools_not_registered_when_disabled(self):
         """Test that tools aren't registered when notes_enabled=False."""
         tool_service = ToolService()
-        
+
         with patch("app.services.notes_tools.settings") as mock_settings:
             mock_settings.notes_enabled = False
             register_notes_tools(tool_service)
-        
+
         # Tools should not be registered
         assert tool_service.get_tool("notes_read") is None
         assert tool_service.get_tool("notes_write") is None
+
+
+class TestNotesSearchThreshold:
+    """notes_search should filter with the deliberate-query threshold."""
+
+    def _fake_index(self, scores):
+        """Build a fake Pinecone index whose search returns the given scores."""
+        hits = []
+        for i, score in enumerate(scores):
+            hit = MagicMock()
+            hit.to_dict.return_value = {
+                "_score": score,
+                "fields": {
+                    "note_filename": f"note{i}.md",
+                    "note_shared": False,
+                    "chunk_index": 0,
+                    "text": f"chunk {i}",
+                },
+            }
+            hits.append(hit)
+        index = MagicMock()
+        index.search.return_value = MagicMock(result=MagicMock(hits=hits))
+        return index
+
+    @pytest.mark.asyncio
+    async def test_uses_query_similarity_threshold(self):
+        from app.services.notes_vector_service import NotesVectorService
+
+        service = NotesVectorService()
+        # Scores straddling the query threshold (0.2) but all below the
+        # automatic-retrieval threshold (0.4).
+        index = self._fake_index([0.35, 0.25, 0.15, 0.05])
+
+        with patch("app.services.notes_vector_service.settings") as mock_settings, \
+             patch.object(service, "_get_index_for_label", return_value=index):
+            mock_settings.query_similarity_threshold = 0.2
+            mock_settings.similarity_threshold = 0.4
+
+            matches = await service.search_notes("q", "query", num_results=5)
+
+        # Only the two hits >= 0.2 survive; the stricter 0.4 would have dropped all.
+        assert [m["score"] for m in matches] == [0.35, 0.25]
+
+    @pytest.mark.asyncio
+    async def test_respects_num_results_after_filtering(self):
+        from app.services.notes_vector_service import NotesVectorService
+
+        service = NotesVectorService()
+        index = self._fake_index([0.9, 0.8, 0.7, 0.6])
+
+        with patch("app.services.notes_vector_service.settings") as mock_settings, \
+             patch.object(service, "_get_index_for_label", return_value=index):
+            mock_settings.query_similarity_threshold = 0.2
+
+            matches = await service.search_notes("q", "query", num_results=2)
+
+        assert len(matches) == 2
+        # Fetches extra candidates (top_k = num_results * 2) to survive filtering.
+        assert index.search.call_args.kwargs["query"]["top_k"] == 4


### PR DESCRIPTION
## Summary
Updates `notes_search` to use the lower `query_similarity_threshold` (like `memory_query`) instead of the stricter `similarity_threshold` that automatic chat-context retrieval applies. This treats notes search as a deliberate query tool rather than automatic retrieval.

## Key Changes
- **notes_vector_service.py:**
  - Changed `search_notes()` to use `settings.query_similarity_threshold` instead of the automatic-retrieval threshold
  - Increased `top_k` to `num_results * 2` to fetch extra candidates before filtering, preventing silent result-set shrinkage
  - Added explicit score filtering: results below the threshold are skipped
  - Added early exit once `num_results` matches are collected (after filtering)

- **test_notes_service.py:**
  - Added `TestNotesSearchThreshold` test class with helper `_fake_index()` to mock Pinecone search results
  - `test_uses_query_similarity_threshold`: verifies that hits are filtered by `query_similarity_threshold` (0.2) rather than the stricter `similarity_threshold` (0.4)
  - `test_respects_num_results_after_filtering`: confirms that `num_results` is respected after threshold filtering, and that `top_k` is set to `num_results * 2` to account for filtering

## Implementation Details
- The threshold filtering happens after Pinecone returns results, allowing the service to fetch more candidates upfront and avoid returning fewer results than requested
- Aligns `notes_search` behavior with `memory_query`, both now using the deliberate-query threshold
- Cleaned up trailing whitespace in existing test

https://claude.ai/code/session_01MsrTgLLXvjQavozpAZVm2S