### PR TITLE
Add reflection significance multiplier for self-authored memories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,15 @@ Significance (`session_helpers.calculate_significance`, also `routes/memories.py
 
 ```
 significance = max(
-    (1 + 0.1 * times_retrieved) * recency_factor * half_life_modifier,
+    (1 + 0.1 * times_retrieved) * recency_factor * half_life_modifier * reflection_multiplier,
     significance_floor   # 0.25
 )
-recency_factor    = 1.0 + min(1 / max(days_since_retrieval, 1), recency_boost_strength=1.2)
-half_life_modifier = 0.5 ** (days_since_creation / 60)
+recency_factor        = 1.0 + min(1 / max(days_since_retrieval, 1), recency_boost_strength=1.2)
+half_life_modifier    = 0.5 ** (days_since_creation / 60)
+reflection_multiplier = reflection_significance_multiplier (=1.5) if role == "reflection" else 1.0
 ```
+
+- **Reflection boost:** memories the entity saved via `memory_save` (`role="reflection"`) get their significance multiplied by `reflection_significance_multiplier` (default 1.5, configurable). Set to 1.0 to disable.
 
 - **Re-ranking:** retrieve `top_k * retrieval_candidate_multiplier` (=2x) candidates, sort by `similarity * (1 + significance)`, keep top_k.
 - **Session accumulator:** `ConversationSession.session_memories` + `retrieved_ids` deduplicate within a conversation. Already-in-context memories are dropped without backfill (no quality dilution).

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -345,6 +345,10 @@ class Settings(BaseSettings):
     recency_boost_strength: float = 1.2
     significance_floor: float = 0.25
     significance_half_life_days: int = 60  # Significance halves every N days since memory creation
+    # Memories saved by the entity via the memory_save tool (reflections) have
+    # their significance multiplied by this factor, giving self-authored
+    # memories extra weight in retrieval re-ranking. Set to 1.0 to disable.
+    reflection_significance_multiplier: float = 1.5
 
     # Role balance in memory retrieval
     # When True, ensures selected memories include at least one human and one assistant message

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -65,6 +65,7 @@ def calculate_significance(
     created_at: datetime,
     last_retrieved_at: Optional[datetime],
     memory_status: Optional[str] = None,
+    role: Optional[str] = None,
 ) -> float:
     """
     Calculate dynamic significance based on retrieval patterns.
@@ -76,6 +77,8 @@ def calculate_significance(
     - recency_factor: Boost based on how recently retrieved (decays over time)
     - half_life_modifier: Decay based on memory age (halves every N days);
       pinned memories (memory_status == "pinned") are exempt from age decay
+    - role: memories saved via memory_save (role == "reflection") are multiplied
+      by settings.reflection_significance_multiplier
     """
     now = datetime.utcnow()
 
@@ -96,6 +99,10 @@ def calculate_significance(
     # Calculate significance (0.1 weight on times_retrieved to prevent retrieval
     # count from dominating; +1 base so never-retrieved memories aren't zeroed out)
     significance = (1 + 0.1 * times_retrieved) * recency_factor * half_life_modifier
+
+    # Boost self-authored memories (saved via the memory_save tool)
+    if role == "reflection":
+        significance *= settings.reflection_significance_multiplier
 
     # Apply floor
     return max(significance, settings.significance_floor)
@@ -144,6 +151,7 @@ async def list_memories(
             msg.created_at,
             msg.last_retrieved_at,
             msg.memory_status,
+            msg.role.value,
         )
         memories.append({
             "id": msg.id,
@@ -248,6 +256,7 @@ async def search_memories(
                 datetime.fromisoformat(full_data["created_at"]),
                 datetime.fromisoformat(full_data["last_retrieved_at"]) if full_data["last_retrieved_at"] else None,
                 full_data.get("memory_status"),
+                full_data.get("role"),
             )
             item = {
                 **full_data,
@@ -338,7 +347,9 @@ async def get_memory_stats(
 
     memories_with_sig = []
     for msg in messages:
-        sig = calculate_significance(msg.times_retrieved, msg.created_at, msg.last_retrieved_at)
+        sig = calculate_significance(
+            msg.times_retrieved, msg.created_at, msg.last_retrieved_at, role=msg.role.value
+        )
         memories_with_sig.append({
             "id": msg.id,
             "content_preview": msg.content[:100],
@@ -522,7 +533,7 @@ async def list_memory_overrides(
             times_retrieved=msg.times_retrieved,
             last_retrieved_at=msg.last_retrieved_at,
             significance=calculate_significance(
-                msg.times_retrieved, msg.created_at, msg.last_retrieved_at, msg.memory_status
+                msg.times_retrieved, msg.created_at, msg.last_retrieved_at, msg.memory_status, msg.role.value
             ),
             memory_status=msg.memory_status,
         )
@@ -579,6 +590,7 @@ async def get_memory(
         message.created_at,
         message.last_retrieved_at,
         message.memory_status,
+        message.role.value,
     )
 
     return MemoryResponse(

--- a/backend/app/services/session_helpers.py
+++ b/backend/app/services/session_helpers.py
@@ -91,6 +91,7 @@ def calculate_significance(
     created_at: Optional[datetime],
     last_retrieved_at: Optional[datetime],
     memory_status: Optional[str] = None,
+    role: Optional[str] = None,
 ) -> float:
     """
     Calculate memory significance based on retrieval patterns.
@@ -103,6 +104,9 @@ def calculate_significance(
 
     Pinned memories (memory_status == "pinned") are exempt from age decay:
     their half_life_modifier stays at 1.0 regardless of age.
+
+    Memories the entity saved via memory_save (role == "reflection") have their
+    significance multiplied by settings.reflection_significance_multiplier.
     """
     now = datetime.utcnow()
 
@@ -133,6 +137,11 @@ def calculate_significance(
     # without letting it dominate. The +1 base ensures never-retrieved memories
     # can still compete based on recency and age factors.
     significance = (1 + 0.1 * times_retrieved) * recency_factor * half_life_modifier
+
+    # Boost self-authored memories (saved via the memory_save tool)
+    if role == "reflection":
+        significance *= settings.reflection_significance_multiplier
+
     return significance
 
 

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -585,6 +585,7 @@ class SessionManager:
                     mem_data["created_at"],
                     mem_data["last_retrieved_at"],
                     memory_status=mem_data.get("memory_status"),
+                    role=mem_data.get("role"),
                 )
 
                 created_at = mem_data["created_at"]
@@ -786,6 +787,7 @@ class SessionManager:
                         mem_data["created_at"],
                         mem_data["last_retrieved_at"],
                         memory_status=mem_data.get("memory_status"),
+                        role=mem_data.get("role"),
                     )
                     # Combined score: similarity boosted by significance
                     # Memories with higher significance get priority among similar matches
@@ -1201,6 +1203,7 @@ class SessionManager:
                         mem_data["created_at"],
                         mem_data["last_retrieved_at"],
                         memory_status=mem_data.get("memory_status"),
+                        role=mem_data.get("role"),
                     )
                     # Combined score: similarity boosted by significance
                     combined_score = candidate["score"] * (1 + significance)

--- a/backend/tests/test_memories_routes.py
+++ b/backend/tests/test_memories_routes.py
@@ -50,6 +50,7 @@ def mock_settings():
         mock.significance_half_life_days = 60
         mock.recency_boost_strength = 1.2
         mock.significance_floor = 0.25
+        mock.reflection_significance_multiplier = 1.5
         mock.retrieval_candidate_multiplier = 2
         mock.query_similarity_threshold = 0.2
         yield mock
@@ -244,6 +245,40 @@ class TestSignificanceCalculation:
 
         # New memory should have higher significance
         assert sig_new > sig_old
+
+    def test_significance_reflection_multiplier(self, mock_settings):
+        """Reflections (memory_save) get their significance multiplied."""
+        now = datetime.utcnow()
+        created_at = now - timedelta(days=10)
+
+        sig_normal = calculate_significance(
+            times_retrieved=5,
+            created_at=created_at,
+            last_retrieved_at=now - timedelta(days=2),
+        )
+        sig_reflection = calculate_significance(
+            times_retrieved=5,
+            created_at=created_at,
+            last_retrieved_at=now - timedelta(days=2),
+            role="reflection",
+        )
+
+        assert sig_reflection == pytest.approx(sig_normal * 1.5, abs=0.001)
+
+    def test_significance_reflection_multiplier_respects_floor(self, mock_settings):
+        """The floor still applies after the reflection multiplier."""
+        now = datetime.utcnow()
+        # Very old memory whose boosted significance is still below the floor
+        created_at = now - timedelta(days=600)
+
+        sig = calculate_significance(
+            times_retrieved=0,
+            created_at=created_at,
+            last_retrieved_at=None,
+            role="reflection",
+        )
+
+        assert sig == pytest.approx(0.25, abs=0.001)
 
 
 class TestListMemories:

--- a/backend/tests/test_session_helpers.py
+++ b/backend/tests/test_session_helpers.py
@@ -229,6 +229,41 @@ class TestCalculateSignificance:
         )
         assert sig_recent > sig_older
 
+    def test_reflection_role_gets_significance_multiplier(self):
+        """Memories saved via memory_save (role='reflection') are boosted."""
+        from app.config import settings
+        now = datetime.utcnow()
+        sig_normal = calculate_significance(
+            times_retrieved=0,
+            created_at=now,
+            last_retrieved_at=None,
+        )
+        sig_reflection = calculate_significance(
+            times_retrieved=0,
+            created_at=now,
+            last_retrieved_at=None,
+            role="reflection",
+        )
+        assert sig_reflection == pytest.approx(
+            sig_normal * settings.reflection_significance_multiplier, abs=0.01
+        )
+
+    def test_non_reflection_role_not_boosted(self):
+        """Human/assistant memories are unaffected by the reflection multiplier."""
+        now = datetime.utcnow()
+        sig_default = calculate_significance(
+            times_retrieved=2,
+            created_at=now,
+            last_retrieved_at=None,
+        )
+        sig_human = calculate_significance(
+            times_retrieved=2,
+            created_at=now,
+            last_retrieved_at=None,
+            role="human",
+        )
+        assert sig_human == pytest.approx(sig_default, abs=0.001)
+
 
 # ============================================================
 # Tests for ensure_role_balance


### PR DESCRIPTION
## Summary
Introduces a configurable significance boost for memories saved via the `memory_save` tool (reflections). Self-authored memories now receive a multiplier to their significance score during retrieval re-ranking, giving them extra weight in memory selection.

## Changes
- **Config:** Added `reflection_significance_multiplier` setting (default 1.5) to `Settings` in `config.py`. Configurable to 1.0 to disable the boost.
- **Significance calculation:** Updated `calculate_significance()` in both `session_helpers.py` and `routes/memories.py` to accept an optional `role` parameter. When `role == "reflection"`, the computed significance is multiplied by `reflection_significance_multiplier` before applying the floor.
- **Call sites:** Updated all calls to `calculate_significance()` across the codebase to pass `msg.role.value` or `mem_data.get("role")`:
  - `routes/memories.py`: `list_memories()`, `_enrich()`, `apply_entity_filter()`, `list_memory_overrides()`, `get_memory()`
  - `session_manager.py`: `_inject_recent_reflections()`, `process_message()`, `process_message_stream()`
- **Tests:** Added comprehensive test coverage:
  - `test_memories_routes.py`: Tests for reflection multiplier application and floor enforcement
  - `test_session_helpers.py`: Tests for reflection boost and non-reflection role handling
- **Documentation:** Updated `CLAUDE.md` memory system section to document the reflection boost formula and behavior.

## Implementation Details
- The reflection multiplier is applied *before* the significance floor, ensuring the floor still acts as a lower bound (e.g., a very old reflection with boosted significance below 0.25 will still be clamped to 0.25).
- Only memories with `role == "reflection"` receive the boost; human and assistant messages are unaffected.
- The multiplier is configurable via environment variable, allowing operators to tune the weight given to self-authored memories without code changes.

https://claude.ai/code/session_018WFH1GXDnB2Z17FoVo8qui