### PR TITLE
Consolidate memory system to memory-in-context only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Reference docs live in `docs/`: `tools.md` (tool catalog — update when adding/
 5. **Tool exchange messages** (`MessageRole.TOOL_USE`/`TOOL_RESULT`) store JSON in `Message.content`. Use `Message.content_blocks` to parse.
 6. **Image attachments are ephemeral** (not stored, not vectorized). Text/PDF/DOCX are extracted, persisted in message content as `[ATTACHED FILE: ...]` blocks, but not vectorized. The live session context stores the same `[ATTACHED FILE]` rendering as the DB row (`session_manager.process_message_stream` folds the file text into the message before stamping), so a session reload rebuilds an identical message and prompt caching survives — don't reintroduce a live/persisted divergence here.
 7. **Archived conversations** (`is_archived=True`) are excluded from memory retrieval, not just hidden from the UI. Imported conversations (`is_imported=True`) are hidden from the list but their messages *are* vectorized.
-8. **Memory injection ordering:** conversation history first (with the cache breakpoint on the last cached message), memories *after*. Changing memories doesn't bust the conversation cache. See `anthropic_service.py`.
+8. **Memory-in-context:** retrieved memories are inserted into the conversation context as `is_memory` user messages (tracked by position in `ConversationSession.memory_tracker`) and land *after* the cache breakpoint, so new retrievals extend the cached history instead of busting it. They roll out with normal context trimming. See `memory_context.py` and `anthropic_service.build_messages`.
 9. **Token counting uses tiktoken GPT-4 encoding** — approximate for Claude. For display/budgeting only. Context trimming and `context_status` calibrate the estimate against the provider-reported prompt usage of the session's last request (`ConversationSession.token_calibration_ratio`); persisted assistant messages store the provider's exact `output_tokens` when it maps 1:1 to the content (tiktoken fallback for tool-loop responses).
 10. **Messages are written at different times:** human before the API call, assistant after. Mid-call failures leave partial history.
 11. **MiniMax** uses `https://api.minimax.io/anthropic` (Anthropic-compatible). Routed through `AnthropicService` with `provider_hint="minimax"`; prompt caching disabled.
@@ -127,9 +127,9 @@ Everything lives in `backend/app/config.py` (`Settings`). Highlights:
 - `ANTHROPIC_API_KEY` is the only strictly required key. `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `MINIMAX_API_KEY` enable their providers.
 - `GITHUB_REPOS` — JSON array of `{owner, repo, label, token, protected_branches?, capabilities?, local_clone_path?, ...}`.
 - Default-on flags: `TOOLS_ENABLED`, `NOTES_ENABLED`, `ATTACHMENTS_ENABLED`, `MEMORY_ROLE_BALANCE_ENABLED`.
-- Default-off flags: `GITHUB_TOOLS_ENABLED`, `CODEBASE_NAVIGATOR_ENABLED`, `MOLTBOOK_ENABLED`, `XTTS_ENABLED`, `STYLETTS2_ENABLED`, `WHISPER_ENABLED`, `USE_MEMORY_IN_CONTEXT`.
+- Default-off flags: `GITHUB_TOOLS_ENABLED`, `CODEBASE_NAVIGATOR_ENABLED`, `MOLTBOOK_ENABLED`, `XTTS_ENABLED`, `STYLETTS2_ENABLED`, `WHISPER_ENABLED`.
 - TTS priority when multiple are enabled: StyleTTS 2 > XTTS > ElevenLabs.
-- Token budgets: `context_token_limit=175000` (history), `memory_token_limit=10000` (memory block — kept small to limit cache-miss cost).
+- Token budget: `context_token_limit=175000` (conversation history; retrieved memories are part of the history).
 - Default models: `claude-sonnet-4-5-20250929`, `gpt-5.1`, `gemini-2.5-flash`, `MiniMax-M2.5`. Model names are passed straight to provider APIs, so new models work without code changes.
 
 ## Adding things

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ python run.py
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `MEMORY_ROLE_BALANCE_ENABLED` | Balance human/assistant memories in retrieval | No (default: true) |
-| `USE_MEMORY_IN_CONTEXT` | Insert memories into conversation context | No (default: true) |
 | `RETRIEVAL_TOP_K` | Memories retrieved per message | No (default: 5) |
 | `SIMILARITY_THRESHOLD` | Minimum similarity for automatic retrieval | No (default: 0.4) |
 | `QUERY_SIMILARITY_THRESHOLD` | Minimum similarity for deliberate `memory_query` searches | No (default: 0.2) |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -73,11 +73,6 @@ HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db
 #     {"index_name": "gpt-research", "label": "GPT", "llm_provider": "openai", "host": "[Your Pinecone index host url]", "default_model": "gpt-5.1"}
 # ]'
 
-# Insert memories directly into conversation context (better cacheability) when
-# true; render them as a separate block each turn when false.
-# USE_MEMORY_IN_CONTEXT=true
-
-
 # ============================================================================
 # MEMORY RETRIEVAL & SIGNIFICANCE TUNING
 # ============================================================================
@@ -127,11 +122,10 @@ HERE_I_AM_DATABASE_URL=sqlite+aiosqlite:///./here_i_am.db
 # ============================================================================
 # CONTEXT WINDOW LIMITS (tokens)
 # ============================================================================
-# Combined inbound token cap for conversation history. Leave headroom below the
-# provider's real max; client-side token counting is approximate.
+# Combined inbound token cap for conversation history (retrieved memories are
+# part of the history). Leave headroom below the provider's real max;
+# client-side token counting is approximate.
 # CONTEXT_TOKEN_LIMIT=175000
-# Memory block cap (kept small to reduce cache-miss cost)
-# MEMORY_TOKEN_LIMIT=10000
 
 
 # ============================================================================

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -312,12 +312,6 @@ class Settings(BaseSettings):
     # Enable DOCX text extraction (requires python-docx)
     attachment_docx_enabled: bool = True
 
-    # Memory System settings
-    # When True, memories are inserted directly into conversation context as user messages
-    # (better cacheability - memories only paid for once per conversation)
-    # When False (default), memories are rendered as a separate block each turn (legacy behavior)
-    use_memory_in_context: bool = True
-
     # Multiple Pinecone indexes (JSON array of objects with index_name, label, description, llm_provider, default_model)
     # Example: '[{"index_name": "claude", "label": "Claude", "description": "Primary AI entity", "llm_provider": "anthropic", "default_model": "claude-sonnet-4-5-20250929"}]'
     pinecone_indexes: str = ""
@@ -436,8 +430,7 @@ class Settings(BaseSettings):
     # OpenAI max context varies by model. For most GPT 5.x models, it's 272,000. For GPT 5.1 Chat and the older models it's 128,000
     # Leave some room between your setting and the actual max; token counting client-side is approximate
     # The maximum is for all inbound tokens, memory and conversation history token counts are combined
-    context_token_limit: int = 175000  # Conversation history cap
-    memory_token_limit: int = 10000    # Memory block cap (kept small to reduce cache miss cost)
+    context_token_limit: int = 175000  # Conversation history cap (memories are part of the history)
 
     class Config:
         env_file = ".env"

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -1216,18 +1216,10 @@ async def get_session_info(
     if not session:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    # Get memories currently in context (not all retrieved, just those in context).
-    # The two memory systems track "in context" differently: the legacy memory
-    # block uses session.in_context_ids, while memory-in-context mode embeds
-    # memories in the conversation and tracks their positions in memory_tracker.
-    # Reading only in_context_ids returns an empty list in memory-in-context mode,
-    # which blanks the "Retrieved Memories" panel after switching conversations.
-    if session.use_memory_in_context:
-        in_context_ids = session.memory_tracker.get_in_context_memory_ids(
-            len(session.conversation_context)
-        )
-    else:
-        in_context_ids = session.in_context_ids
+    # Get memories currently in context (not all retrieved, just those in
+    # context). Memories are embedded in the conversation context and tracked
+    # by position in memory_tracker; rolled-out ones are excluded here.
+    in_context_ids = session.get_in_context_memory_ids()
     in_context_memories = [
         session.session_memories[mid]
         for mid in in_context_ids

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, AsyncIterator, Set, Union
+from typing import Optional, List, Dict, Any, AsyncIterator, Union
 from datetime import datetime
 from anthropic import AsyncAnthropic
 from app.config import settings
@@ -403,16 +403,13 @@ class AnthropicService:
             logger.exception(f"[TOOLS] Stream error: {e}")
             yield {"type": "error", "error": str(e)}
 
-    def build_messages_with_memories(
+    def build_messages(
         self,
-        memories: List[Dict[str, Any]],
         conversation_context: List[Dict[str, str]],
         current_message: Optional[str],
         conversation_start_date: Optional[datetime] = None,
         enable_caching: bool = True,
-        new_memory_ids: Optional[Set[str]] = None,
         # Caching parameters
-        cached_memories: Optional[List[Dict[str, Any]]] = None,
         cached_context: Optional[List[Dict[str, str]]] = None,
         new_context: Optional[List[Dict[str, str]]] = None,
         # Multi-entity conversation parameters
@@ -436,11 +433,12 @@ class AnthropicService:
         2. Assistant: cached history msg 2
         ...
         N. Last cached history msg*       <- cache breakpoint (cache_control here)
-        N+1. New history messages (added since the breakpoint was last advanced;
-             sent uncached this turn, cached from the next turn onward)
+        N+1. New history messages (added since the breakpoint was last advanced,
+             e.g. memory insertions and context notices; sent uncached this
+             turn, cached from the next turn onward)
         ...
-        M-1. User: [/CONVERSATION HISTORY] + [MEMORIES] + memories block + [/MEMORIES]
-        M. User: [CURRENT USER MESSAGE] + date context + entity notes + current message
+        M. User: [/CONVERSATION HISTORY] + [CURRENT USER MESSAGE] + date context
+           + entity notes + current message
 
         If current_message is None (multi-entity continuation), the entity is prompted
         to continue the conversation without a new human message.
@@ -449,11 +447,10 @@ class AnthropicService:
         explaining the conversation structure and participant labels.
 
         Cache hits occur when cached conversation history is identical to previous call.
-        Memories are placed after conversation history so new retrievals don't invalidate
-        the conversation cache.
+        Retrieved memories are embedded in the conversation context as messages, so
+        new retrievals extend the history instead of invalidating the cache.
         """
         messages = []
-        new_memory_ids = new_memory_ids or set()
 
         # Use cached_context if provided, otherwise use all context as cached
         if cached_context is None:
@@ -575,36 +572,8 @@ class AnthropicService:
                         content = "[CONVERSATION HISTORY]\n" + multi_entity_header + "\n" + content
                     messages.append({"role": msg["role"], "content": content})
 
-        # STEP 3: Build the memories block text (after conversation history)
-        # Memories go after conversation so new retrievals don't invalidate conversation cache
-        all_memories = memories  # Already combined and sorted by caller
-        memory_block_text = ""
-        if all_memories:
-            memory_block_text = "[MEMORIES FROM PREVIOUS CONVERSATIONS]\n\n"
-            for mem in all_memories:
-                # Map memory role to display label
-                mem_role = mem.get("role", "")
-                if mem_role == "human":
-                    role_display = user_label
-                elif mem_role == "assistant":
-                    role_display = assistant_label
-                elif mem_role == "reflection":
-                    role_display = "a reflection you saved"
-                else:
-                    role_display = mem_role if mem_role else "unknown"
-                # Short ID lets the entity reference this memory in memory_mark/memory_release
-                short_id = str(mem.get("id", ""))[:8]
-                id_part = f"{short_id} " if short_id else ""
-                memory_block_text += f"Memory {id_part}from {role_display} (from {mem['created_at']}):\n"
-                memory_block_text += f'"{mem["content"]}"\n\n'
-            memory_block_text += "[/MEMORIES]"
-
-        memory_block_tokens = self.count_tokens(memory_block_text) if memory_block_text else 0
-        logger.info(f"[CACHE] Total memories: {len(all_memories)}, {memory_block_tokens} tokens")
-
-        # STEP 4: Build the final user message combining:
+        # STEP 3: Build the final user message combining:
         # - End of conversation history marker
-        # - Memories block
         # - Date context
         # - Entity notes (index.md)
         # - Current user message
@@ -614,10 +583,6 @@ class AnthropicService:
         # End conversation history marker (if there was any history)
         if has_conversation:
             final_parts.append("[/CONVERSATION HISTORY]")
-
-        # Memories block
-        if memory_block_text:
-            final_parts.append(memory_block_text)
 
         # Current message section marker
         final_parts.append("[CURRENT USER MESSAGE]")

--- a/backend/app/services/context_tools.py
+++ b/backend/app/services/context_tools.py
@@ -67,11 +67,8 @@ async def _context_status() -> str:
         memories_in_context = session.get_in_context_memory_count()
 
         # Memories that were retrieved this conversation but are no longer in context
-        if session.use_memory_in_context:
-            in_context_ids = session.memory_tracker.get_in_context_memory_ids(message_count)
-            rolled_out_memories = len(session.memory_tracker.retrieved_ids - in_context_ids)
-        else:
-            rolled_out_memories = len(session.retrieved_ids - session.in_context_ids)
+        in_context_ids = session.memory_tracker.get_in_context_memory_ids(message_count)
+        rolled_out_memories = len(session.memory_tracker.retrieved_ids - in_context_ids)
 
         lines = [
             "[CONTEXT STATUS]",

--- a/backend/app/services/conversation_session.py
+++ b/backend/app/services/conversation_session.py
@@ -15,7 +15,6 @@ import logging
 from app.config import settings
 from app.services.session_helpers import (
     get_message_content_text,
-    build_memory_block_text,
 )
 from app.services.memory_context import (
     MemoryContextTracker,
@@ -51,16 +50,7 @@ class ConversationSession:
     Maintains the conversation context (message history) and tracks memories
     that have been retrieved during this conversation.
 
-    Memory System (Transitioning):
-    The memory system is being reworked from a "memory block" approach to
-    "memory-in-context" approach. During transition, both systems coexist:
-    
-    Legacy (memory block):
-    - in_context_ids: Set of memory IDs in the memory block
-    - get_memories_for_injection(): Returns memories for block construction
-    - trim_memories_to_limit(): Trims memory block to token limit
-    
-    New (memory-in-context):
+    Memory system (memory-in-context):
     - memory_tracker: MemoryContextTracker for position-based tracking
     - insert_memory_into_context(): Inserts memory as context message
     - Memory messages have is_memory=True flag
@@ -92,16 +82,8 @@ class ConversationSession:
     # All IDs that have had retrieval count updated in this conversation (never remove)
     retrieved_ids: Set[str] = field(default_factory=set)
 
-    # ===== Legacy memory block tracking (to be deprecated) =====
-    # IDs currently in the memory block (can be trimmed and restored)
-    in_context_ids: Set[str] = field(default_factory=set)
-
-    # ===== New memory-in-context tracking =====
-    # Position-based memory tracker for the new system
+    # Position-based memory tracker (memories live inside conversation_context)
     memory_tracker: MemoryContextTracker = field(default_factory=MemoryContextTracker)
-    
-    # Flag to enable new memory system (set to True to use memory-in-context)
-    use_memory_in_context: bool = False
 
     # Cache tracking for conversation history (single breakpoint).
     # Advanced to the full context length after every exchange, so each turn's
@@ -138,111 +120,10 @@ class ConversationSession:
         ratio = self.last_prompt_actual_tokens / self.last_prompt_estimated_tokens
         return max(0.5, min(2.0, ratio))
 
-    # ===== Legacy memory block methods (to be deprecated) =====
-    
-    def add_memory(self, memory: MemoryEntry) -> Tuple[bool, bool]:
-        """
-        Add a memory to the session (legacy memory block system).
-
-        Returns tuple of (added_to_session, is_new_retrieval):
-        - (True, True): New memory added, retrieval count should be updated
-        - (True, False): Previously trimmed memory restored, don't update count
-        - (False, False): Memory already in context, no action needed
-        """
-        # If already in context, nothing to do
-        if memory.id in self.in_context_ids:
-            return (False, False)
-
-        # If previously retrieved but trimmed, restore to context without updating count
-        if memory.id in self.retrieved_ids:
-            self.in_context_ids.add(memory.id)
-            # Update the memory entry with new score
-            if memory.id in self.session_memories:
-                self.session_memories[memory.id].score = memory.score
-            return (True, False)
-
-        # New memory - add to all tracking structures
-        self.retrieved_ids.add(memory.id)
-        self.in_context_ids.add(memory.id)
-        self.session_memories[memory.id] = memory
-        return (True, True)
-
-    def get_memories_for_injection(self) -> List[Dict[str, Any]]:
-        """Get memories formatted for API injection (legacy memory block system)."""
-        # Only include memories that are in context
-        memories = [
-            self.session_memories[mid]
-            for mid in self.in_context_ids
-            if mid in self.session_memories
-        ]
-        # Sort by ID for stable ordering (improves Anthropic cache hit rate)
-        memories.sort(key=lambda m: m.id)
-
-        return [
-            {
-                "id": m.id,
-                "content": m.content,
-                "created_at": m.created_at,
-                "times_retrieved": m.times_retrieved,
-                "role": m.role,
-            }
-            for m in memories
-        ]
-
-    def trim_memories_to_limit(
-        self,
-        max_tokens: int,
-        count_tokens_fn: Callable[[str], int],
-    ) -> List[str]:
-        """
-        Trim oldest-retrieved memories until the memory block fits within token limit.
-        (Legacy memory block system - not needed when use_memory_in_context=True)
-
-        Memories are removed from in_context_ids in FIFO order (first retrieved = first removed).
-        They remain in retrieved_ids and session_memories so they can be restored without
-        incrementing retrieval count if they become relevant again.
-
-        Args:
-            max_tokens: Maximum token count for memory block
-            count_tokens_fn: Function to count tokens in a string
-
-        Returns:
-            List of memory IDs that were removed from context
-        """
-        removed_ids = []
-
-        # Build ordered list of in-context IDs based on session_memories insertion order
-        # (which reflects retrieval order)
-        ordered_in_context = [
-            mid for mid in self.session_memories.keys()
-            if mid in self.in_context_ids
-        ]
-
-        while ordered_in_context:
-            # Get memories for injection and calculate current token count
-            memories_for_injection = self.get_memories_for_injection()
-            memory_block_text = build_memory_block_text(
-                memories_for_injection,
-                conversation_start_date=self.conversation_start_date,
-            )
-            current_tokens = count_tokens_fn(memory_block_text)
-
-            if current_tokens <= max_tokens:
-                break
-
-            # Remove the oldest in-context memory (first in ordered list)
-            oldest_id = ordered_in_context.pop(0)
-            self.in_context_ids.discard(oldest_id)
-            removed_ids.append(oldest_id)
-
-        return removed_ids
-
-    # ===== New memory-in-context methods =====
-    
     def insert_memory_into_context(self, memory: MemoryEntry) -> Tuple[bool, bool]:
         """
-        Insert a memory into the conversation context (new memory-in-context system).
-        
+        Insert a memory into the conversation context.
+
         The memory is formatted as a user message and inserted at the current end
         of the conversation context. Its position is tracked so we know if it gets
         rolled out when context is trimmed.
@@ -286,8 +167,7 @@ class ConversationSession:
         
         # Also store in session_memories for reference
         self.session_memories[memory.id] = memory
-        
-        # Keep retrieved_ids in sync (for compatibility)
+
         if is_new_retrieval:
             self.retrieved_ids.add(memory.id)
         
@@ -296,25 +176,12 @@ class ConversationSession:
         return (True, is_new_retrieval)
     
     def get_in_context_memory_ids(self) -> Set[str]:
-        """
-        Get the set of memory IDs currently in context.
-
-        Works with both legacy and new memory systems.
-        """
-        if self.use_memory_in_context:
-            return self.memory_tracker.get_in_context_memory_ids(len(self.conversation_context))
-        else:
-            return set(self.in_context_ids)
+        """Get the set of memory IDs currently in context (not rolled out)."""
+        return self.memory_tracker.get_in_context_memory_ids(len(self.conversation_context))
 
     def get_in_context_memory_count(self) -> int:
-        """
-        Get the count of memories currently in context.
-
-        Works with both legacy and new memory systems.
-        """
+        """Get the count of memories currently in context."""
         return len(self.get_in_context_memory_ids())
-
-    # ===== Shared methods (work with both systems) =====
 
     def has_conversational_messages(self) -> bool:
         """
@@ -427,7 +294,7 @@ class ConversationSession:
         Trim oldest messages from conversation context until it fits within token limit.
 
         Messages are removed in FIFO order (oldest = first removed).
-        When using memory-in-context, this also updates memory tracking for rolled-out memories.
+        Memory tracking is updated for any memories that roll out with them.
 
         Args:
             max_tokens: Maximum token count for conversation context
@@ -484,13 +351,12 @@ class ConversationSession:
                     f"cache breakpoint {old_cache_len}->{self.last_cached_context_length}"
                 )
 
-            # If using memory-in-context, update memory tracking for rolled-out memories
-            if self.use_memory_in_context:
-                rolled_out = self.memory_tracker.handle_context_rollout(
-                    num_messages_removed=removed_count,
-                    conversation_context=self.conversation_context,
-                )
-                if rolled_out:
-                    logger.info(f"[MEMORY] Context trimming rolled out {len(rolled_out)} memories")
+            # Update memory tracking for rolled-out memories
+            rolled_out = self.memory_tracker.handle_context_rollout(
+                num_messages_removed=removed_count,
+                conversation_context=self.conversation_context,
+            )
+            if rolled_out:
+                logger.info(f"[MEMORY] Context trimming rolled out {len(rolled_out)} memories")
 
         return removed_count

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -418,9 +418,8 @@ class LLMService:
         else:
             yield {"type": "error", "error": f"Unsupported provider: {provider}"}
 
-    def build_messages_with_memories(
+    def build_messages(
         self,
-        memories: List[Dict[str, Any]],
         conversation_context: List[Dict[str, str]],
         current_message: Optional[str],
         model: Optional[str] = None,
@@ -441,7 +440,7 @@ class LLMService:
         provider_hint: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
-        Build the message list for API call with memory injection.
+        Build the message list for the API call.
 
         Uses the appropriate service based on model/provider.
         When enable_caching=True and using Anthropic, adds cache_control markers
@@ -449,9 +448,11 @@ class LLMService:
 
         Cache structure (conversation-first):
         1. Cached conversation history (with cache breakpoint at end)
-        2. New conversation history (uncached)
-        3. Memories (after conversation, so retrievals don't invalidate cache)
-        4. Current user message (with optional attachments for multimodal)
+        2. New conversation history (uncached; includes memory insertions)
+        3. Current user message (with optional attachments for multimodal)
+
+        Retrieved memories are embedded in the conversation context as messages,
+        so new retrievals extend the history instead of invalidating the cache.
 
         For cache hits, the cached_context must be IDENTICAL to the previous call.
 
@@ -463,7 +464,6 @@ class LLMService:
         history or memories. The AI's response becomes the persisted context.
 
         Args:
-            memories: List of memory dicts to inject
             conversation_context: Previous messages in conversation
             current_message: The current user message (None for multi-entity continuation)
             model: Model ID (used to determine provider)
@@ -491,8 +491,7 @@ class LLMService:
             provider = ModelProvider.ANTHROPIC
         use_caching = enable_caching and provider == ModelProvider.ANTHROPIC
 
-        return anthropic_service.build_messages_with_memories(
-            memories=memories,
+        return anthropic_service.build_messages(
             conversation_context=conversation_context,
             current_message=current_message,
             conversation_start_date=conversation_start_date,

--- a/backend/app/services/memory_context.py
+++ b/backend/app/services/memory_context.py
@@ -1,16 +1,12 @@
 """
 Memory Context Integration Module
 
-This module provides the new memory tracking system where memories are inserted
-directly into conversation history rather than being rendered as a separate block.
+Memories are inserted directly into conversation history rather than being
+rendered as a separate block. This improves cacheability (memories are paid
+for once per conversation instead of re-rendered each turn) and creates a
+more integrated experience.
 
-This approach improves cacheability (memories are paid for once per conversation
-instead of re-rendered each turn) and creates a more integrated experience.
-
-Usage:
-    The functions and class in this module are designed to work alongside the 
-    existing ConversationSession. During migration, ConversationSession will 
-    be updated to use these new tracking mechanisms.
+ConversationSession uses these tracking mechanisms for all memory handling.
 """
 
 from typing import Dict, List, Set, Optional, Any, Tuple
@@ -67,11 +63,10 @@ def format_memory_as_context_message(
 class MemoryContextTracker:
     """
     Tracks memories that have been inserted into conversation context.
-    
-    This replaces the old in_context_ids/memory block approach with position-based
-    tracking. Memories are inserted into conversation_context as regular messages,
-    and we track their positions to know which are still present after context rolling.
-    
+
+    Memories are inserted into conversation_context as regular messages, and we
+    track their positions to know which are still present after context rolling.
+
     Attributes:
         retrieved_ids: All memory IDs that have been retrieved this conversation
                       (retrieval count has been incremented). Never cleared.

--- a/backend/app/services/session_helpers.py
+++ b/backend/app/services/session_helpers.py
@@ -300,31 +300,6 @@ def estimate_prompt_tokens(
     return count_tokens_fn(text) if text else 0
 
 
-def build_memory_block_text(
-    memories: List[Dict[str, Any]],
-    conversation_start_date: Optional[datetime] = None,
-) -> str:
-    """
-    Build the memory block text for token counting purposes.
-
-    This matches the format used in anthropic_service.build_messages_with_memories
-    where memories are placed after conversation history.
-    
-    NOTE: This function is used by the legacy memory block system and will be
-    deprecated when memory-context-integration is complete.
-    """
-    if not memories:
-        return ""
-
-    memory_block = "[MEMORIES FROM PREVIOUS CONVERSATIONS]\n\n"
-    for mem in memories:
-        memory_block += f"Memory (from {mem['created_at']}):\n"
-        memory_block += f'"{mem["content"]}"\n\n'
-    memory_block += "[/MEMORIES]"
-
-    return memory_block
-
-
 def add_cache_control_to_tool_result(user_msg: Dict[str, Any]) -> Dict[str, Any]:
     """
     Add cache_control to the last tool_result block in a user message.
@@ -332,9 +307,8 @@ def add_cache_control_to_tool_result(user_msg: Dict[str, Any]) -> Dict[str, Any]
     This enables Anthropic's prompt caching between tool iterations: the
     breakpoint sits on the latest tool_result every iteration, so each API
     call writes only the newest exchange and reads the rest of the prefix
-    from cache. The 1h TTL matters because with memory-in-context
-    (USE_MEMORY_IN_CONTEXT=true) tool exchanges can survive into the next
-    turn, which is human-paced and may exceed the 5-minute TTL.
+    from cache. The 1h TTL matters because tool exchanges survive into the
+    next turn, which is human-paced and may exceed the 5-minute TTL.
 
     Args:
         user_msg: The user message containing tool_result content blocks
@@ -369,5 +343,4 @@ _build_memory_queries = build_memory_queries
 _calculate_significance = calculate_significance
 _ensure_role_balance = ensure_role_balance
 _get_message_content_text = get_message_content_text
-_build_memory_block_text = build_memory_block_text
 _add_cache_control_to_tool_result = add_cache_control_to_tool_result

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -35,7 +35,6 @@ from app.services.session_helpers import (
     stamp_human_message,
     ensure_role_balance,
     get_message_content_text,
-    build_memory_block_text,
     add_cache_control_to_tool_result,
     estimate_prompt_tokens,
     total_prompt_tokens_from_usage,
@@ -44,7 +43,6 @@ from app.services.session_helpers import (
     _calculate_significance,
     _ensure_role_balance,
     _get_message_content_text,
-    _build_memory_block_text,
     _add_cache_control_to_tool_result,
 )
 from app.services.memory_context import format_memory_as_context_message
@@ -95,7 +93,6 @@ class SessionManager:
             system_prompt=system_prompt,
             entity_id=entity_id,
             conversation_start_date=conversation_start_date,
-            use_memory_in_context=settings.use_memory_in_context,
             provider_hint=provider_hint,
         )
         self._sessions[conversation_id] = session
@@ -272,83 +269,50 @@ class SessionManager:
                 db, entity_id=entity_id
             )
 
-        # For memory-in-context mode, we need to interleave messages with memories
-        # based on retrieval timestamps. Get memories with timestamps first.
-        memories_with_timestamps = []
-        if session.use_memory_in_context:
-            memories_with_timestamps = await memory_service.get_retrieved_memories_with_timestamps(
-                conversation_id, db, entity_id=entity_id if is_multi_entity else None
-            )
+        # Memories are re-inserted into the rebuilt context at their original
+        # positions, interleaved with messages by retrieval timestamp.
+        memories_with_timestamps = await memory_service.get_retrieved_memories_with_timestamps(
+            conversation_id, db, entity_id=entity_id if is_multi_entity else None
+        )
 
         # Build a mapping of message_id -> memory data for quick lookup
         memory_data_by_id: Dict[str, Optional[Dict]] = {}
         retrieved_ids = set()
         skipped_archived = 0
 
-        if memories_with_timestamps:
-            for mem_info in memories_with_timestamps:
-                mem_id = mem_info["message_id"]
-                mem_data = await memory_service.get_full_memory_content(mem_id, db)
-                if mem_data:
-                    if mem_data["conversation_id"] in archived_source_ids:
-                        skipped_archived += 1
-                        continue
-                    # Memories released since first retrieval are not re-injected
-                    if mem_data.get("memory_status") == "released":
-                        continue
-                    retrieved_ids.add(mem_id)
-                    str_id = mem_data["id"]
-                    memory_data_by_id[str_id] = {
-                        "data": mem_data,
-                        "retrieved_at": mem_info["retrieved_at"],
-                    }
-                    session.session_memories[str_id] = MemoryEntry(
-                        id=str_id,
-                        conversation_id=mem_data["conversation_id"],
-                        role=mem_data["role"],
-                        content=mem_data["content"],
-                        created_at=mem_data["created_at"],
-                        times_retrieved=mem_data["times_retrieved"],
-                    )
-                    session.in_context_ids.add(str_id)
+        for mem_info in memories_with_timestamps:
+            mem_id = mem_info["message_id"]
+            mem_data = await memory_service.get_full_memory_content(mem_id, db)
+            if mem_data:
+                if mem_data["conversation_id"] in archived_source_ids:
+                    skipped_archived += 1
+                    continue
+                # Memories released since first retrieval are not re-injected
+                if mem_data.get("memory_status") == "released":
+                    continue
+                retrieved_ids.add(mem_id)
+                str_id = mem_data["id"]
+                memory_data_by_id[str_id] = {
+                    "data": mem_data,
+                    "retrieved_at": mem_info["retrieved_at"],
+                }
+                session.session_memories[str_id] = MemoryEntry(
+                    id=str_id,
+                    conversation_id=mem_data["conversation_id"],
+                    role=mem_data["role"],
+                    content=mem_data["content"],
+                    created_at=mem_data["created_at"],
+                    times_retrieved=mem_data["times_retrieved"],
+                )
 
-            session.retrieved_ids = retrieved_ids
+        session.retrieved_ids = retrieved_ids
 
-            # Sort memories by retrieved_at for insertion
-            sorted_memory_entries = sorted(
-                memory_data_by_id.items(),
-                key=lambda x: x[1]["retrieved_at"]
-            )
-            memory_queue = list(sorted_memory_entries)  # List of (mem_id, {data, retrieved_at})
-        else:
-            # Non-memory-in-context mode: just load retrieved IDs for deduplication
-            all_retrieved_ids = await memory_service.get_retrieved_ids_for_conversation(
-                conversation_id, db, entity_id=entity_id if is_multi_entity else None
-            )
-
-            # Load full memory content for already-retrieved memories
-            for mem_id in all_retrieved_ids:
-                mem_data = await memory_service.get_full_memory_content(mem_id, db)
-                if mem_data:
-                    if mem_data["conversation_id"] in archived_source_ids:
-                        skipped_archived += 1
-                        continue
-                    # Memories released since first retrieval are not re-injected
-                    if mem_data.get("memory_status") == "released":
-                        continue
-                    retrieved_ids.add(mem_id)
-                    str_id = mem_data["id"]
-                    session.session_memories[str_id] = MemoryEntry(
-                        id=str_id,
-                        conversation_id=mem_data["conversation_id"],
-                        role=mem_data["role"],
-                        content=mem_data["content"],
-                        created_at=mem_data["created_at"],
-                        times_retrieved=mem_data["times_retrieved"],
-                    )
-                    session.in_context_ids.add(str_id)
-            session.retrieved_ids = retrieved_ids
-            memory_queue = []
+        # Sort memories by retrieved_at for insertion
+        sorted_memory_entries = sorted(
+            memory_data_by_id.items(),
+            key=lambda x: x[1]["retrieved_at"]
+        )
+        memory_queue = list(sorted_memory_entries)  # List of (mem_id, {data, retrieved_at})
 
         if skipped_archived:
             logger.info(
@@ -371,8 +335,7 @@ class SessionManager:
         # Build conversation context, interleaving memories at their original positions
         memory_insert_count = 0
         for msg in messages:
-            # In memory-in-context mode, insert any memories that were retrieved
-            # BEFORE this message was created
+            # Insert any memories that were retrieved BEFORE this message was created
             while memory_queue:
                 mem_id, mem_info = memory_queue[0]
                 if mem_info["retrieved_at"] <= msg.created_at:
@@ -518,7 +481,6 @@ class SessionManager:
         db: AsyncSession,
         new_memories: List[MemoryEntry],
         truly_new_memory_ids: Set[str],
-        use_in_context_insertion: bool,
     ) -> None:
         """
         Pull the most recently created reflections into context on the
@@ -616,10 +578,7 @@ class SessionManager:
                     source="recent_reflection",
                 )
 
-                if use_in_context_insertion:
-                    added, is_new_retrieval = session.insert_memory_into_context(memory)
-                else:
-                    added, is_new_retrieval = session.add_memory(memory)
+                added, is_new_retrieval = session.insert_memory_into_context(memory)
                 if added:
                     injected += 1
                     new_memories.append(memory)
@@ -857,11 +816,11 @@ class SessionManager:
                     source=item["source"],
                 )
 
-                added, is_new_retrieval = session.add_memory(memory)
+                added, is_new_retrieval = session.insert_memory_into_context(memory)
                 if added:
                     new_memories.append(memory)
                     # Track truly new memories separately for cache stability
-                    # Restored memories (trimmed then re-retrieved) should be treated as "old"
+                    # Restored memories (rolled out then re-retrieved) should be treated as "old"
                     if is_new_retrieval:
                         truly_new_memory_ids.add(memory.id)
                         # Update retrieval tracking only for truly new retrievals
@@ -886,7 +845,6 @@ class SessionManager:
                         db,
                         new_memories,
                         truly_new_memory_ids,
-                        use_in_context_insertion=False,
                     )
                 else:
                     logger.info("[MEMORY] Recent reflections: skipped (not the responding entity's first turn)")
@@ -928,13 +886,8 @@ class SessionManager:
         )
 
         # Step 4: Apply token limits before building API messages
-        # Trim memories if over limit (FIFO - oldest retrieved first)
-        trimmed_memory_ids = session.trim_memories_to_limit(
-            max_tokens=settings.memory_token_limit,
-            count_tokens_fn=llm_service.count_tokens,
-        )
-
-        # Trim conversation context if over limit (FIFO - oldest messages first)
+        # Memories live inside the conversation context, so trimming the
+        # context (FIFO - oldest messages first) covers them too.
         trimmed_context_count = session.trim_context_to_limit(
             max_tokens=settings.context_token_limit,
             count_tokens_fn=llm_service.count_tokens,
@@ -943,12 +896,9 @@ class SessionManager:
 
         # Step 5: Build API messages with conversation-first caching
         # Cache breakpoint: end of cached conversation history
-        # Memories are placed after history (don't invalidate cache)
-        memories_for_injection = session.get_memories_for_injection()
         cache_content = session.get_cache_aware_content()
 
-        # Debug logging for memory injection
-        logger.info(f"[MEMORY] Injecting {len(memories_for_injection)} memories into context (in_context_ids: {len(session.in_context_ids)}, session_memories: {len(session.session_memories)})")
+        logger.info(f"[MEMORY] {session.get_in_context_memory_count()} memories embedded in conversation history")
         # Log cached context breakdown by role
         cached_ctx = cache_content['cached_context']
         new_ctx = cache_content['new_context']
@@ -958,8 +908,7 @@ class SessionManager:
         new_asst = sum(1 for m in new_ctx if m.get('role') == 'assistant')
         logger.info(f"[CACHE] Context: {len(cached_ctx)} cached msgs ({cached_user} user, {cached_asst} assistant), {len(new_ctx)} new msgs ({new_user} user, {new_asst} assistant)")
 
-        messages = llm_service.build_messages_with_memories(
-            memories=memories_for_injection,
+        messages = llm_service.build_messages(
             conversation_context=session.conversation_context,
             current_message=stamped_user_message,
             model=session.model,
@@ -1024,8 +973,9 @@ class SessionManager:
                 }
                 for m in new_memories
             ],
-            "total_memories_in_context": len(session.in_context_ids),
-            "trimmed_memory_ids": trimmed_memory_ids,
+            "total_memories_in_context": session.get_in_context_memory_count(),
+            # Memories are trimmed with the context now; kept for API shape stability
+            "trimmed_memory_ids": [],
             "trimmed_context_messages": trimmed_context_count,
         }
 
@@ -1272,14 +1222,11 @@ class SessionManager:
                     source=item["source"],
                 )
 
-                if session.use_memory_in_context:
-                    added, is_new_retrieval = session.insert_memory_into_context(memory)
-                else:
-                    added, is_new_retrieval = session.add_memory(memory)
+                added, is_new_retrieval = session.insert_memory_into_context(memory)
                 if added:
                     new_memories.append(memory)
                     # Track truly new memories separately for cache stability
-                    # Restored memories (trimmed then re-retrieved) should be treated as "old"
+                    # Restored memories (rolled out then re-retrieved) should be treated as "old"
                     if is_new_retrieval:
                         truly_new_memory_ids.add(memory.id)
                         # Only update retrieval count for truly new retrievals
@@ -1304,7 +1251,6 @@ class SessionManager:
                         db,
                         new_memories,
                         truly_new_memory_ids,
-                        use_in_context_insertion=session.use_memory_in_context,
                     )
                 else:
                     logger.info("[MEMORY] Recent reflections: skipped (not the responding entity's first turn)")
@@ -1336,16 +1282,9 @@ class SessionManager:
             else:
                 logger.info(f"[MEMORY] Memory retrieval skipped: entity_id={session.entity_id}")
 
-# Step 3: Apply token limits before building API messages
-# With memory-in-context, memory trimming is handled by context trimming
-        if session.use_memory_in_context:
-            trimmed_memory_ids = []  # Memories are part of context, trimmed there
-        else:
-            # Trim memories if over limit (FIFO - oldest retrieved first)
-            trimmed_memory_ids = session.trim_memories_to_limit(
-                max_tokens=settings.memory_token_limit,
-                count_tokens_fn=llm_service.count_tokens,
-            )
+        # Step 3: Apply token limits before building API messages
+        # Memories live inside the conversation context, so context trimming
+        # below covers them too.
 
         # Fold extracted text-file content into the message using the same
         # rendering the route persists to the DB (build_persistable_content),
@@ -1411,26 +1350,17 @@ class SessionManager:
                 for m in new_memories
             ],
             "total_in_context": session.get_in_context_memory_count(),
-            "trimmed_memory_ids": trimmed_memory_ids,
+            # Memories are trimmed with the context now; kept for event shape stability
+            "trimmed_memory_ids": [],
             "trimmed_context_messages": trimmed_context_count,
         }
 
         # Step 4: Build API messages with conversation-first caching
         # Cache breakpoint: end of cached conversation history
-        # With memory-in-context, memories are already in conversation_context
-        if session.use_memory_in_context:
-            memories_for_injection = []  # Empty - memories are in context
-        else:
-            memories_for_injection = session.get_memories_for_injection()
-
+        # Memories are already embedded in conversation_context
         cache_content = session.get_cache_aware_content()
 
-        # Debug logging for memory injection
-        if session.use_memory_in_context:
-            in_context_count = session.get_in_context_memory_count()
-            logger.info(f"[MEMORY] Memory-in-context mode: {in_context_count} memories embedded in conversation history")
-        else:
-            logger.info(f"[MEMORY] Injecting {len(memories_for_injection)} memories into context (in_context_ids: {len(session.in_context_ids)}, session_memories: {len(session.session_memories)})")
+        logger.info(f"[MEMORY] {session.get_in_context_memory_count()} memories embedded in conversation history")
 
         # Log cached context breakdown by role
         cached_ctx = cache_content['cached_context']
@@ -1450,8 +1380,7 @@ class SessionManager:
             if images or files:
                 logger.info(f"[ATTACHMENTS] Processing {len(images)} images, {len(files)} files")
 
-        messages = llm_service.build_messages_with_memories(
-            memories=memories_for_injection,
+        messages = llm_service.build_messages(
             conversation_context=session.conversation_context,
             current_message=stamped_user_message,
             model=session.model,
@@ -1467,16 +1396,11 @@ class SessionManager:
             provider_hint=session.provider_hint,
         )
 
-        # Build messages WITHOUT memories for subsequent tool iterations (memory optimization)
-        # This reduces context size on iterations after the first
-        # Lazy initialization - only built when tool use is detected
-        base_messages_no_memories = None
-
         # Step 5: Stream LLM response with caching enabled
         # This includes a tool use loop if tools are provided
         full_content = ""
         accumulated_tool_uses = []  # Track all tool uses across iterations
-        tool_exchanges = []  # Track tool exchanges for rebuilding messages without memories
+        tool_exchanges = []  # Track tool exchanges for rebuilding messages between iterations
         # Single moving cache breakpoint (like conversation history caching):
         # it sits on the latest tool_result every iteration, so each iteration
         # incrementally writes only the newest exchange while reading the rest
@@ -1492,40 +1416,16 @@ class SessionManager:
             stop_reason = None
 
             # Build working messages for this iteration
-            # First iteration: include memories for full context
-            # Subsequent iterations: use base messages without memories (memory optimization)
+            # First iteration: the base messages as built above
+            # Subsequent iterations: base messages + accumulated tool exchanges
             if iteration == 1:
-                working_messages = list(messages)  # Include memories
+                working_messages = list(messages)
             else:
-                # Lazy build base messages without memories (only when tool use actually happens)
-                if base_messages_no_memories is None:
-                    base_messages_no_memories = llm_service.build_messages_with_memories(
-                        memories=[],  # No memories for subsequent iterations
-                        conversation_context=session.conversation_context,
-                        current_message=stamped_user_message,
-                        model=session.model,
-                        conversation_start_date=session.conversation_start_date,
-                        enable_caching=True,
-                        cached_context=cache_content["cached_context"],
-                        new_context=cache_content["new_context"],
-                        is_multi_entity=session.is_multi_entity,
-                        entity_labels=session.entity_labels,
-                        responding_entity_label=session.responding_entity_label,
-                        user_display_name=session.user_display_name,
-                        # Keep image attachments on the current message so they
-                        # survive across tool-use iterations. Without this, any
-                        # tool call drops the attachment from the final answer's
-                        # context and the model responds as if nothing was
-                        # attached. (File text travels in stamped_user_message.)
-                        attachments=llm_attachments,
-                        provider_hint=session.provider_hint,
-                    )
-
-                # Rebuild from base (no memories) + accumulated tool exchanges
+                # Rebuild from base + accumulated tool exchanges
                 # Single moving cache breakpoint: cache_control goes on the
                 # latest tool_result, so each iteration writes only the newest
                 # exchange and reads everything before it from cache.
-                working_messages = list(base_messages_no_memories)
+                working_messages = list(messages)
                 for i, exchange in enumerate(tool_exchanges):
                     working_messages.append(exchange["assistant"])
                     if i == len(tool_exchanges) - 1:
@@ -1533,7 +1433,7 @@ class SessionManager:
                     else:
                         user_msg = exchange["user"]
                     working_messages.append(user_msg)
-                logger.info(f"[TOOLS] Iteration {iteration}: Using messages without memory block ({len(working_messages)} messages, {len(tool_exchanges)} tool exchanges, breakpoint on latest tool_result)")
+                logger.info(f"[TOOLS] Iteration {iteration}: {len(working_messages)} messages, {len(tool_exchanges)} tool exchanges, breakpoint on latest tool_result")
 
             async for event in llm_service.send_message_stream(
                 messages=working_messages,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -278,27 +278,6 @@ def mock_pinecone_index():
 
 
 @pytest.fixture
-def sample_memories():
-    """Create sample memory data for injection."""
-    return [
-        {
-            "id": "mem-1",
-            "content": "I remember you mentioned enjoying programming.",
-            "created_at": "2024-01-01",
-            "times_retrieved": 3,
-            "role": "assistant",
-        },
-        {
-            "id": "mem-2",
-            "content": "We discussed AI ethics last time.",
-            "created_at": "2024-01-02",
-            "times_retrieved": 1,
-            "role": "human",
-        },
-    ]
-
-
-@pytest.fixture
 def sample_conversation_context():
     """Create sample conversation context."""
     return [

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -165,19 +165,18 @@ class TestAnthropicService:
         assert call_kwargs["temperature"] == 0.5
         assert call_kwargs["max_tokens"] == 2000
 
-    def test_build_messages_with_memories_no_memories(self, mock_encoder):
-        """Test building messages without memories but with conversation context."""
+    def test_build_messages_with_context(self, mock_encoder):
+        """Test building messages with conversation context."""
         service = AnthropicService()
         service._encoder = mock_encoder
 
-        memories = []
         context = [
             {"role": "user", "content": "Hi"},
             {"role": "assistant", "content": "Hello!"},
         ]
         current = "How are you?"
 
-        messages = service.build_messages_with_memories(memories, context, current)
+        messages = service.build_messages(context, current)
 
         # Conversation-first structure:
         # 1. user: [CONVERSATION HISTORY] + Hi
@@ -197,20 +196,19 @@ class TestAnthropicService:
         assert "[DATE CONTEXT]" in messages[2]["content"]
         assert "How are you?" in messages[2]["content"]
 
-    def test_build_messages_with_memories_no_memories_no_caching(self, mock_encoder):
-        """Test building messages without memories and caching disabled."""
+    def test_build_messages_no_caching(self, mock_encoder):
+        """Test building messages with caching disabled."""
         service = AnthropicService()
         service._encoder = mock_encoder
 
-        memories = []
         context = [
             {"role": "user", "content": "Hi"},
             {"role": "assistant", "content": "Hello!"},
         ]
         current = "How are you?"
 
-        messages = service.build_messages_with_memories(
-            memories, context, current, enable_caching=False
+        messages = service.build_messages(
+            context, current, enable_caching=False
         )
 
         # Conversation-first structure (same as with caching):
@@ -240,8 +238,8 @@ class TestAnthropicService:
             }],
         }
 
-        messages = service.build_messages_with_memories(
-            [], [], None, attachments=attachments
+        messages = service.build_messages(
+            [], None, attachments=attachments
         )
 
         # Final user message carries the file content under the normal
@@ -265,8 +263,8 @@ class TestAnthropicService:
             {"role": "assistant", "content": "Hello!"},
         ]
 
-        messages = service.build_messages_with_memories(
-            [], context, None,
+        messages = service.build_messages(
+            context, None,
             cached_context=context, new_context=[],
             attachments={"images": [], "files": []},
         )
@@ -278,89 +276,38 @@ class TestAnthropicService:
         )
         assert "[CONTINUATION]" in joined
 
-    def test_build_messages_with_memories(self, sample_memories, mock_encoder):
-        """Test building messages with memories."""
+    def test_build_messages_memory_messages_in_context(self, mock_encoder):
+        """Memory messages embedded in the context flow through like any other message."""
         service = AnthropicService()
         service._encoder = mock_encoder
 
-        context = []
-        current = "What do you remember?"
+        context = [
+            {
+                "role": "user",
+                "content": "[MEMORY mem-1 from 2024-01-01 - originally from you]\nI remember you mentioned enjoying programming.\n[/MEMORY]",
+                "is_memory": True,
+                "memory_id": "mem-1",
+            },
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
 
-        messages = service.build_messages_with_memories(sample_memories, context, current)
+        messages = service.build_messages(context, "Tell me more.")
 
-        # Conversation-first structure with no context (memories only):
-        # Single user message with: [CONVERSATION HISTORY] + [/CONVERSATION HISTORY] + [MEMORIES] + date + current
-        assert len(messages) == 1
-
-        # Single message should contain memories in the final block
-        assert messages[0]["role"] == "user"
-        content = messages[0]["content"]
-        if isinstance(content, list):
-            content = content[0]["text"]
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in content
-        assert "I remember you mentioned enjoying programming" in content
-        assert "[/MEMORIES]" in content
-        assert "[DATE CONTEXT]" in content
-        assert "What do you remember?" in content
-
-    def test_build_messages_with_memories_and_context(
-        self, sample_memories, sample_conversation_context, mock_encoder
-    ):
-        """Test building messages with both memories and context."""
-        service = AnthropicService()
-        service._encoder = mock_encoder
-
-        current = "Tell me more."
-
-        messages = service.build_messages_with_memories(
-            sample_memories,
-            sample_conversation_context,
-            current
-        )
-
-        # Conversation-first structure with memories and context:
-        # 1. user: [CONVERSATION HISTORY] + Hello!
-        # 2. assistant: Hi there!
-        # 3. user: [/CONVERSATION HISTORY] + [MEMORIES] + memories + [/MEMORIES] + date + current
-        assert len(messages) == 3
-
-        # First message: conversation history start
+        # Memory message is part of the conversation history
         assert messages[0]["role"] == "user"
         assert "[CONVERSATION HISTORY]" in messages[0]["content"]
-        assert "Hello!" in messages[0]["content"]
+        assert "[MEMORY mem-1" in messages[0]["content"]
+        assert "enjoying programming" in messages[0]["content"]
 
-        # Second message: assistant response from history
-        assert messages[1]["role"] == "assistant"
-        assert "Hi there!" in messages[1]["content"]
-
-        # Third message: combined final message
-        assert messages[2]["role"] == "user"
-        final_content = messages[2]["content"]
+        # Final message has no memory block, just the current message framing
+        final_content = messages[-1]["content"]
         assert "[/CONVERSATION HISTORY]" in final_content
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in final_content
-        assert "I remember you mentioned enjoying programming" in final_content
+        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" not in final_content
         assert "[DATE CONTEXT]" in final_content
         assert "Tell me more." in final_content
 
-    def test_build_messages_memory_format(self, sample_memories, mock_encoder):
-        """Test that memories are formatted correctly."""
-        service = AnthropicService()
-        service._encoder = mock_encoder
-
-        messages = service.build_messages_with_memories(sample_memories, [], "Test")
-
-        # With no context, single message contains everything
-        memory_content = messages[0]["content"]
-        if isinstance(memory_content, list):
-            memory_content = memory_content[0]["text"]
-
-        # Check formatting - memories include short ID (for memory_mark/memory_release)
-        # and role; times_retrieved was removed for cache stability
-        assert "Memory mem-1 from assistant (from 2024-01-01):" in memory_content
-        assert '"I remember you mentioned enjoying programming."' in memory_content
-        assert "Memory mem-2 from user (from 2024-01-02):" in memory_content
-
-    def test_build_messages_caching_structure(self, sample_memories):
+    def test_build_messages_caching_structure(self):
         """Test that cache_control markers are added correctly on conversation history."""
         service = AnthropicService()
 
@@ -380,8 +327,8 @@ class TestAnthropicService:
             {"role": "assistant", "content": "Hi " * 100},
         ]
 
-        messages = service.build_messages_with_memories(
-            sample_memories, [], "Test",
+        messages = service.build_messages(
+            [], "Test",
             cached_context=cached_context,
             new_context=[],
         )
@@ -394,40 +341,6 @@ class TestAnthropicService:
         assert last_cached_msg["content"][0]["type"] == "text"
         assert "cache_control" in last_cached_msg["content"][0]
         assert last_cached_msg["content"][0]["cache_control"]["type"] == "ephemeral"
-
-    def test_build_messages_all_memories_consolidated(self):
-        """Test that all memories (old and new) are consolidated into one block."""
-        service = AnthropicService()
-
-        # Mock encoder and cache
-        mock_encoder = MagicMock()
-        mock_encoder.encode.return_value = list(range(1500))
-        service._encoder = mock_encoder
-
-        mock_cache = MagicMock()
-        mock_cache.get_token_count.return_value = None
-        service._cache_service = mock_cache
-
-        memories = [
-            {"id": "old-1", "content": "Old memory", "created_at": "2024-01-01"},
-            {"id": "new-1", "content": "New memory", "created_at": "2024-01-02"},
-        ]
-        new_memory_ids = {"new-1"}
-
-        messages = service.build_messages_with_memories(
-            memories, [], "Test", new_memory_ids=new_memory_ids
-        )
-
-        # All memories should be in the final message (conversation-first structure)
-        final_content = messages[-1]["content"]
-        if isinstance(final_content, list):
-            final_content = final_content[0]["text"]
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in final_content
-        assert "Old memory" in final_content
-        assert "New memory" in final_content
-        assert "[/MEMORIES]" in final_content
-        assert "[DATE CONTEXT]" in final_content
-        assert "Test" in final_content
 
 
 class TestCacheBreakpointPlacement:
@@ -451,8 +364,8 @@ class TestCacheBreakpointPlacement:
             {"role": "assistant", "content": "Hi " * 100},
         ]
 
-        messages = service.build_messages_with_memories(
-            [], [], "Test",
+        messages = service.build_messages(
+            [], "Test",
             cached_context=cached_context,
             new_context=[],
         )
@@ -480,8 +393,8 @@ class TestCacheBreakpointPlacement:
             {"role": "assistant", "content": "Short reply"},
         ]
 
-        messages = service.build_messages_with_memories(
-            [], [], "Test",
+        messages = service.build_messages(
+            [], "Test",
             cached_context=cached_context,
             new_context=[],
         )
@@ -511,8 +424,7 @@ class TestCacheBreakpointPlacement:
             {"role": "assistant", "content": "Second assistant response " * 50},
         ]
 
-        messages = service.build_messages_with_memories(
-            memories=[],
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -547,8 +459,7 @@ class TestCacheBreakpointPlacement:
             {"role": "assistant", "content": "New response"},
         ]
 
-        messages = service.build_messages_with_memories(
-            memories=[],
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -575,30 +486,20 @@ class TestCacheBreakpointPlacement:
         mock_cache.get_token_count.return_value = None
         service._cache_service = mock_cache
 
-        memories = [
-            {"id": "mem-1", "content": "Memory 1 " * 50, "created_at": "2024-01-01"},
-            {"id": "mem-2", "content": "Memory 2 " * 50, "created_at": "2024-01-02"},
-        ]
         cached_context = [
             {"role": "user", "content": "Hello " * 50},
             {"role": "assistant", "content": "Hi " * 50},
         ]
 
-        from datetime import datetime
-        with patch.object(service, 'build_messages_with_memories') as original:
-            original.side_effect = lambda *args, **kwargs: AnthropicService.build_messages_with_memories(service, *args, **kwargs)
-
         # Build messages twice with identical inputs
-        messages1 = service.build_messages_with_memories(
-            memories=memories,
+        messages1 = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
             new_context=[],
         )
 
-        messages2 = service.build_messages_with_memories(
-            memories=memories,
+        messages2 = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -637,8 +538,7 @@ class TestCacheBreakpointPlacement:
         ]
 
         # Build messages twice
-        messages1 = service.build_messages_with_memories(
-            memories=[],
+        messages1 = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -648,8 +548,7 @@ class TestCacheBreakpointPlacement:
             responding_entity_label="Claude",
         )
 
-        messages2 = service.build_messages_with_memories(
-            memories=[],
+        messages2 = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -684,8 +583,7 @@ class TestCacheBreakpointPlacement:
         ]
 
         # Build for Claude
-        messages_claude = service.build_messages_with_memories(
-            memories=[],
+        messages_claude = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -696,8 +594,7 @@ class TestCacheBreakpointPlacement:
         )
 
         # Build for GPT
-        messages_gpt = service.build_messages_with_memories(
-            memories=[],
+        messages_gpt = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -720,8 +617,8 @@ class TestCacheBreakpointPlacement:
 class TestTwoBreakpointCachingStrategy:
     """Tests for the conversation-first caching strategy."""
 
-    def test_conversation_history_cached_not_memories(self):
-        """Test that conversation history is cached, not memories."""
+    def test_new_memory_messages_not_cached(self):
+        """Newly inserted memory messages ride in new_context without cache_control."""
         service = AnthropicService()
 
         mock_encoder = MagicMock()
@@ -732,34 +629,37 @@ class TestTwoBreakpointCachingStrategy:
         mock_cache.get_token_count.return_value = None
         service._cache_service = mock_cache
 
-        memories = [
-            {"id": "mem-1", "content": "Memory " * 200, "created_at": "2024-01-01"},
-        ]
         cached_context = [
             {"role": "user", "content": "Question " * 100},
             {"role": "assistant", "content": "Answer " * 100},
         ]
+        new_context = [
+            {
+                "role": "user",
+                "content": "[MEMORY mem-1 from 2024-01-01 - originally from you]\nMemory content\n[/MEMORY]",
+                "is_memory": True,
+                "memory_id": "mem-1",
+            },
+        ]
 
-        messages = service.build_messages_with_memories(
-            memories=memories,
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
-            new_context=[],
+            new_context=new_context,
         )
 
-        # Last cached context message should have cache_control (not memory block)
-        # Structure: context[0], context[1] with cache_control, final with memories
+        # Cache breakpoint stays on the last cached history message
         last_cached = messages[1]
         assert last_cached["role"] == "assistant"
         assert isinstance(last_cached["content"], list)
         assert last_cached["content"][0]["cache_control"]["type"] == "ephemeral"
 
-        # Final message should contain memories (not cached)
-        final_msg = messages[2]
-        assert final_msg["role"] == "user"
-        assert isinstance(final_msg["content"], str)
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in final_msg["content"]
+        # Memory message follows uncached, as a plain string
+        memory_msg = messages[2]
+        assert memory_msg["role"] == "user"
+        assert isinstance(memory_msg["content"], str)
+        assert "[MEMORY mem-1" in memory_msg["content"]
 
     def test_breakpoint_2_last_cached_context_has_cache_control(self):
         """Test breakpoint 2: last cached context message has cache_control."""
@@ -778,8 +678,7 @@ class TestTwoBreakpointCachingStrategy:
             {"role": "assistant", "content": "Answer " * 100},
         ]
 
-        messages = service.build_messages_with_memories(
-            memories=[],
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -793,7 +692,7 @@ class TestTwoBreakpointCachingStrategy:
         assert isinstance(last_cached["content"], list)
         assert last_cached["content"][0]["cache_control"]["type"] == "ephemeral"
 
-    def test_conversation_first_structure_with_memories_and_context(self):
+    def test_conversation_first_structure_with_context(self):
         """Test conversation-first structure with single cache breakpoint."""
         service = AnthropicService()
 
@@ -805,16 +704,12 @@ class TestTwoBreakpointCachingStrategy:
         mock_cache.get_token_count.return_value = None
         service._cache_service = mock_cache
 
-        memories = [
-            {"id": "mem-1", "content": "Memory " * 200, "created_at": "2024-01-01"},
-        ]
         cached_context = [
             {"role": "user", "content": "Question " * 100},
             {"role": "assistant", "content": "Answer " * 100},
         ]
 
-        messages = service.build_messages_with_memories(
-            memories=memories,
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Test",
             cached_context=cached_context,
@@ -824,7 +719,7 @@ class TestTwoBreakpointCachingStrategy:
         # Structure should be (3 messages for proper alternation):
         # 0: cached context[0] with [CONVERSATION HISTORY] marker
         # 1: cached context[1] with cache_control (cache breakpoint)
-        # 2: combined: [/CONVERSATION HISTORY] + memories + [CURRENT USER MESSAGE] + date + current message
+        # 2: combined: [/CONVERSATION HISTORY] + [CURRENT USER MESSAGE] + date + current message
 
         assert len(messages) == 3
 
@@ -841,8 +736,6 @@ class TestTwoBreakpointCachingStrategy:
         # Combined final message (maintains proper user/assistant alternation)
         assert messages[2]["role"] == "user"
         assert "[/CONVERSATION HISTORY]" in messages[2]["content"]
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in messages[2]["content"]
-        assert "Memory " in messages[2]["content"]
         assert "[CURRENT USER MESSAGE]" in messages[2]["content"]
         assert "[DATE CONTEXT]" in messages[2]["content"]
         assert "Test" in messages[2]["content"]
@@ -868,8 +761,7 @@ class TestTwoBreakpointCachingStrategy:
             {"role": "assistant", "content": "New answer"},
         ]
 
-        messages = service.build_messages_with_memories(
-            memories=[],
+        messages = service.build_messages(
             conversation_context=[],
             current_message="Current",
             cached_context=cached_context,

--- a/backend/tests/test_conversation_session.py
+++ b/backend/tests/test_conversation_session.py
@@ -3,9 +3,8 @@ Tests for conversation_session.py - ConversationSession and MemoryEntry dataclas
 
 Tests cover:
 - MemoryEntry: Dataclass initialization
-- ConversationSession: Legacy memory system (add_memory, get_memories_for_injection, trim_memories_to_limit)
-- ConversationSession: New memory-in-context system (insert_memory_into_context, get_in_context_memory_count)
-- ConversationSession: Shared methods (add_exchange, get_cache_aware_content,
+- ConversationSession: Memory-in-context system (insert_memory_into_context, get_in_context_memory_count)
+- ConversationSession: Context methods (add_exchange, get_cache_aware_content,
   update_cache_state, trim_context_to_limit)
 """
 
@@ -56,115 +55,11 @@ class TestMemoryEntry:
 
 
 # ============================================================
-# Tests for ConversationSession - Legacy Memory System
-# ============================================================
-
-class TestConversationSessionLegacyMemory:
-    """Tests for the legacy memory block system in ConversationSession."""
-
-    def _make_memory(self, mem_id="mem-1", role="assistant", content="Test"):
-        return MemoryEntry(
-            id=mem_id,
-            conversation_id="conv-1",
-            role=role,
-            content=content,
-            created_at="2024-01-01",
-            times_retrieved=1,
-            score=0.9,
-        )
-
-    def test_add_new_memory(self):
-        """Should add a new memory and return (True, True)."""
-        session = ConversationSession(conversation_id="conv-1")
-        memory = self._make_memory()
-
-        added, is_new = session.add_memory(memory)
-        assert added is True
-        assert is_new is True
-        assert "mem-1" in session.retrieved_ids
-        assert "mem-1" in session.in_context_ids
-        assert "mem-1" in session.session_memories
-
-    def test_add_duplicate_memory(self):
-        """Should not re-add memory already in context."""
-        session = ConversationSession(conversation_id="conv-1")
-        memory = self._make_memory()
-
-        session.add_memory(memory)
-        added, is_new = session.add_memory(memory)
-        assert added is False
-        assert is_new is False
-
-    def test_restore_trimmed_memory(self):
-        """Should restore trimmed memory without new retrieval."""
-        session = ConversationSession(conversation_id="conv-1")
-        memory = self._make_memory()
-
-        # Add, then simulate trimming
-        session.add_memory(memory)
-        session.in_context_ids.discard("mem-1")
-
-        # Re-add (restore)
-        added, is_new = session.add_memory(memory)
-        assert added is True
-        assert is_new is False  # Not a new retrieval
-        assert "mem-1" in session.in_context_ids
-
-    def test_get_memories_for_injection_empty(self):
-        """Should return empty list when no memories."""
-        session = ConversationSession(conversation_id="conv-1")
-        assert session.get_memories_for_injection() == []
-
-    def test_get_memories_for_injection_sorted(self):
-        """Should return memories sorted by ID for cache stability."""
-        session = ConversationSession(conversation_id="conv-1")
-        session.add_memory(self._make_memory("mem-b", content="B"))
-        session.add_memory(self._make_memory("mem-a", content="A"))
-
-        memories = session.get_memories_for_injection()
-        assert len(memories) == 2
-        assert memories[0]["id"] == "mem-a"
-        assert memories[1]["id"] == "mem-b"
-
-    def test_get_memories_excludes_trimmed(self):
-        """Should exclude trimmed memories from injection."""
-        session = ConversationSession(conversation_id="conv-1")
-        session.add_memory(self._make_memory("mem-1"))
-        session.add_memory(self._make_memory("mem-2"))
-        session.in_context_ids.discard("mem-1")
-
-        memories = session.get_memories_for_injection()
-        assert len(memories) == 1
-        assert memories[0]["id"] == "mem-2"
-
-    def test_trim_memories_to_limit(self):
-        """Should trim oldest memories when over token limit."""
-        session = ConversationSession(conversation_id="conv-1")
-        session.add_memory(self._make_memory("mem-1", content="First memory"))
-        session.add_memory(self._make_memory("mem-2", content="Second memory"))
-        session.add_memory(self._make_memory("mem-3", content="Third memory"))
-
-        # Mock token counter that returns a high count initially
-        call_count = [0]
-        def mock_count(text):
-            call_count[0] += 1
-            # Return high on first call, lower after removing memories
-            if "mem-1" in str(session.in_context_ids) and "mem-2" in str(session.in_context_ids) and "mem-3" in str(session.in_context_ids):
-                return 1000  # Over limit
-            return 5  # Under limit
-
-        removed = session.trim_memories_to_limit(max_tokens=50, count_tokens_fn=mock_count)
-        assert len(removed) > 0
-        # First memory should be removed (FIFO order)
-        assert "mem-1" in removed
-
-
-# ============================================================
-# Tests for ConversationSession - New Memory-in-Context System
+# Tests for ConversationSession - Memory-in-Context System
 # ============================================================
 
 class TestConversationSessionMemoryInContext:
-    """Tests for the new memory-in-context system."""
+    """Tests for the memory-in-context system."""
 
     def _make_memory(self, mem_id="mem-1", role="assistant", content="Test"):
         return MemoryEntry(
@@ -179,7 +74,7 @@ class TestConversationSessionMemoryInContext:
 
     def test_insert_new_memory(self):
         """Should insert a new memory into context."""
-        session = ConversationSession(conversation_id="conv-1", use_memory_in_context=True)
+        session = ConversationSession(conversation_id="conv-1")
         session.conversation_context = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
@@ -195,7 +90,7 @@ class TestConversationSessionMemoryInContext:
 
     def test_insert_duplicate_memory_skipped(self):
         """Should not insert a memory already in context."""
-        session = ConversationSession(conversation_id="conv-1", use_memory_in_context=True)
+        session = ConversationSession(conversation_id="conv-1")
         session.conversation_context = [
             {"role": "user", "content": "Hello"},
         ]
@@ -206,21 +101,9 @@ class TestConversationSessionMemoryInContext:
         assert inserted is False
         assert is_new is False
 
-    def test_get_in_context_memory_count_legacy(self):
-        """Should count using legacy system when not using memory-in-context."""
-        session = ConversationSession(
-            conversation_id="conv-1",
-            use_memory_in_context=False,
-        )
-        session.in_context_ids = {"mem-1", "mem-2"}
-        assert session.get_in_context_memory_count() == 2
-
-    def test_get_in_context_memory_count_new_system(self):
-        """Should count using tracker when using memory-in-context."""
-        session = ConversationSession(
-            conversation_id="conv-1",
-            use_memory_in_context=True,
-        )
+    def test_get_in_context_memory_count(self):
+        """Should count memories via the position tracker."""
+        session = ConversationSession(conversation_id="conv-1")
         session.conversation_context = [
             {"role": "user", "content": "Hello"},
             {"role": "user", "content": "[MEMORY]...[/MEMORY]", "is_memory": True, "memory_id": "mem-1"},
@@ -234,7 +117,7 @@ class TestConversationSessionMemoryInContext:
 # ============================================================
 
 class TestConversationSessionSharedMethods:
-    """Tests for shared methods that work with both memory systems."""
+    """Tests for the session's context management methods."""
 
     def test_add_exchange_basic(self):
         """Should add human and assistant messages to context."""

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -273,25 +273,23 @@ class TestLLMService:
             with pytest.raises(ValueError, match="not configured"):
                 await service.send_message(messages, model="claude-sonnet-4-5-20250929")
 
-    def test_build_messages_with_memories(self, sample_memories, sample_conversation_context):
-        """Test build_messages_with_memories delegates to anthropic_service."""
+    def test_build_messages(self, sample_conversation_context):
+        """Test build_messages delegates to anthropic_service."""
         service = LLMService()
 
         with patch("app.services.llm_service.anthropic_service") as mock_anthropic:
-            mock_anthropic.build_messages_with_memories.return_value = [
-                {"role": "user", "content": "Memory block"},
+            mock_anthropic.build_messages.return_value = [
+                {"role": "user", "content": "Built message"},
             ]
 
-            result = service.build_messages_with_memories(
-                sample_memories,
+            result = service.build_messages(
                 sample_conversation_context,
                 "Current message",
             )
 
             # Verify the call was made with the required parameters
-            mock_anthropic.build_messages_with_memories.assert_called_once()
-            call_kwargs = mock_anthropic.build_messages_with_memories.call_args.kwargs
-            assert call_kwargs["memories"] == sample_memories
+            mock_anthropic.build_messages.assert_called_once()
+            call_kwargs = mock_anthropic.build_messages.call_args.kwargs
             assert call_kwargs["conversation_context"] == sample_conversation_context
             assert call_kwargs["current_message"] == "Current message"
 

--- a/backend/tests/test_session_helpers.py
+++ b/backend/tests/test_session_helpers.py
@@ -6,7 +6,6 @@ Tests cover:
 - calculate_significance: Memory significance calculation
 - ensure_role_balance: Memory role balance in retrieval
 - get_message_content_text: Content text extraction from messages
-- build_memory_block_text: Memory block text formatting
 - add_cache_control_to_tool_result: Cache control insertion
 """
 
@@ -22,7 +21,6 @@ from app.services.session_helpers import (
     calculate_significance,
     ensure_role_balance,
     get_message_content_text,
-    build_memory_block_text,
     add_cache_control_to_tool_result,
     estimate_prompt_tokens,
     total_prompt_tokens_from_usage,
@@ -414,39 +412,6 @@ class TestGetMessageContentText:
         result = get_message_content_text(blocks)
         assert "plain string" in result
         assert "42" in result
-
-
-# ============================================================
-# Tests for build_memory_block_text
-# ============================================================
-
-class TestBuildMemoryBlockText:
-    """Tests for building memory block text."""
-
-    def test_empty_memories(self):
-        """Should return empty string for no memories."""
-        assert build_memory_block_text([]) == ""
-
-    def test_single_memory(self):
-        """Should format single memory correctly."""
-        memories = [
-            {"content": "I like Python", "created_at": "2024-01-01", "role": "human"},
-        ]
-        result = build_memory_block_text(memories)
-        assert "[MEMORIES FROM PREVIOUS CONVERSATIONS]" in result
-        assert "I like Python" in result
-        assert "2024-01-01" in result
-        assert "[/MEMORIES]" in result
-
-    def test_multiple_memories(self):
-        """Should format multiple memories."""
-        memories = [
-            {"content": "Memory 1", "created_at": "2024-01-01", "role": "human"},
-            {"content": "Memory 2", "created_at": "2024-01-02", "role": "assistant"},
-        ]
-        result = build_memory_block_text(memories)
-        assert "Memory 1" in result
-        assert "Memory 2" in result
 
 
 # ============================================================

--- a/backend/tests/test_session_info_memories.py
+++ b/backend/tests/test_session_info_memories.py
@@ -150,11 +150,10 @@ async def test_build_skips_memories_from_archived_source_conversations(db_sessio
 
 
 @pytest.mark.asyncio
-async def test_session_info_returns_memories_in_memory_in_context_mode(async_client):
-    """Regression: memory-in-context mode tracks in-context memories via the
-    memory_tracker, not session.in_context_ids. The session-info endpoint must
-    read the right source, otherwise the panel blanks after switching away and
-    back from a single-entity conversation.
+async def test_session_info_returns_in_context_memories(async_client):
+    """Regression: in-context memories are tracked via the memory_tracker.
+    The session-info endpoint must read from it, otherwise the panel blanks
+    after switching away and back from a single-entity conversation.
     """
     conversation_id = str(uuid.uuid4())
     session = session_manager.create_session(
@@ -162,7 +161,6 @@ async def test_session_info_returns_memories_in_memory_in_context_mode(async_cli
         model="claude-sonnet-4-5-20250929",
         entity_id="test-entity",
     )
-    session.use_memory_in_context = True
 
     memory = MemoryEntry(
         id=str(uuid.uuid4()),
@@ -175,8 +173,6 @@ async def test_session_info_returns_memories_in_memory_in_context_mode(async_cli
     )
     inserted, _ = session.insert_memory_into_context(memory)
     assert inserted
-    # The legacy set stays empty in this mode - the bug was reading from it.
-    assert session.in_context_ids == set()
 
     try:
         response = await async_client.get(f"/api/chat/session/{conversation_id}")

--- a/backend/tests/test_session_manager.py
+++ b/backend/tests/test_session_manager.py
@@ -70,10 +70,9 @@ class TestConversationSession:
         assert session.conversation_context == []
         assert session.session_memories == {}
         assert session.retrieved_ids == set()
-        assert session.in_context_ids == set()
 
-    def test_add_memory_new(self):
-        """Test adding a new memory."""
+    def test_insert_memory_into_context(self):
+        """Test inserting a new memory into the conversation context."""
         session = ConversationSession(conversation_id="conv-123")
         memory = MemoryEntry(
             id="mem-1",
@@ -84,17 +83,18 @@ class TestConversationSession:
             times_retrieved=1,
         )
 
-        added, is_new_retrieval = session.add_memory(memory)
+        added, is_new_retrieval = session.insert_memory_into_context(memory)
 
         assert added is True
         assert is_new_retrieval is True
         assert "mem-1" in session.retrieved_ids
-        assert "mem-1" in session.in_context_ids
+        assert "mem-1" in session.get_in_context_memory_ids()
         assert "mem-1" in session.session_memories
         assert session.session_memories["mem-1"] == memory
+        assert session.conversation_context[-1]["is_memory"] is True
 
-    def test_add_memory_duplicate(self):
-        """Test adding a memory already in context is rejected."""
+    def test_insert_memory_duplicate(self):
+        """Test inserting a memory already in context is rejected."""
         session = ConversationSession(conversation_id="conv-123")
         memory = MemoryEntry(
             id="mem-1",
@@ -105,15 +105,15 @@ class TestConversationSession:
             times_retrieved=1,
         )
 
-        session.add_memory(memory)
-        added, is_new_retrieval = session.add_memory(memory)
+        session.insert_memory_into_context(memory)
+        added, is_new_retrieval = session.insert_memory_into_context(memory)
 
         assert added is False
         assert is_new_retrieval is False
         assert len(session.session_memories) == 1
 
-    def test_add_memory_restore_trimmed(self):
-        """Test re-adding a previously trimmed memory restores it without updating count."""
+    def test_insert_memory_reinsert_rolled_out(self):
+        """Test re-inserting a rolled-out memory restores it without updating count."""
         session = ConversationSession(conversation_id="conv-123")
         memory = MemoryEntry(
             id="mem-1",
@@ -125,84 +125,28 @@ class TestConversationSession:
             score=0.8,
         )
 
-        # Add memory initially
-        session.add_memory(memory)
-        assert "mem-1" in session.in_context_ids
+        # Insert memory initially
+        session.insert_memory_into_context(memory)
+        assert "mem-1" in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids
 
-        # Simulate trimming by removing from in_context_ids only
-        session.in_context_ids.discard("mem-1")
-        assert "mem-1" not in session.in_context_ids
+        # Simulate rollout via context trimming
+        session.conversation_context.pop(0)
+        session.memory_tracker.handle_context_rollout(
+            num_messages_removed=1,
+            conversation_context=session.conversation_context,
+        )
+        assert "mem-1" not in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids  # Still in retrieved_ids
 
-        # Re-add the same memory (with potentially different score)
-        memory2 = MemoryEntry(
-            id="mem-1",
-            conversation_id="old-conv",
-            role="assistant",
-            content="Test",
-            created_at="2024-01-01",
-            times_retrieved=1,
-            score=0.95,  # Higher score this time
-        )
-        added, is_new_retrieval = session.add_memory(memory2)
+        # Re-insert the same memory
+        added, is_new_retrieval = session.insert_memory_into_context(memory)
 
         # Should be added back to context but not trigger new retrieval count
         assert added is True
         assert is_new_retrieval is False
-        assert "mem-1" in session.in_context_ids
+        assert "mem-1" in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids
-        # Score should be updated
-        assert session.session_memories["mem-1"].score == 0.95
-
-    def test_get_memories_for_injection_sorted(self):
-        """Test memories are sorted by ID for stable caching."""
-        session = ConversationSession(conversation_id="conv-123")
-
-        # Add memories with different scores but they should be sorted by ID
-        for i, score in enumerate([0.5, 0.9, 0.7]):
-            memory = MemoryEntry(
-                id=f"mem-{i}",
-                conversation_id="old-conv",
-                role="assistant",
-                content=f"Content {i}",
-                created_at="2024-01-01",
-                times_retrieved=1,
-                score=score,
-            )
-            session.add_memory(memory)
-
-        memories = session.get_memories_for_injection()
-
-        # Should be sorted by ID (for cache stability), not score
-        assert len(memories) == 3
-        assert memories[0]["id"] == "mem-0"
-        assert memories[1]["id"] == "mem-1"
-        assert memories[2]["id"] == "mem-2"
-
-    def test_get_memories_for_injection_format(self):
-        """Test memories are formatted correctly for injection."""
-        session = ConversationSession(conversation_id="conv-123")
-
-        memory = MemoryEntry(
-            id="mem-1",
-            conversation_id="old-conv",
-            role="assistant",
-            content="Test content",
-            created_at="2024-01-01",
-            times_retrieved=5,
-            score=0.9,
-        )
-        session.add_memory(memory)
-
-        memories = session.get_memories_for_injection()
-
-        assert len(memories) == 1
-        assert memories[0]["id"] == "mem-1"
-        assert memories[0]["content"] == "Test content"
-        assert memories[0]["created_at"] == "2024-01-01"
-        assert memories[0]["times_retrieved"] == 5
-        assert memories[0]["role"] == "assistant"
 
     def test_add_exchange(self):
         """Test adding a conversation exchange."""
@@ -214,80 +158,34 @@ class TestConversationSession:
         assert session.conversation_context[0] == {"role": "user", "content": "Hello!"}
         assert session.conversation_context[1] == {"role": "assistant", "content": "Hi there!"}
 
-    def test_trim_memories_to_limit_no_trimming_needed(self):
-        """Test that memories are not trimmed when under limit."""
+    def test_trim_context_rolls_out_memories(self):
+        """Memories trimmed out with the context are tracked as rolled out."""
         session = ConversationSession(conversation_id="conv-123")
 
-        # Add a memory
+        # Memory inserted first, then enough exchanges to trim it out
         memory = MemoryEntry(
             id="mem-1",
             conversation_id="old-conv",
             role="assistant",
-            content="Test content",
+            content="Memory content",
             created_at="2024-01-01",
             times_retrieved=1,
-            score=0.9,
         )
-        session.add_memory(memory)
+        session.insert_memory_into_context(memory)
+        session.add_exchange("Hello", "Hi there")
+        session.add_exchange("How are you?", "I'm well!")
 
-        # Mock token counter that returns small count
-        count_tokens = lambda x: 100
-
-        removed = session.trim_memories_to_limit(max_tokens=40000, count_tokens_fn=count_tokens)
-
-        assert removed == []
-        assert "mem-1" in session.session_memories
-        assert "mem-1" in session.retrieved_ids
-        assert "mem-1" in session.in_context_ids
-
-    def test_trim_memories_to_limit_removes_oldest_first(self):
-        """Test that oldest-retrieved memories are removed from context first (FIFO)."""
-        session = ConversationSession(conversation_id="conv-123")
-
-        # Add memories in order - first added = first to be removed from context
-        for i in range(3):
-            memory = MemoryEntry(
-                id=f"mem-{i}",
-                conversation_id="old-conv",
-                role="assistant",
-                content=f"Memory content {i}",
-                created_at="2024-01-01",
-                times_retrieved=1,
-                score=0.5 + i * 0.1,  # Different scores
-            )
-            session.add_memory(memory)
-
-        # Token counter that forces trimming (returns decreasing values)
-        call_count = [0]
+        # Over limit until the first three messages are gone
         def count_tokens(x):
-            call_count[0] += 1
-            # Return high value first, then lower to simulate trimming effect
-            if call_count[0] <= 2:
-                return 50000  # Over limit
-            return 100  # Under limit after removing 2
+            return 50000 if len(session.conversation_context) > 2 else 100
 
-        removed = session.trim_memories_to_limit(max_tokens=40000, count_tokens_fn=count_tokens)
+        removed = session.trim_context_to_limit(max_tokens=40000, count_tokens_fn=count_tokens)
 
-        # Should have removed mem-0 and mem-1 from context (oldest retrieved first)
-        assert "mem-0" in removed
-        assert "mem-1" in removed
-        assert "mem-2" not in removed
-
-        # mem-0 and mem-1 should be removed from in_context_ids only
-        assert "mem-0" not in session.in_context_ids
-        assert "mem-1" not in session.in_context_ids
-
-        # But they should still be in retrieved_ids and session_memories
-        # (to prevent re-incrementing retrieval count and to allow restoration)
-        assert "mem-0" in session.retrieved_ids
-        assert "mem-0" in session.session_memories
+        assert removed > 0
+        assert "mem-1" not in session.get_in_context_memory_ids()
+        # Still tracked as retrieved (prevents re-incrementing retrieval count)
         assert "mem-1" in session.retrieved_ids
         assert "mem-1" in session.session_memories
-
-        # mem-2 should still be in context
-        assert "mem-2" in session.in_context_ids
-        assert "mem-2" in session.retrieved_ids
-        assert "mem-2" in session.session_memories
 
     def test_trim_context_to_limit_no_trimming_needed(self):
         """Test that context is not trimmed when under limit."""
@@ -408,7 +306,6 @@ class TestSessionManager:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
 
             # Pass a UUID object instead of string
             conv_uuid = uuid.uuid4()
@@ -428,7 +325,6 @@ class TestSessionManager:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
 
             conv_str = "test-conversation-123"
             session = manager.create_session(conv_str)
@@ -488,12 +384,11 @@ class TestSessionManager:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
@@ -526,8 +421,10 @@ class TestSessionManager:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(
-                return_value={retrieved_id}
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(
+                return_value=[
+                    {"message_id": retrieved_id, "retrieved_at": datetime.utcnow()}
+                ]
             )
             mock_memory.get_full_memory_content = AsyncMock(return_value={
                 "id": retrieved_id,
@@ -541,7 +438,6 @@ class TestSessionManager:
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
@@ -560,7 +456,7 @@ class TestSessionManager:
              patch("app.services.session_manager.llm_service") as mock_llm, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.is_configured.return_value = False  # No memory retrieval
-            mock_llm.build_messages_with_memories.return_value = [
+            mock_llm.build_messages.return_value = [
                 {"role": "user", "content": "Hello"}
             ]
             mock_llm.send_message = AsyncMock(return_value={
@@ -573,7 +469,6 @@ class TestSessionManager:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
 
             session = manager.create_session(sample_conversation.id)
@@ -623,7 +518,7 @@ class TestSessionManager:
             mock_memory.update_retrieval_count = AsyncMock()
             mock_memory.record_memory_link = AsyncMock()
 
-            mock_llm.build_messages_with_memories.return_value = [
+            mock_llm.build_messages.return_value = [
                 {"role": "user", "content": "With memory context"}
             ]
             mock_llm.send_message = AsyncMock(return_value={
@@ -637,7 +532,6 @@ class TestSessionManager:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.significance_half_life_days = 60
             mock_settings.recency_boost_strength = 1.0
@@ -645,7 +539,6 @@ class TestSessionManager:
             mock_settings.retrieval_candidate_multiplier = 2
             mock_settings.initial_retrieval_top_k = 5
             mock_settings.retrieval_top_k = 5
-            mock_settings.use_memory_in_context = False
             mock_settings.recent_reflections_enabled = False
 
             session = manager.create_session(sample_conversation.id)
@@ -687,7 +580,7 @@ class TestSessionManager:
             mock_memory.update_retrieval_count = AsyncMock()
             mock_memory.record_memory_link = AsyncMock()
 
-            mock_llm.build_messages_with_memories.return_value = []
+            mock_llm.build_messages.return_value = []
             mock_llm.send_message = AsyncMock(return_value={
                 "content": "Response",
                 "model": "claude-sonnet-4-5-20250929",
@@ -699,7 +592,6 @@ class TestSessionManager:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.significance_half_life_days = 60
             mock_settings.recency_boost_strength = 1.0
@@ -707,7 +599,6 @@ class TestSessionManager:
             mock_settings.retrieval_candidate_multiplier = 2
             mock_settings.initial_retrieval_top_k = 5
             mock_settings.retrieval_top_k = 5
-            mock_settings.use_memory_in_context = False
             mock_settings.recent_reflections_enabled = False
 
             session = manager.create_session(sample_conversation.id)
@@ -732,10 +623,10 @@ class TestSessionManager:
             mock_memory.update_retrieval_count.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_process_message_restores_trimmed_memory_without_count_update(
+    async def test_process_message_restores_rolled_out_memory_without_count_update(
         self, db_session, sample_conversation
     ):
-        """Test that trimmed memories can be restored without updating retrieval count."""
+        """Test that rolled-out memories can be restored without updating retrieval count."""
         # This tests the ConversationSession behavior for restored memories
         session = ConversationSession(conversation_id="conv-123")
 
@@ -750,18 +641,22 @@ class TestSessionManager:
         )
 
         # First retrieval - should be marked as new
-        added, is_new_retrieval = session.add_memory(memory)
+        added, is_new_retrieval = session.insert_memory_into_context(memory)
         assert added is True
         assert is_new_retrieval is True
-        assert "mem-1" in session.in_context_ids
+        assert "mem-1" in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids
 
-        # Simulate trimming by removing from in_context_ids only
-        session.in_context_ids.discard("mem-1")
-        assert "mem-1" not in session.in_context_ids
+        # Simulate the memory rolling out via context trimming
+        session.conversation_context.pop(0)
+        session.memory_tracker.handle_context_rollout(
+            num_messages_removed=1,
+            conversation_context=session.conversation_context,
+        )
+        assert "mem-1" not in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids  # Still tracked
 
-        # Re-add the same memory (as if search returned it again)
+        # Re-insert the same memory (as if search returned it again)
         memory2 = MemoryEntry(
             id="mem-1",
             conversation_id="old-conv",
@@ -771,13 +666,13 @@ class TestSessionManager:
             times_retrieved=1,
             score=0.95,  # Maybe different score this time
         )
-        added, is_new_retrieval = session.add_memory(memory2)
+        added, is_new_retrieval = session.insert_memory_into_context(memory2)
 
         # Should be added back to context
         assert added is True
         # But should NOT be treated as a new retrieval (no count update needed)
         assert is_new_retrieval is False
-        assert "mem-1" in session.in_context_ids
+        assert "mem-1" in session.get_in_context_memory_ids()
         assert "mem-1" in session.retrieved_ids
 
 
@@ -816,11 +711,10 @@ class TestMultiEntityMemoryIsolation:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
             mock_settings.get_entity_by_index.return_value = MagicMock(
                 label="Claude",
                 default_model="claude-sonnet-4-5-20250929",
@@ -834,9 +728,9 @@ class TestMultiEntityMemoryIsolation:
                 responding_entity_id="claude-main"  # Specify responding entity
             )
 
-        # Verify get_retrieved_ids_for_conversation was called with entity_id
-        mock_memory.get_retrieved_ids_for_conversation.assert_called_once()
-        call_kwargs = mock_memory.get_retrieved_ids_for_conversation.call_args.kwargs
+        # Verify get_retrieved_memories_with_timestamps was called with entity_id
+        mock_memory.get_retrieved_memories_with_timestamps.assert_called_once()
+        call_kwargs = mock_memory.get_retrieved_memories_with_timestamps.call_args.kwargs
         assert call_kwargs.get("entity_id") == "claude-main"
 
         # Verify session has correct entity_id
@@ -853,21 +747,20 @@ class TestMultiEntityMemoryIsolation:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(
                 sample_conversation.id,
                 db_session
             )
 
-        # Verify get_retrieved_ids_for_conversation was called without entity_id
-        mock_memory.get_retrieved_ids_for_conversation.assert_called_once()
-        call_kwargs = mock_memory.get_retrieved_ids_for_conversation.call_args.kwargs
+        # Verify get_retrieved_memories_with_timestamps was called without entity_id
+        mock_memory.get_retrieved_memories_with_timestamps.assert_called_once()
+        call_kwargs = mock_memory.get_retrieved_memories_with_timestamps.call_args.kwargs
         assert call_kwargs.get("entity_id") is None
 
         assert session.is_multi_entity is False
@@ -956,7 +849,7 @@ class TestCacheStateManagement:
         """Test cache-aware content when nothing is cached yet."""
         session = ConversationSession(conversation_id="conv-123")
 
-        # Add some memories
+        # Add some memories (inserted into the conversation context)
         for i in range(3):
             memory = MemoryEntry(
                 id=f"mem-{i}",
@@ -966,7 +859,7 @@ class TestCacheStateManagement:
                 created_at="2024-01-01",
                 times_retrieved=1,
             )
-            session.add_memory(memory)
+            session.insert_memory_into_context(memory)
 
         # Add conversation context
         session.add_exchange("Hello", "Hi")
@@ -977,9 +870,9 @@ class TestCacheStateManagement:
 
         content = session.get_cache_aware_content()
 
-        # All context is new (memories are no longer tracked in cache state)
+        # All context is new (3 memory messages + 4 exchange messages)
         assert len(content["cached_context"]) == 0
-        assert len(content["new_context"]) == 4
+        assert len(content["new_context"]) == 7
 
     def test_get_cache_aware_content_with_cached_state(self):
         """Test cache-aware content with existing cached state."""
@@ -1084,12 +977,11 @@ class TestCacheStateManagement:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             # Load without preserving - should use full context length
             session1 = await manager.load_session_from_db(
@@ -1121,12 +1013,11 @@ class TestCacheStateManagement:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             # Load with preserved value larger than actual context
             session = await manager.load_session_from_db(
@@ -1142,11 +1033,11 @@ class TestCacheStateManagement:
 class TestCacheBreakpointPlacement:
     """Tests for cache breakpoint placement in message building."""
 
-    def test_memory_ids_sorted_for_cache_stability(self):
-        """Test that memories are sorted by ID for cache stability."""
+    def test_memory_insertions_keep_positions_for_cache_stability(self):
+        """Memory messages stay at their insertion positions in the context."""
         session = ConversationSession(conversation_id="conv-123")
 
-        # Add memories in random order
+        # Insert memories in arrival order
         for id_suffix in ["z", "a", "m", "b"]:
             memory = MemoryEntry(
                 id=f"mem-{id_suffix}",
@@ -1156,13 +1047,14 @@ class TestCacheBreakpointPlacement:
                 created_at="2024-01-01",
                 times_retrieved=1,
             )
-            session.add_memory(memory)
+            session.insert_memory_into_context(memory)
 
-        memories = session.get_memories_for_injection()
-
-        # Should be sorted by ID
-        ids = [m["id"] for m in memories]
-        assert ids == ["mem-a", "mem-b", "mem-m", "mem-z"]
+        # Context preserves insertion order (positions never reshuffle,
+        # which is what keeps the cached prefix stable)
+        memory_ids = [
+            m["memory_id"] for m in session.conversation_context if m.get("is_memory")
+        ]
+        assert memory_ids == ["mem-z", "mem-a", "mem-m", "mem-b"]
 
     def test_context_split_preserves_order(self):
         """Test that context split preserves message order."""
@@ -1237,12 +1129,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1272,12 +1163,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1307,12 +1197,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1360,11 +1249,10 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
             mock_entity = MagicMock()
             mock_entity.label = "Claude"
             mock_entity.default_model = "claude-sonnet-4-5-20250929"
@@ -1423,11 +1311,10 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
 
             # Mock entity configs
             def get_entity(eid):
@@ -1508,11 +1395,10 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.use_memory_in_context = False
             mock_entity = MagicMock()
             mock_entity.label = "GPT"
             mock_entity.default_model = "gpt-4o"
@@ -1553,12 +1439,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1587,12 +1472,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1620,12 +1504,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1655,12 +1538,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1689,12 +1571,11 @@ class TestSystemPromptSelection:
         with patch("app.services.session_manager.memory_service") as mock_memory, \
              patch("app.services.session_manager.settings") as mock_settings:
             mock_memory.get_archived_conversation_ids = AsyncMock(return_value=set())
-            mock_memory.get_retrieved_ids_for_conversation = AsyncMock(return_value=set())
+            mock_memory.get_retrieved_memories_with_timestamps = AsyncMock(return_value=[])
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
             mock_settings.get_entity_by_index.return_value = None
-            mock_settings.use_memory_in_context = False
 
             session = await manager.load_session_from_db(conversation.id, db_session)
 
@@ -1702,17 +1583,17 @@ class TestSystemPromptSelection:
         assert session.system_prompt == "Fallback prompt"
 
 
-class TestAgenticToolLoopMemoryOptimization:
-    """Tests for memory optimization in the agentic tool loop.
+class TestAgenticToolLoopMessages:
+    """Tests for message building in the agentic tool loop.
 
-    When tools are used, the first iteration should include memories,
-    but subsequent iterations should exclude the memory block to reduce
-    context size and token costs.
+    Memories are embedded in the conversation context, so the base message
+    set is built once and reused across tool iterations, with accumulated
+    tool exchanges appended.
     """
 
     @pytest.mark.asyncio
     async def test_first_iteration_includes_memories(self, db_session, sample_conversation):
-        """Test that a simple response (no tool use) includes memories in the single call."""
+        """A simple response (no tool use) builds once with memories in the context."""
         manager = SessionManager()
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
@@ -1724,19 +1605,17 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             # Track what messages are built
             build_calls = []
 
-            def track_build_messages(memories, **kwargs):
-                build_calls.append({"memories": memories, "kwargs": kwargs})
+            def track_build_messages(**kwargs):
+                build_calls.append({"kwargs": kwargs})
                 return [{"role": "user", "content": "test"}]
 
-            mock_llm.build_messages_with_memories.side_effect = track_build_messages
+            mock_llm.build_messages.side_effect = track_build_messages
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             # Simple response without tool use
@@ -1755,7 +1634,7 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_llm.send_message_stream = mock_stream
 
             session = manager.create_session(sample_conversation.id)
-            # Add a mock memory to the session
+            # Insert a mock memory into the session context
             memory = MemoryEntry(
                 id="mem-1",
                 conversation_id="old-conv",
@@ -1764,7 +1643,7 @@ class TestAgenticToolLoopMemoryOptimization:
                 created_at="2024-01-01",
                 times_retrieved=1,
             )
-            session.add_memory(memory)
+            session.insert_memory_into_context(memory)
 
             # Process message
             events = []
@@ -1773,17 +1652,17 @@ class TestAgenticToolLoopMemoryOptimization:
             ):
                 events.append(event)
 
-        # Without tool use, messages are built only once (with memories)
-        # Base messages without memories are lazily built only when tool use is detected
+        # Without tool use, messages are built only once
         assert len(build_calls) == 1
 
-        # The single call should include the memory
-        assert len(build_calls[0]["memories"]) == 1
-        assert build_calls[0]["memories"][0]["id"] == "mem-1"
+        # The memory rides inside the conversation context passed to the builder
+        context_arg = build_calls[0]["kwargs"]["conversation_context"]
+        memory_msgs = [m for m in context_arg if m.get("is_memory")]
+        assert [m["memory_id"] for m in memory_msgs] == ["mem-1"]
 
     @pytest.mark.asyncio
-    async def test_subsequent_iterations_exclude_memories(self, db_session, sample_conversation):
-        """Test that subsequent tool loop iterations exclude memory block."""
+    async def test_subsequent_iterations_reuse_base_messages(self, db_session, sample_conversation):
+        """Subsequent tool loop iterations reuse the base messages plus tool exchanges."""
         manager = SessionManager()
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
@@ -1795,21 +1674,18 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             # Track messages sent to LLM
             sent_messages = []
+            build_call_count = [0]
 
-            def build_messages(memories, **kwargs):
-                if memories:
-                    return [{"role": "user", "content": "with_memories"}]
-                else:
-                    return [{"role": "user", "content": "without_memories"}]
+            def build_messages(**kwargs):
+                build_call_count[0] += 1
+                return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             call_count = [0]
@@ -1855,7 +1731,7 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_tool.execute_tool = AsyncMock(return_value=mock_tool_result)
 
             session = manager.create_session(sample_conversation.id)
-            # Add a mock memory
+            # Insert a mock memory into the session context
             memory = MemoryEntry(
                 id="mem-1",
                 conversation_id="old-conv",
@@ -1864,7 +1740,7 @@ class TestAgenticToolLoopMemoryOptimization:
                 created_at="2024-01-01",
                 times_retrieved=1,
             )
-            session.add_memory(memory)
+            session.insert_memory_into_context(memory)
 
             # Process message
             events = []
@@ -1873,15 +1749,15 @@ class TestAgenticToolLoopMemoryOptimization:
             ):
                 events.append(event)
 
-        # Should have two LLM calls
+        # Should have two LLM calls but only one message build (base is reused)
         assert len(sent_messages) == 2
+        assert build_call_count[0] == 1
 
-        # First iteration should use messages with memories
-        assert sent_messages[0][0]["content"] == "with_memories"
+        # First iteration uses the base messages
+        assert sent_messages[0][0]["content"] == "base"
 
-        # Second iteration should use messages without memories (plus tool exchanges)
-        assert sent_messages[1][0]["content"] == "without_memories"
-        # Should also have tool exchange messages appended
+        # Second iteration reuses the base messages plus the tool exchange
+        assert sent_messages[1][0]["content"] == "base"
         assert len(sent_messages[1]) == 3  # base message + assistant tool_use + user tool_result
         assert sent_messages[1][1]["role"] == "assistant"
         assert sent_messages[1][2]["role"] == "user"
@@ -1890,10 +1766,10 @@ class TestAgenticToolLoopMemoryOptimization:
     async def test_attachments_persist_across_tool_iterations(self, db_session, sample_conversation):
         """Attachments must stay on the current message after a tool call.
 
-        Regression test: previously the base (no-memory) message set rebuilt for
-        subsequent tool-loop iterations was built without the attachments, so any
-        tool call dropped the attached file/image from the final answer's context
-        and the model responded as if nothing was attached.
+        Regression test: previously the base message set rebuilt for subsequent
+        tool-loop iterations was built without the attachments, so any tool call
+        dropped the attached file/image from the final answer's context and the
+        model responded as if nothing was attached.
         """
         manager = SessionManager()
 
@@ -1905,19 +1781,17 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             # Capture the kwargs of every build call so we can inspect attachments
             build_calls = []
 
-            def build_messages(memories, **kwargs):
-                build_calls.append({"memories": memories, "kwargs": kwargs})
+            def build_messages(**kwargs):
+                build_calls.append({"kwargs": kwargs})
                 return [{"role": "user", "content": "msg"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             call_count = [0]
@@ -1979,12 +1853,12 @@ class TestAgenticToolLoopMemoryOptimization:
             ):
                 events.append(event)
 
-        # Two build calls: iteration 1 and the lazily-built base message set
-        # for iteration 2. The extracted file text is folded into the current
-        # message (matching the DB-persisted rendering) so it survives both
-        # iterations; the files themselves are stripped from the attachments
-        # passed to message building, leaving only (ephemeral) images.
-        assert len(build_calls) == 2
+        # One build call whose messages are reused across both iterations.
+        # The extracted file text is folded into the current message (matching
+        # the DB-persisted rendering) so it survives both iterations; the files
+        # themselves are stripped from the attachments passed to message
+        # building, leaving only (ephemeral) images.
+        assert len(build_calls) == 1
         for call in build_calls:
             assert call["kwargs"].get("attachments") == {"images": [], "files": []}
             current = call["kwargs"].get("current_message")
@@ -2025,12 +1899,10 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
-            mock_llm.build_messages_with_memories = MagicMock(
+            mock_llm.build_messages = MagicMock(
                 return_value=[{"role": "user", "content": "msg"}]
             )
             mock_llm.count_tokens = MagicMock(return_value=100)
@@ -2086,17 +1958,15 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             sent_messages = []
 
-            def build_messages(memories, **kwargs):
+            def build_messages(**kwargs):
                 return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             call_count = [0]
@@ -2189,7 +2059,7 @@ class TestAgenticToolLoopMemoryOptimization:
 
     @pytest.mark.asyncio
     async def test_no_tool_use_single_iteration(self, db_session, sample_conversation):
-        """Test that without tool use, only one iteration occurs with memories."""
+        """Test that without tool use, only one iteration occurs."""
         manager = SessionManager()
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
@@ -2200,20 +2070,15 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             sent_messages = []
 
-            def build_messages(memories, **kwargs):
-                if memories:
-                    return [{"role": "user", "content": "with_memories"}]
-                else:
-                    return [{"role": "user", "content": "without_memories"}]
+            def build_messages(**kwargs):
+                return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             async def mock_stream(messages, **kwargs):
@@ -2240,7 +2105,7 @@ class TestAgenticToolLoopMemoryOptimization:
                 created_at="2024-01-01",
                 times_retrieved=1,
             )
-            session.add_memory(memory)
+            session.insert_memory_into_context(memory)
 
             events = []
             async for event in manager.process_message_stream(
@@ -2248,14 +2113,13 @@ class TestAgenticToolLoopMemoryOptimization:
             ):
                 events.append(event)
 
-        # Should have only one LLM call
+        # Should have only one LLM call, using the built base messages
         assert len(sent_messages) == 1
-        # That call should use messages with memories
-        assert sent_messages[0][0]["content"] == "with_memories"
+        assert sent_messages[0][0]["content"] == "base"
 
     @pytest.mark.asyncio
-    async def test_base_messages_built_without_memories(self, db_session, sample_conversation):
-        """Test that base_messages_no_memories is lazily built on tool use."""
+    async def test_base_messages_built_once_for_tool_loop(self, db_session, sample_conversation):
+        """The base message set is built once and reused when tools are used."""
         manager = SessionManager()
 
         with patch("app.services.session_manager.memory_service") as mock_memory, \
@@ -2266,21 +2130,16 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             build_calls = []
 
-            def track_build(memories, **kwargs):
-                build_calls.append({
-                    "memories_count": len(memories),
-                    "memories": list(memories),
-                })
+            def track_build(**kwargs):
+                build_calls.append({"kwargs": kwargs})
                 return [{"role": "user", "content": "test"}]
 
-            mock_llm.build_messages_with_memories.side_effect = track_build
+            mock_llm.build_messages.side_effect = track_build
             mock_llm.count_tokens = MagicMock(return_value=100)
 
             call_count = [0]
@@ -2324,7 +2183,7 @@ class TestAgenticToolLoopMemoryOptimization:
             mock_tool.execute_tool = AsyncMock(return_value=mock_tool_result)
 
             session = manager.create_session(sample_conversation.id)
-            # Add multiple memories
+            # Insert multiple memories into the session context
             for i in range(3):
                 memory = MemoryEntry(
                     id=f"mem-{i}",
@@ -2334,7 +2193,7 @@ class TestAgenticToolLoopMemoryOptimization:
                     created_at="2024-01-01",
                     times_retrieved=1,
                 )
-                session.add_memory(memory)
+                session.insert_memory_into_context(memory)
 
             events = []
             async for event in manager.process_message_stream(
@@ -2342,15 +2201,12 @@ class TestAgenticToolLoopMemoryOptimization:
             ):
                 events.append(event)
 
-        # Should have two build calls: first with memories, second without (lazy built on tool use)
-        assert len(build_calls) == 2
-
-        # First: with all 3 memories
-        assert build_calls[0]["memories_count"] == 3
-
-        # Second: with no memories (base for subsequent iterations, lazily built)
-        assert build_calls[1]["memories_count"] == 0
-        assert build_calls[1]["memories"] == []
+        # A single build call serves both iterations; the memories ride in
+        # the conversation context it was given
+        assert len(build_calls) == 1
+        context_arg = build_calls[0]["kwargs"]["conversation_context"]
+        memory_msgs = [m for m in context_arg if m.get("is_memory")]
+        assert len(memory_msgs) == 3
 
 
 class TestAddCacheControlToToolResult:
@@ -2520,17 +2376,15 @@ class TestToolIterationCaching:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             sent_messages = []
 
-            def build_messages(memories, **kwargs):
+            def build_messages(**kwargs):
                 return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=3000)
 
             call_count = [0]
@@ -2612,17 +2466,15 @@ class TestToolIterationCaching:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             sent_messages = []
 
-            def build_messages(memories, **kwargs):
+            def build_messages(**kwargs):
                 return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             # Small token counts don't matter: caching is unconditional
             mock_llm.count_tokens = MagicMock(return_value=100)
 
@@ -2703,17 +2555,15 @@ class TestToolIterationCaching:
             mock_settings.default_model = "claude-sonnet-4-5-20250929"
             mock_settings.default_temperature = 1.0
             mock_settings.default_max_tokens = 64000
-            mock_settings.memory_token_limit = 40000
             mock_settings.context_token_limit = 150000
             mock_settings.tool_use_max_iterations = 10
-            mock_settings.use_memory_in_context = False
 
             sent_messages = []
 
-            def build_messages(memories, **kwargs):
+            def build_messages(**kwargs):
                 return [{"role": "user", "content": "base"}]
 
-            mock_llm.build_messages_with_memories.side_effect = build_messages
+            mock_llm.build_messages.side_effect = build_messages
             mock_llm.count_tokens = MagicMock(return_value=3000)
 
             call_count = [0]
@@ -2826,11 +2676,10 @@ class TestRecentReflectionsInjection:
         }
 
     @staticmethod
-    def _configure_settings(mock_settings, enabled=True, count=3, use_memory_in_context=False):
+    def _configure_settings(mock_settings, enabled=True, count=3):
         mock_settings.default_model = "claude-sonnet-4-5-20250929"
         mock_settings.default_temperature = 1.0
         mock_settings.default_max_tokens = 64000
-        mock_settings.memory_token_limit = 40000
         mock_settings.context_token_limit = 150000
         mock_settings.significance_half_life_days = 60
         mock_settings.recency_boost_strength = 1.0
@@ -2840,13 +2689,12 @@ class TestRecentReflectionsInjection:
         mock_settings.retrieval_top_k = 5
         mock_settings.memory_role_balance_enabled = False
         mock_settings.tool_use_max_iterations = 10
-        mock_settings.use_memory_in_context = use_memory_in_context
         mock_settings.recent_reflections_enabled = enabled
         mock_settings.recent_reflections_count = count
 
     @staticmethod
     def _configure_llm(mock_llm):
-        mock_llm.build_messages_with_memories.return_value = [
+        mock_llm.build_messages.return_value = [
             {"role": "user", "content": "Hello"}
         ]
         mock_llm.send_message = AsyncMock(return_value={
@@ -3023,10 +2871,8 @@ class TestRecentReflectionsInjection:
                 self._reflection_dict("refl-new", created_at="2026-01-02T00:00:00"),
                 self._reflection_dict("refl-old", created_at="2026-01-01T00:00:00"),
             ])
-            self._configure_settings(
-                mock_settings, enabled=True, count=2, use_memory_in_context=True
-            )
-            mock_llm.build_messages_with_memories.return_value = [
+            self._configure_settings(mock_settings, enabled=True, count=2)
+            mock_llm.build_messages.return_value = [
                 {"role": "user", "content": "Hello"}
             ]
             mock_llm.count_tokens = MagicMock(return_value=10)


### PR DESCRIPTION
## Summary

Remove the legacy memory block system entirely and consolidate to memory-in-context mode, where memories are inserted directly into conversation history as context messages rather than rendered as a separate block. This simplifies the codebase and improves cacheability.

## Key Changes

- **Remove legacy memory block tracking:** Deleted `in_context_ids` set, `add_memory()`, `get_memories_for_injection()`, and `trim_memories_to_limit()` methods from `ConversationSession`
- **Remove `use_memory_in_context` flag:** This setting is no longer needed; memory-in-context is now the only mode
- **Rename memory insertion method:** `add_memory()` → `insert_memory_into_context()` to clarify the new behavior
- **Update memory tracking:** Replace `in_context_ids` with `get_in_context_memory_ids()` method that queries the `memory_tracker`
- **Simplify session loading:** Remove conditional logic that branched on `use_memory_in_context`; always load and interleave memories by retrieval timestamp
- **Update LLM service:** Rename `build_messages_with_memories()` → `build_messages()` and remove the separate `memories` parameter; memories now flow through `conversation_context` like any other message
- **Remove memory block formatting:** Delete `build_memory_block_text()` helper and related token-counting logic
- **Update tests:** Rename test methods and remove legacy memory block test suite; consolidate to memory-in-context tests only
- **Clean up config:** Remove `USE_MEMORY_IN_CONTEXT` environment variable and related settings

## Implementation Details

- Memory messages are now marked with `is_memory=True` and `memory_id` in the context, allowing the system to track their positions via `MemoryContextTracker`
- When context is trimmed, the `memory_tracker.handle_context_rollout()` method updates which memories are still in context
- Memories can be re-inserted if they roll out and become relevant again, without re-incrementing retrieval counts (tracked via `retrieved_ids`)
- The conversation-first message structure is preserved: cached conversation history, then new messages (including memory insertions), then the current user message with date context

https://claude.ai/code/session_01NJNePQbCpmvSNRWqjwnFEe