### PR TITLE
Add draggable divider to resize message-entry area

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -530,6 +530,7 @@ html, body {
 /* Messages Container */
 .messages-container {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 24px;
 }
@@ -1034,10 +1035,45 @@ h4.md-header {
 }
 
 /* Input Area */
+/* Draggable divider between the conversation content and the message entry */
+.input-resizer {
+    flex: 0 0 auto;
+    height: 8px;
+    cursor: ns-resize;
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border-color);
+    position: relative;
+    touch-action: none;
+    user-select: none;
+}
+
+.input-resizer::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 3px;
+    border-radius: 2px;
+    background-color: var(--border-color);
+    transition: background-color 0.15s;
+}
+
+.input-resizer:hover::before,
+.input-resizer.dragging::before {
+    background-color: var(--accent);
+}
+
+/* While dragging the divider, suppress text selection across the app */
+body.resizing-input {
+    cursor: ns-resize;
+    user-select: none;
+}
+
 .input-area {
     padding: 16px 24px;
     background-color: var(--bg-secondary);
-    border-top: 1px solid var(--border-color);
 }
 
 .input-container {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,6 +76,9 @@
                 </div>
             </div>
 
+            <!-- Draggable divider between conversation content and message entry -->
+            <div class="input-resizer" id="input-resizer" role="separator" aria-orientation="horizontal" aria-label="Resize message entry area" title="Drag to resize the message entry area"></div>
+
             <!-- Input Area -->
             <div class="input-area">
                 <!-- Attachment Preview Area -->

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -4,7 +4,7 @@
  */
 
 // Import modules
-import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, loadEnterInsertsNewline, getValidSavedEntityModel, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
+import { state, resetMemoryState, loadEntityModelsFromStorage, loadSelectedVoiceFromStorage, loadResearcherName, loadEnterInsertsNewline, loadMessageInputHeight, saveMessageInputHeight, getValidSavedEntityModel, LEGACY_ENTITY_PROMPTS_KEY } from './modules/state.js';
 import { showToast, showLoading, setToastContainer, escapeHtml, renderMarkdown, truncateText, stripMarkdown } from './modules/utils.js';
 import { loadTheme, getCurrentTheme, setTheme } from './modules/theme.js';
 import { setElements as setModalElements, showModal, hideModal, closeActiveModal, isModalOpen, closeAllDropdowns } from './modules/modals.js';
@@ -144,6 +144,11 @@ import {
 // Reference to global API client
 const api = window.api;
 
+// Default auto-resize cap for the message textarea (matches the CSS max-height).
+const DEFAULT_MESSAGE_INPUT_MAX_HEIGHT = 200;
+// Smallest height the divider can shrink the message textarea to.
+const MESSAGE_INPUT_MIN_HEIGHT = 44;
+
 /**
  * Main Application Class
  * Coordinates all modules and handles initialization
@@ -180,6 +185,7 @@ class App {
 
             // Chat input
             messageInput: document.getElementById('message-input'),
+            inputResizer: document.getElementById('input-resizer'),
             sendBtn: document.getElementById('send-btn'),
             stopBtn: document.getElementById('stop-btn'),
             continueBtn: document.getElementById('continue-btn'),
@@ -429,6 +435,9 @@ class App {
         });
         this.elements.messageInput?.addEventListener('input', () => this.handleInputChange());
 
+        // Draggable divider to resize the message-entry area
+        this.setupInputResizer();
+
         // Stop generation
         this.elements.stopBtn?.addEventListener('click', () => stopGeneration());
 
@@ -588,6 +597,10 @@ class App {
         }
         loadEnterInsertsNewline();
 
+        // Restore the user's chosen message-entry height (divider position)
+        loadMessageInputHeight();
+        this.resizeMessageInput();
+
         // Load chat config (available models)
         await this.loadChatConfig();
 
@@ -705,11 +718,84 @@ class App {
             this.elements.sendBtn.disabled = state.isLoading || (!hasContent && !hasAttachmentsFlag);
         }
 
-        // Auto-resize textarea
-        if (this.elements.messageInput) {
-            this.elements.messageInput.style.height = 'auto';
-            this.elements.messageInput.style.height = Math.min(this.elements.messageInput.scrollHeight, 200) + 'px';
+        // Auto-resize textarea (or hold the user-chosen height from the divider)
+        this.resizeMessageInput();
+    }
+
+    /**
+     * Size the message textarea. When the user has dragged the divider to fix a
+     * height, hold that height; otherwise auto-grow with content up to the
+     * default cap.
+     */
+    resizeMessageInput() {
+        const input = this.elements.messageInput;
+        if (!input) return;
+
+        if (state.messageInputHeight) {
+            // User fixed the entry height via the divider — keep it, and allow
+            // internal scrolling for drafts taller than the chosen height.
+            input.style.maxHeight = state.messageInputHeight + 'px';
+            input.style.height = state.messageInputHeight + 'px';
+        } else {
+            // Default behavior: grow with content up to the CSS-defined cap.
+            input.style.maxHeight = '';
+            input.style.height = 'auto';
+            input.style.height = Math.min(input.scrollHeight, DEFAULT_MESSAGE_INPUT_MAX_HEIGHT) + 'px';
         }
+    }
+
+    /**
+     * Wire the draggable divider that resizes the message-entry area.
+     * Dragging up enlarges the textarea; the chosen height persists.
+     */
+    setupInputResizer() {
+        const resizer = this.elements.inputResizer;
+        const input = this.elements.messageInput;
+        if (!resizer || !input) return;
+
+        let startY = 0;
+        let startHeight = 0;
+
+        const onPointerMove = (e) => {
+            // Dragging up (smaller clientY) increases the height.
+            const delta = startY - e.clientY;
+            const maxHeight = Math.max(
+                DEFAULT_MESSAGE_INPUT_MAX_HEIGHT,
+                Math.round(window.innerHeight * 0.7)
+            );
+            const newHeight = Math.min(
+                Math.max(startHeight + delta, MESSAGE_INPUT_MIN_HEIGHT),
+                maxHeight
+            );
+            state.messageInputHeight = newHeight;
+            this.resizeMessageInput();
+        };
+
+        const onPointerUp = (e) => {
+            resizer.classList.remove('dragging');
+            document.body.classList.remove('resizing-input');
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
+            try {
+                resizer.releasePointerCapture(e.pointerId);
+            } catch (_) { /* ignore */ }
+            // Persist the final height so it survives sends and restarts.
+            saveMessageInputHeight(state.messageInputHeight);
+        };
+
+        resizer.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            startY = e.clientY;
+            // Start from the current rendered height so the drag feels anchored.
+            startHeight = state.messageInputHeight || input.getBoundingClientRect().height;
+            resizer.classList.add('dragging');
+            document.body.classList.add('resizing-input');
+            try {
+                resizer.setPointerCapture(e.pointerId);
+            } catch (_) { /* ignore */ }
+            window.addEventListener('pointermove', onPointerMove);
+            window.addEventListener('pointerup', onPointerUp);
+        });
     }
 
     /**

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -791,6 +791,7 @@ class App {
 
         let startY = 0;
         let startHeight = 0;
+        let wasAtBottom = true;
 
         const onPointerMove = (e) => {
             // Dragging up (smaller clientY) increases the height, but never
@@ -802,6 +803,10 @@ class App {
             );
             state.messageInputHeight = newHeight;
             this.resizeMessageInput();
+            // Growing the entry section shrinks the conversation area from the
+            // bottom up. If the latest message was in view, keep it pinned so
+            // the entry section never rises over the end of the conversation.
+            if (wasAtBottom) scrollToBottom();
         };
 
         const onPointerUp = (e) => {
@@ -819,6 +824,7 @@ class App {
         resizer.addEventListener('pointerdown', (e) => {
             e.preventDefault();
             startY = e.clientY;
+            wasAtBottom = isNearBottom();
             // Start from the current rendered height so the drag feels anchored.
             startHeight = state.messageInputHeight || input.getBoundingClientRect().height;
             resizer.classList.add('dragging');
@@ -833,7 +839,10 @@ class App {
         // Re-clamp the fixed height when the window (and thus available space)
         // shrinks, so an enlarged entry section can't start covering messages.
         window.addEventListener('resize', () => {
-            if (state.messageInputHeight) this.resizeMessageInput();
+            if (!state.messageInputHeight) return;
+            const atBottom = isNearBottom();
+            this.resizeMessageInput();
+            if (atBottom) scrollToBottom();
         });
     }
 

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -148,6 +148,9 @@ const api = window.api;
 const DEFAULT_MESSAGE_INPUT_MAX_HEIGHT = 200;
 // Smallest height the divider can shrink the message textarea to.
 const MESSAGE_INPUT_MIN_HEIGHT = 44;
+// Minimum slice of the conversation area kept visible so the end of the most
+// recent message is never hidden behind an enlarged message-entry section.
+const MIN_MESSAGES_VISIBLE_HEIGHT = 60;
 
 /**
  * Main Application Class
@@ -732,16 +735,49 @@ class App {
         if (!input) return;
 
         if (state.messageInputHeight) {
-            // User fixed the entry height via the divider — keep it, and allow
-            // internal scrolling for drafts taller than the chosen height.
-            input.style.maxHeight = state.messageInputHeight + 'px';
-            input.style.height = state.messageInputHeight + 'px';
+            // User fixed the entry height via the divider — keep it, but never
+            // let it grow past the space the chat area can spare, so the end of
+            // the most recent message stays visible. The stored value is left
+            // untouched so a larger window can restore the full chosen height.
+            const height = Math.min(state.messageInputHeight, this.getMaxMessageInputHeight());
+            input.style.maxHeight = height + 'px';
+            input.style.height = height + 'px';
         } else {
             // Default behavior: grow with content up to the CSS-defined cap.
             input.style.maxHeight = '';
             input.style.height = 'auto';
             input.style.height = Math.min(input.scrollHeight, DEFAULT_MESSAGE_INPUT_MAX_HEIGHT) + 'px';
         }
+    }
+
+    /**
+     * Largest height the message textarea may take while keeping at least a
+     * sliver of the conversation content visible (so the bottom of the latest
+     * message can never be covered by the entry section). Derived from the live
+     * layout, so it adapts to window size and the memories panel.
+     */
+    getMaxMessageInputHeight() {
+        const input = this.elements.messageInput;
+        const chatArea = document.querySelector('.chat-area');
+        const inputArea = document.querySelector('.input-area');
+        const messages = this.elements.messagesContainer || document.querySelector('.messages-container');
+        if (!input || !chatArea || !inputArea || !messages) {
+            return Math.max(DEFAULT_MESSAGE_INPUT_MAX_HEIGHT, Math.round(window.innerHeight * 0.6));
+        }
+
+        const chatRect = chatArea.getBoundingClientRect();
+        const messagesRect = messages.getBoundingClientRect();
+        // Chrome above the conversation area (header, memories panel).
+        const topUsed = messagesRect.top - chatRect.top;
+        // Fixed parts of the input area other than the textarea itself
+        // (padding, attachment preview, meta row, and the resizer handle).
+        const inputExtras = inputArea.getBoundingClientRect().height - input.getBoundingClientRect().height;
+        const resizerH = this.elements.inputResizer
+            ? this.elements.inputResizer.getBoundingClientRect().height
+            : 0;
+
+        const available = chatRect.height - topUsed - resizerH - inputExtras - MIN_MESSAGES_VISIBLE_HEIGHT;
+        return Math.max(MESSAGE_INPUT_MIN_HEIGHT, Math.floor(available));
     }
 
     /**
@@ -757,15 +793,12 @@ class App {
         let startHeight = 0;
 
         const onPointerMove = (e) => {
-            // Dragging up (smaller clientY) increases the height.
+            // Dragging up (smaller clientY) increases the height, but never
+            // beyond the space that keeps the last message visible.
             const delta = startY - e.clientY;
-            const maxHeight = Math.max(
-                DEFAULT_MESSAGE_INPUT_MAX_HEIGHT,
-                Math.round(window.innerHeight * 0.7)
-            );
             const newHeight = Math.min(
                 Math.max(startHeight + delta, MESSAGE_INPUT_MIN_HEIGHT),
-                maxHeight
+                this.getMaxMessageInputHeight()
             );
             state.messageInputHeight = newHeight;
             this.resizeMessageInput();
@@ -795,6 +828,12 @@ class App {
             } catch (_) { /* ignore */ }
             window.addEventListener('pointermove', onPointerMove);
             window.addEventListener('pointerup', onPointerUp);
