### PR TITLE
Add Claude Opus 5 support and handle temperature rejection

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -387,6 +387,7 @@ class Settings(BaseSettings):
     #
     # ANTHROPIC MODELS:
     #   - claude-fable-5
+    #   - claude-opus-5
     #   - claude-opus-4-8
     #   - claude-opus-4-7
     #   - claude-opus-4-6

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -10,6 +10,24 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# Anthropic models that reject sampling parameters. Claude Opus 4.7 dropped
+# temperature/top_p/top_k, and every model since (Opus 4.8, Opus 5, Sonnet 5,
+# Fable 5, Mythos 5) does the same — sending temperature returns a 400.
+MODELS_WITHOUT_TEMPERATURE = {
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+}
+
+
+def supports_temperature(model: str) -> bool:
+    """Whether the model accepts a temperature parameter."""
+    return model not in MODELS_WITHOUT_TEMPERATURE
+
+
 def _get_content_text(content: Union[str, List[Dict[str, Any]]]) -> str:
     """
     Extract text representation from content (string or content blocks).
@@ -141,9 +159,12 @@ class AnthropicService:
         api_params = {
             "model": model,
             "max_tokens": max_tokens,
-            "temperature": temperature,
             "messages": messages,
         }
+
+        # Newer Claude models reject temperature entirely (400)
+        if supports_temperature(model):
+            api_params["temperature"] = temperature
 
         # Add system prompt with caching if provided
         if system_prompt:
@@ -252,9 +273,12 @@ class AnthropicService:
         api_params = {
             "model": model,
             "max_tokens": max_tokens,
-            "temperature": temperature,
             "messages": messages,
         }
+
+        # Newer Claude models reject temperature entirely (400)
+        if supports_temperature(model):
+            api_params["temperature"] = temperature
 
         # Add system prompt with caching if provided
         if system_prompt:

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from enum import Enum
 
 from app.services import anthropic_service, openai_service
+from app.services.anthropic_service import supports_temperature as anthropic_supports_temperature
 from app.services.openai_service import OpenAIService
 from app.services.google_service import google_service, GoogleService
 from app.config import settings
@@ -36,8 +37,9 @@ MODEL_PROVIDER_MAP = {
     "claude-opus-4-7": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4.8 models
     "claude-opus-4-8": ModelProvider.ANTHROPIC,
-    # Anthropic Claude Fable 5 models
+    # Anthropic Claude 5 models
     "claude-fable-5": ModelProvider.ANTHROPIC,
+    "claude-opus-5": ModelProvider.ANTHROPIC,
     # Anthropic Claude 4 models
     "claude-sonnet-4-20250514": ModelProvider.ANTHROPIC,
     "claude-opus-4-20250514": ModelProvider.ANTHROPIC,
@@ -80,6 +82,7 @@ MODEL_PROVIDER_MAP = {
 AVAILABLE_MODELS = {
     ModelProvider.ANTHROPIC: [
         {"id": "claude-fable-5", "name": "Claude Fable 5"},
+        {"id": "claude-opus-5", "name": "Claude Opus 5"},
         {"id": "claude-opus-4-8", "name": "Claude Opus 4.8"},
         {"id": "claude-opus-4-7", "name": "Claude Opus 4.7"},
         {"id": "claude-opus-4-6", "name": "Claude Opus 4.6"},
@@ -186,13 +189,14 @@ class LLMService:
         for provider_info in self.get_available_providers():
             for model in provider_info["models"]:
                 # Check if model supports temperature
-                # All Anthropic and Google models support temperature
-                # OpenAI models check against MODELS_WITHOUT_TEMPERATURE
+                # OpenAI models check against MODELS_WITHOUT_TEMPERATURE; newer
+                # Claude models (Opus 4.7+) reject temperature outright.
+                # All Gemini and MiniMax models support it.
                 if provider_info["id"] == ModelProvider.OPENAI.value:
                     supports_temp = model["id"] not in OpenAIService.MODELS_WITHOUT_TEMPERATURE
                     supports_verbosity = model["id"] in OpenAIService.MODELS_WITH_VERBOSITY
-                elif provider_info["id"] == ModelProvider.GOOGLE.value:
-                    supports_temp = True  # All Gemini models support temperature
+                elif provider_info["id"] == ModelProvider.ANTHROPIC.value:
+                    supports_temp = anthropic_supports_temperature(model["id"])
                     supports_verbosity = False
                 else:
                     supports_temp = True

--- a/backend/tests/test_anthropic_service.py
+++ b/backend/tests/test_anthropic_service.py
@@ -4,7 +4,19 @@ Unit tests for AnthropicService.
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from app.services.anthropic_service import AnthropicService
+from app.services.anthropic_service import AnthropicService, supports_temperature
+
+
+def _empty_async_iterator():
+    """An async-iterable stream that yields no events."""
+    class _Empty:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    return _Empty()
 
 
 @pytest.fixture
@@ -164,6 +176,87 @@ class TestAnthropicService:
         assert call_kwargs["model"] == "claude-opus-4-20250514"
         assert call_kwargs["temperature"] == 0.5
         assert call_kwargs["max_tokens"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_send_message_omits_temperature_for_opus_5(self, mock_anthropic_client):
+        """Claude Opus 5 rejects sampling params, so temperature must not be sent."""
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        await service.send_message(messages, model="claude-opus-5", temperature=0.5)
+
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-opus-5"
+        assert "temperature" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_omits_temperature_for_opus_5(self):
+        """The streaming path applies the same temperature rule as send_message."""
+        service = AnthropicService()
+
+        stream_ctx = MagicMock()
+        stream_ctx.__aenter__ = AsyncMock(return_value=_empty_async_iterator())
+        stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        client = MagicMock()
+        client.messages.stream = MagicMock(return_value=stream_ctx)
+        service.client = client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        async for _ in service.send_message_stream(
+            messages, model="claude-opus-5", temperature=0.5
+        ):
+            pass
+
+        call_kwargs = client.messages.stream.call_args.kwargs
+        assert call_kwargs["model"] == "claude-opus-5"
+        assert "temperature" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_keeps_temperature_for_older_models(self):
+        """Older Claude models still accept temperature."""
+        service = AnthropicService()
+
+        stream_ctx = MagicMock()
+        stream_ctx.__aenter__ = AsyncMock(return_value=_empty_async_iterator())
+        stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        client = MagicMock()
+        client.messages.stream = MagicMock(return_value=stream_ctx)
+        service.client = client
+
+        messages = [{"role": "user", "content": "Hello!"}]
+        async for _ in service.send_message_stream(
+            messages, model="claude-sonnet-4-5-20250929", temperature=0.5
+        ):
+            pass
+
+        call_kwargs = client.messages.stream.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.5
+
+
+class TestSupportsTemperature:
+    """Tests for the temperature capability check."""
+
+    def test_models_that_reject_temperature(self):
+        for model in [
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-mythos-5",
+        ]:
+            assert supports_temperature(model) is False
+
+    def test_models_that_accept_temperature(self):
+        for model in [
+            "claude-sonnet-4-5-20250929",
+            "claude-opus-4-5-20251101",
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-6",
+            "MiniMax-M2.5",
+        ]:
+            assert supports_temperature(model) is True
 
     def test_build_messages_with_context(self, mock_encoder):
         """Test building messages with conversation context."""

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -20,10 +20,16 @@ class TestModelProviderMapping:
             "claude-opus-4-20250514",
             "claude-opus-4-8",
             "claude-fable-5",
+            "claude-opus-5",
         ]
 
         for model in claude_models:
             assert MODEL_PROVIDER_MAP.get(model) == ModelProvider.ANTHROPIC
+
+    def test_claude_opus_5_is_listed_as_available(self):
+        """Claude Opus 5 should be selectable in the Anthropic model list."""
+        anthropic_ids = [m["id"] for m in AVAILABLE_MODELS[ModelProvider.ANTHROPIC]]
+        assert "claude-opus-5" in anthropic_ids
 
     def test_minimax_models_map_to_minimax(self):
         """Test that MiniMax models map to MiniMax provider."""
@@ -156,6 +162,25 @@ class TestLLMService:
                 assert "name" in model
                 assert "provider" in model
                 assert "provider_name" in model
+
+    def test_get_all_available_models_temperature_support(self):
+        """Newer Claude models are reported as not supporting temperature."""
+        service = LLMService()
+
+        with patch("app.services.llm_service.settings") as mock_settings, \
+             patch("app.services.llm_service.openai_service") as mock_openai, \
+             patch("app.services.llm_service.google_service") as mock_google:
+            mock_settings.anthropic_api_key = "test-key"
+            mock_settings.default_model = "claude-sonnet-4-5-20250929"
+            mock_settings.minimax_api_key = ""
+            mock_openai.is_configured.return_value = False
+            mock_google.is_configured.return_value = False
+
+            models = {m["id"]: m for m in service.get_all_available_models()}
+
+            assert models["claude-opus-5"]["temperature_supported"] is False
+            assert models["claude-fable-5"]["temperature_supported"] is False
+            assert models["claude-sonnet-4-5-20250929"]["temperature_supported"] is True
 
     def test_count_tokens(self):
         """Test count_tokens delegates to anthropic_service."""

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -142,6 +142,7 @@
                     <label for="model-select">Model</label>
                     <select id="model-select">
                         <option value="claude-fable-5">Claude Fable 5</option>
+                        <option value="claude-opus-5">Claude Opus 5</option>
                         <option value="claude-opus-4-8">Claude Opus 4.8</option>
                         <option value="claude-opus-4-7">Claude Opus 4.7</option>
                         <option value="claude-opus-4-6">Claude Opus 4.6</option>


### PR DESCRIPTION
## Summary

Claude Opus 5 and other newer Claude models (Opus 4.7+, Sonnet 5, Fable 5, Mythos 5) reject the `temperature` parameter with a 400 error. This PR adds support for Claude Opus 5 while conditionally omitting temperature for models that don't accept it.

## Key Changes

- **anthropic_service.py:**
  - Added `MODELS_WITHOUT_TEMPERATURE` set listing models that reject sampling parameters (Opus 4.7+, Sonnet 5, Fable 5, Mythos 5)
  - Added `supports_temperature(model: str)` helper function to check if a model accepts temperature
  - Modified `send_message()` and `send_message_stream()` to conditionally include temperature only for models that support it

- **llm_service.py:**
  - Added `claude-opus-5` to `MODEL_PROVIDER_MAP` and `AVAILABLE_MODELS`
  - Updated `get_all_available_models()` to use `anthropic_supports_temperature()` for Anthropic models instead of assuming all support temperature
  - Updated comments to clarify that newer Claude models reject temperature

- **config.py:**
  - Added `claude-opus-5` to the documented list of available Anthropic models

- **frontend/index.html:**
  - Added `claude-opus-5` option to the model selector dropdown

- **test_anthropic_service.py:**
  - Added `_empty_async_iterator()` helper for mocking streaming responses
  - Added `test_send_message_omits_temperature_for_opus_5()` to verify temperature is excluded for Opus 5
  - Added `test_send_message_stream_omits_temperature_for_opus_5()` to verify streaming path respects the same rule
  - Added `test_send_message_stream_keeps_temperature_for_older_models()` to verify older models still receive temperature
  - Added `TestSupportsTemperature` class with comprehensive tests for the temperature capability check

- **test_llm_service.py:**
  - Added `test_claude_opus_5_is_listed_as_available()` to verify Opus 5 is selectable
  - Added `test_get_all_available_models_temperature_support()` to verify temperature support is correctly reported in the model list

## Implementation Details

The solution uses a blocklist approach (`MODELS_WITHOUT_TEMPERATURE`) rather than an allowlist, making it forward-compatible with future Claude models that may accept temperature. The temperature parameter is conditionally added to the API request dictionary only when `supports_temperature()` returns `True`, ensuring both the synchronous and streaming code paths handle the restriction consistently.

https://claude.ai/code/session_01Wu4vaRnPW5cEVX5dvWwmRx