+        });
+
+        // Re-clamp the fixed height when the window (and thus available space)
+        // shrinks, so an enlarged entry section can't start covering messages.
+        window.addEventListener('resize', () => {
+            if (state.messageInputHeight) this.resizeMessageInput();
         });
     }
 

--- a/frontend/js/modules/chat.js
+++ b/frontend/js/modules/chat.js
@@ -57,6 +57,23 @@ export function setCallbacks(cbs) {
 }
 
 /**
+ * Reset the message textarea height after sending. Honors a height the user
+ * fixed by dragging the divider (state.messageInputHeight) so it does not reset
+ * on the next message; otherwise collapses back to auto-resize.
+ */
+function resetInputHeight() {
+    const input = elements.messageInput;
+    if (!input) return;
+    if (state.messageInputHeight) {
+        input.style.maxHeight = state.messageInputHeight + 'px';
+        input.style.height = state.messageInputHeight + 'px';
+    } else {
+        input.style.maxHeight = '';
+        input.style.height = 'auto';
+    }
+}
+
+/**
  * Get the stream abort controller
  * @returns {AbortController|null}
  */
@@ -139,7 +156,7 @@ export async function sendMessage(skipEntityModal = false) {
         state.pendingMessageContent = content;
         state.pendingMessageAttachments = attachments;
         elements.messageInput.value = '';
-        elements.messageInput.style.height = 'auto';
+        resetInputHeight();
         clearAttachments();
 
         // Add user message visually immediately
@@ -157,7 +174,7 @@ export async function sendMessage(skipEntityModal = false) {
     // Standard single-entity flow
     beginStreaming();
     elements.messageInput.value = '';
-    elements.messageInput.style.height = 'auto';
+    resetInputHeight();
     clearAttachments();
 
     // Add user message

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -42,6 +42,11 @@ export const state = {
     streamAbortController: null,
     importAbortController: null,
 
+    // Message-entry height chosen by dragging the divider above the input area.
+    // null = default auto-resize behavior; a number is a user-fixed pixel height
+    // for the message textarea that persists across messages and restarts.
+    messageInputHeight: null,
+
     // Settings
     settings: {
         model: 'claude-sonnet-4-5-20250929',
@@ -281,6 +286,44 @@ export function saveResearcherName(name) {
         state.settings.researcherName = name;
     }
     localStorage.setItem('researcher_name', state.settings.researcherName || '');
+}
+
+const MESSAGE_INPUT_HEIGHT_KEY = 'message_input_height';
+
+/**
+ * Load the user-chosen message-entry height from localStorage into state.
+ * @returns {number|null} The saved height in pixels, or null if unset/invalid
+ */
+export function loadMessageInputHeight() {
+    try {
+        const saved = localStorage.getItem(MESSAGE_INPUT_HEIGHT_KEY);
+        const height = saved !== null ? parseInt(saved, 10) : NaN;
+        state.messageInputHeight = Number.isFinite(height) && height > 0 ? height : null;
+    } catch (e) {
+        console.warn('Failed to load message input height:', e);
+        state.messageInputHeight = null;
+    }
+    return state.messageInputHeight;
+}
+
+/**
+ * Persist the user-chosen message-entry height to localStorage.
+ * Pass null to clear the saved height and restore default auto-resize.
+ * @param {number|null} height - Height in pixels, or null to reset
+ */
+export function saveMessageInputHeight(height) {
+    if (height !== undefined) {
+        state.messageInputHeight = Number.isFinite(height) && height > 0 ? Math.round(height) : null;
+    }
+    try {
+        if (state.messageInputHeight) {
+            localStorage.setItem(MESSAGE_INPUT_HEIGHT_KEY, String(state.messageInputHeight));
+        } else {
+            localStorage.removeItem(MESSAGE_INPUT_HEIGHT_KEY);
+        }
+    } catch (e) {
+        console.warn('Failed to save message input height:', e);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a draggable divider (`input-resizer`) above the message textarea that allows users to manually resize the message-entry area. The chosen height persists across messages and browser restarts via localStorage, while respecting layout constraints to keep the conversation content visible.

## Key Changes

- **New state property** (`messageInputHeight`): Tracks user-chosen textarea height (null = auto-resize mode)
- **Draggable divider UI**: Added `.input-resizer` element with pointer event handling and visual feedback (hover/drag states)
- **Height persistence**: `loadMessageInputHeight()` and `saveMessageInputHeight()` functions manage localStorage serialization
- **Smart resizing logic** (`resizeMessageInput()`): 
  - When user has set a height via divider, holds that height (clamped to available space)
  - Otherwise auto-grows with content up to 200px default cap
  - Respects minimum textarea height (44px) and keeps at least 60px of conversation visible
- **Dynamic max-height calculation** (`getMaxMessageInputHeight()`): Adapts to window size and layout changes (memories panel, etc.)
- **Drag behavior**:
  - Dragging up enlarges textarea; down shrinks it
  - Pinned scroll-to-bottom when conversation was in view (prevents entry section from rising over latest message)
  - Window resize re-clamps fixed height to prevent covering messages in smaller viewports
- **Input reset on send** (`resetInputHeight()`): Preserves user-fixed height across messages instead of collapsing to auto-resize
- **CSS improvements**: 
  - Added `min-height: 0` to `.messages-container` for proper flex layout
  - Moved border from `.input-area` to `.input-resizer` to avoid double borders
  - Suppressed text selection during drag via `body.resizing-input` class

## Implementation Details

- Divider uses pointer events with capture for smooth cross-window dragging
- Height clamping accounts for chrome (header, memories), input extras (padding, attachments, meta), and resizer handle itself
- Scroll-to-bottom is pinned during drag if conversation was already scrolled to bottom, maintaining UX continuity
- localStorage key: `message_input_height` (cleared when reset to auto-resize)
- Integrates with existing `handleInputChange()` flow without breaking auto-resize when height is unset

https://claude.ai/code/session_01JPMH5x9RZ7277KgN3Rj7tN