### PR TITLE
Add thinking effort control across all LLM providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,14 @@ reflection_multiplier = reflection_significance_multiplier (=1.5) if role == "re
 - **Context awareness:** `context_status` tool reports approximate context fullness; when trimming occurs a `[CONTEXT NOTICE]` message is injected into context (not persisted to DB).
 - **Human message timestamps:** human messages get a `[YYYY-MM-DD HH:MM <TZ>]` prefix in the server's local timezone (OS/`TZ` env var — no config knob) when rendered into LLM context (`session_helpers.stamp_human_message`) for finer-grained time awareness. Context-only — DB content and vectorized memories stay unstamped (naive UTC in the DB, converted at render time). **Stability contract:** the chat routes capture one timestamp per send and use it both for stamping and as the persisted row's `created_at`, so a session reload (conversation switch, message edit) re-renders the identical prefix and prompt caching survives. The stamp is a *prefix* so regenerate's `endswith` content matching keeps working.
 
+## Thinking effort
+
+One canonical scale — `low`, `medium`, `high`, `xhigh`, `max` (`services/thinking_effort.py`) — translated per provider at the call site: Anthropic `output_config.effort` (sent via `extra_body`, since `output_config` postdates the pinned SDK floor), OpenAI `reasoning_effort` (`xhigh`/`max` collapse onto `high`), Google `thinking_config` (Gemini 3 `thinking_level`, Gemini 2.5 `thinking_budget`, feature-probed on `types.ThinkingConfig.model_fields` because the pinned google-genai floor predates both). Models with no effort control get nothing sent; MiniMax is excluded like adaptive thinking.
+
+- **Per entity, not per conversation:** stored in `EntitySetting.thinking_effort` (NULL = follow `DEFAULT_THINKING_EFFORT`). `SessionManager.refresh_thinking_effort` re-reads it at the start of every turn, so a UI change lands on the next turn and each responder in a multi-entity conversation brings its own level.
+- **Clamped, never dropped:** levels above a model's ceiling step down (`anthropic_service.EFFORT_MODEL_LADDERS` — `xhigh` arrived with Opus 4.7, Opus 4.5 tops out at `high`). Sending a level a model doesn't know is a 400.
+- **Adding a model:** if it takes effort, add its prefix to the right ladder (Anthropic) or set (`OpenAIService.MODELS_WITH_REASONING_EFFORT`, `GoogleService.THINKING_MODEL_PREFIXES`). `llm_service.get_all_available_models()` derives the `thinking_effort_supported` flag the settings UI uses to show/hide the control.
+
 ## Multi-entity rules
 
 When touching the chat flow:
@@ -136,6 +144,7 @@ Everything lives in `backend/app/config.py` (`Settings`). Highlights:
 - Default-off flags: `GITHUB_TOOLS_ENABLED`, `CODEBASE_NAVIGATOR_ENABLED`, `MOLTBOOK_ENABLED`, `XTTS_ENABLED`, `STYLETTS2_ENABLED`, `WHISPER_ENABLED`.
 - TTS priority when multiple are enabled: StyleTTS 2 > XTTS > ElevenLabs.
 - Token budget: `context_token_limit=175000` (conversation history; retrieved memories are part of the history).
+- `DEFAULT_THINKING_EFFORT` (default `high`) — reasoning depth for models that expose one, used when an entity has no override. See "Thinking effort" below.
 - Default models: `claude-sonnet-4-5-20250929`, `gpt-5.1`, `gemini-2.5-flash`, `MiniMax-M2.5`. Model names are passed straight to provider APIs, so new models work without code changes.
 
 ## Adding things

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -262,6 +262,13 @@ class Settings(BaseSettings):
     # identical either way. Turn off to hide reasoning from the chat UI.
     thinking_summaries_enabled: bool = True
 
+    # How hard models that expose a thinking/reasoning effort control should
+    # think (low, medium, high, xhigh, max — see services/thinking_effort.py).
+    # This is the fallback: each entity can override it, and the per-entity
+    # value lives in the entity_settings table. Levels above a model's ceiling
+    # are clamped, and models with no effort parameter ignore it entirely.
+    default_thinking_effort: str = "high"
+
     # Tool Use settings
     # Enable tool use (web search, content fetching) for AI entities
     tools_enabled: bool = True

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -130,8 +130,32 @@ async def _migrate_messages_role_enum(conn):
         print("  ✓ Updated messages table to support tool_use and tool_result roles")
 
 
+async def _migrate_entity_settings(conn):
+    """Add per-entity settings columns that postdate the table's creation."""
+    result = await conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='entity_settings'"
+    ))
+    if not result.fetchone():
+        # Table doesn't exist yet, will be created by create_all
+        return
+
+    result = await conn.execute(text("PRAGMA table_info(entity_settings)"))
+    columns = [row[1] for row in result.fetchall()]
+
+    if 'thinking_effort' not in columns:
+        print("Migrating: Adding 'thinking_effort' column to entity_settings table...")
+        await conn.execute(text(
+            "ALTER TABLE entity_settings ADD COLUMN thinking_effort VARCHAR(20)"
+        ))
+        print("  ✓ Added thinking_effort column for per-entity thinking effort")
+
+
 async def run_migrations(conn):
     """Run schema migrations for new columns that SQLAlchemy create_all doesn't handle."""
+    # Entity settings migrate independently of the messages table below, which
+    # returns early on a fresh database.
+    await _migrate_entity_settings(conn)
+
     # Check if messages table exists before trying to migrate
     result = await conn.execute(text(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='messages'"

--- a/backend/app/models/entity_setting.py
+++ b/backend/app/models/entity_setting.py
@@ -11,8 +11,8 @@ class EntitySetting(Base):
 
     Entities themselves are defined in config (PINECONE_INDEXES), which is
     immutable at runtime. This table holds the mutable per-entity preferences
-    the researcher sets in the UI — currently the entity's default system
-    prompt — keyed by the entity's Pinecone index name.
+    the researcher sets in the UI — the entity's default system prompt and its
+    thinking effort — keyed by the entity's Pinecone index name.
     """
     __tablename__ = "entity_settings"
 
@@ -20,6 +20,9 @@ class EntitySetting(Base):
     entity_id: Mapped[str] = mapped_column(String(100), primary_key=True)
     # Default system prompt for this entity. NULL means "no system prompt".
     system_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Thinking effort for this entity (low, medium, high, xhigh, max).
+    # NULL means "follow settings.default_thinking_effort".
+    thinking_effort: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True

--- a/backend/app/routes/entities.py
+++ b/backend/app/routes/entities.py
@@ -8,6 +8,7 @@ from app.config import settings
 from app.database import get_db
 from app.models import EntitySetting
 from app.services import memory_service
+from app.services.thinking_effort import EFFORT_LEVELS, normalize_effort, resolve_effort
 
 router = APIRouter(prefix="/api/entities", tags=["entities"])
 
@@ -21,11 +22,18 @@ class EntityResponse(BaseModel):
     is_default: bool = False
     # Persisted per-entity default system prompt (None means no prompt).
     system_prompt: Optional[str] = None
+    # Persisted per-entity thinking effort (None means "use the global default").
+    thinking_effort: Optional[str] = None
 
 
 class EntityListResponse(BaseModel):
     entities: List[EntityResponse]
     default_entity: Optional[str] = None
+    # The effort an entity gets when it has none of its own, so the UI can
+    # label the "Default" option with the level it actually resolves to.
+    default_thinking_effort: str = "high"
+    # The levels the UI may offer, in ascending order.
+    thinking_effort_levels: List[str] = list(EFFORT_LEVELS)
 
 
 class SystemPromptUpdate(BaseModel):
@@ -38,10 +46,22 @@ class SystemPromptResponse(BaseModel):
     system_prompt: Optional[str] = None
 
 
-async def _load_system_prompts(db: AsyncSession) -> Dict[str, Optional[str]]:
-    """Load all persisted per-entity system prompts, keyed by entity_id."""
+class ThinkingEffortUpdate(BaseModel):
+    # None / empty clears the override, falling back to the global default.
+    thinking_effort: Optional[str] = None
+
+
+class ThinkingEffortResponse(BaseModel):
+    entity_id: str
+    thinking_effort: Optional[str] = None
+    # The level that will actually be sent (the override, or the global default)
+    effective_thinking_effort: str
+
+
+async def _load_entity_settings(db: AsyncSession) -> Dict[str, EntitySetting]:
+    """Load all persisted per-entity settings rows, keyed by entity_id."""
     result = await db.execute(select(EntitySetting))
-    return {row.entity_id: row.system_prompt for row in result.scalars().all()}
+    return {row.entity_id: row for row in result.scalars().all()}
 
 
 @router.get("/", response_model=EntityListResponse)
@@ -51,8 +71,8 @@ async def list_entities(db: AsyncSession = Depends(get_db)):
 
     Each entity corresponds to a separate Pinecone index with its own
     conversation history and memory, and can have its own model provider/model.
-    Each entity also carries its persisted default system prompt so the UI can
-    render it without keeping any client-side copy.
+    Each entity also carries its persisted default system prompt and thinking
+    effort so the UI can render them without keeping any client-side copy.
     """
     entities = settings.get_entities()
     default_entity = settings.get_default_entity()
@@ -62,9 +82,10 @@ async def list_entities(db: AsyncSession = Depends(get_db)):
         return EntityListResponse(
             entities=[],
             default_entity=None,
+            default_thinking_effort=resolve_effort(None),
         )
 
-    system_prompts = await _load_system_prompts(db)
+    entity_settings = await _load_entity_settings(db)
 
     return EntityListResponse(
         entities=[
@@ -75,11 +96,15 @@ async def list_entities(db: AsyncSession = Depends(get_db)):
                 llm_provider=entity.llm_provider,
                 default_model=entity.default_model,
                 is_default=(entity.index_name == default_entity.index_name),
-                system_prompt=system_prompts.get(entity.index_name),
+                system_prompt=getattr(entity_settings.get(entity.index_name), "system_prompt", None),
+                thinking_effort=getattr(entity_settings.get(entity.index_name), "thinking_effort", None),
             )
             for entity in entities
         ],
         default_entity=default_entity.index_name,
+        # Resolved rather than read raw, so the UI is told the level that will
+        # actually be sent even if THINKING_EFFORT is set to something unknown.
+        default_thinking_effort=resolve_effort(None),
     )
 
 
@@ -102,6 +127,7 @@ async def get_entity(entity_id: str, db: AsyncSession = Depends(get_db)):
         default_model=entity.default_model,
         is_default=(entity.index_name == default_entity.index_name),
         system_prompt=setting.system_prompt if setting else None,
+        thinking_effort=setting.thinking_effort if setting else None,
     )
 
 
@@ -136,6 +162,49 @@ async def update_entity_system_prompt(
     await db.commit()
 
     return SystemPromptResponse(entity_id=entity_id, system_prompt=prompt)
+
+
+@router.put("/{entity_id}/thinking-effort", response_model=ThinkingEffortResponse)
+async def update_entity_thinking_effort(
+    entity_id: str,
+    payload: ThinkingEffortUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Set (or clear) how hard this entity's model should think.
+
+    Levels are low, medium, high, xhigh, max. Clearing the value (null/empty)
+    falls the entity back to DEFAULT_THINKING_EFFORT ("high"). Levels above a
+    model's ceiling are clamped at request time, and models with no thinking
+    control ignore the setting — so any level is accepted for any entity.
+    """
+    if not settings.get_entity_by_index(entity_id):
+        raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
+
+    raw = payload.thinking_effort
+    effort = normalize_effort(raw)
+    # Distinguish "clear it" from "that isn't a level": an unrecognized value
+    # is a client bug worth surfacing, not a silent fallback to the default.
+    if effort is None and isinstance(raw, str) and raw.strip():
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid thinking effort '{raw}'. Expected one of: {', '.join(EFFORT_LEVELS)}",
+        )
+
+    setting = await db.get(EntitySetting, entity_id)
+    if setting is None:
+        setting = EntitySetting(entity_id=entity_id, thinking_effort=effort)
+        db.add(setting)
+    else:
+        setting.thinking_effort = effort
+
+    await db.commit()
+
+    return ThinkingEffortResponse(
+        entity_id=entity_id,
+        thinking_effort=effort,
+        effective_thinking_effort=resolve_effort(effort),
+    )
 
 
 @router.get("/{entity_id}/status")

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -1,8 +1,9 @@
-from typing import Optional, List, Dict, Any, AsyncIterator, Union
+from typing import Optional, List, Dict, Any, AsyncIterator, Tuple, Union
 from datetime import datetime
 from anthropic import AsyncAnthropic, APIConnectionError
 from app.config import settings
 from app.services.notes_service import notes_service
+from app.services.thinking_effort import clamp_effort, resolve_effort
 import asyncio
 import httpx
 import tiktoken
@@ -64,6 +65,84 @@ ADAPTIVE_THINKING_MODEL_PREFIXES = (
 def supports_adaptive_thinking(model: str) -> bool:
     """Whether the model accepts the adaptive thinking parameter."""
     return model.startswith(ADAPTIVE_THINKING_MODEL_PREFIXES)
+
+
+# Effort ladders by model, highest-precedence prefix first. `output_config.
+# effort` is GA (no beta header) but the accepted levels differ by model:
+# `xhigh` arrived with Opus 4.7, `max` with the 4.6 generation, and Opus 4.5
+# only ever took low/medium/high. Sonnet 4.5, Haiku 4.5 and anything older
+# reject the parameter outright, so they are absent here and get nothing sent.
+# Matched as prefixes because configured model names may carry a date suffix.
+EFFORT_MODEL_LADDERS = (
+    (
+        ("claude-opus-5", "claude-opus-4-8", "claude-opus-4-7",
+         "claude-sonnet-5", "claude-fable-5", "claude-mythos-5"),
+        ("low", "medium", "high", "xhigh", "max"),
+    ),
+    (
+        ("claude-opus-4-6", "claude-sonnet-4-6"),
+        ("low", "medium", "high", "max"),
+    ),
+    (
+        ("claude-opus-4-5",),
+        ("low", "medium", "high"),
+    ),
+)
+
+
+def supported_effort_levels(model: str) -> Tuple[str, ...]:
+    """The effort levels a model accepts, or () if it takes no effort param."""
+    for prefixes, levels in EFFORT_MODEL_LADDERS:
+        if model.startswith(prefixes):
+            return levels
+    return ()
+
+
+def supports_thinking_effort(model: str) -> bool:
+    """Whether the model accepts `output_config.effort`."""
+    return bool(supported_effort_levels(model))
+
+
+def resolve_effort_for_model(model: str, thinking_effort: Optional[str]) -> Optional[str]:
+    """
+    The effort level to send for this model, or None to send nothing.
+
+    Requests above the model's ceiling are clamped down rather than dropped,
+    so an entity set to `max` still thinks as hard as its model allows.
+    """
+    levels = supported_effort_levels(model)
+    if not levels:
+        return None
+    return clamp_effort(resolve_effort(thinking_effort), levels)
+
+
+def _apply_thinking_effort(
+    api_params: Dict[str, Any],
+    model: str,
+    thinking_effort: Optional[str],
+    provider: Optional[str],
+) -> None:
+    """
+    Add `output_config.effort` to the request when the model accepts it.
+
+    Sent through `extra_body` rather than a named argument: `output_config` is
+    newer than the SDK floor this project pins (anthropic>=0.40.0), and an
+    older client would reject the keyword before the request left the process.
+    `extra_body` is merged into the request body by every SDK version, so this
+    works on old and new clients alike.
+
+    MiniMax speaks the Anthropic wire format but does not accept this
+    parameter, so it is excluded — same carve-out as adaptive thinking.
+    """
+    if provider == "minimax":
+        return
+    effort = resolve_effort_for_model(model, thinking_effort)
+    if not effort:
+        return
+    extra_body = api_params.setdefault("extra_body", {})
+    output_config = extra_body.setdefault("output_config", {})
+    output_config["effort"] = effort
+    logger.info(f"[THINKING] Effort '{effort}' for model {model}")
 
 
 def _get_content_text(content: Union[str, List[Dict[str, Any]]]) -> str:
@@ -193,6 +272,7 @@ class AnthropicService:
         enable_caching: bool = True,
         tools: Optional[List[Dict[str, Any]]] = None,
         provider: Optional[str] = None,
+        thinking_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Send a message to an Anthropic-compatible API with optional prompt caching and tool use.
@@ -206,6 +286,7 @@ class AnthropicService:
             enable_caching: Whether to enable Anthropic prompt caching (default True)
             tools: Optional list of tool definitions in Anthropic format
             provider: Optional provider hint ("anthropic" or "minimax") to select client
+            thinking_effort: Optional thinking effort level (None uses the configured default)
 
         Returns:
             Dict with:
@@ -229,6 +310,8 @@ class AnthropicService:
         # Newer Claude models reject temperature entirely (400)
         if supports_temperature(model):
             api_params["temperature"] = temperature
+
+        _apply_thinking_effort(api_params, model, thinking_effort, provider)
 
         # Add system prompt with caching if provided
         if system_prompt:
@@ -549,6 +632,7 @@ class AnthropicService:
         enable_caching: bool = True,
         tools: Optional[List[Dict[str, Any]]] = None,
         provider: Optional[str] = None,
+        thinking_effort: Optional[str] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """
         Send a message to an Anthropic-compatible API with streaming response and optional prompt caching.
@@ -601,6 +685,11 @@ class AnthropicService:
             and supports_adaptive_thinking(model)
         ):
             api_params["thinking"] = {"type": "adaptive", "display": "summarized"}
+
+        # Reasoning depth. Independent of the display setting above: effort
+        # controls how much the model thinks, display only whether that
+        # thinking comes back readable.
+        _apply_thinking_effort(api_params, model, thinking_effort, provider)
 
         # Add system prompt with caching if provided
         if system_prompt:

--- a/backend/app/services/conversation_session.py
+++ b/backend/app/services/conversation_session.py
@@ -64,6 +64,11 @@ class ConversationSession:
     conversation_start_date: Optional[datetime] = None  # When the conversation was created
     verbosity: Optional[str] = None  # Verbosity level for gpt-5.1 models (low, medium, high)
     provider_hint: Optional[str] = None  # LLM provider from entity config (e.g., "minimax")
+    # Thinking effort for the responding entity (low..max). None = use the
+    # configured default. Refreshed from the entity's persisted setting at the
+    # start of every turn, so a change in the UI takes effect on the next turn
+    # without reloading the session.
+    thinking_effort: Optional[str] = None
 
     # Multi-entity conversation support
     is_multi_entity: bool = False  # True if this is a multi-entity conversation

--- a/backend/app/services/google_service.py
+++ b/backend/app/services/google_service.py
@@ -3,6 +3,7 @@ from google import genai
 from google.genai import types
 from app.config import settings
 from app.services.session_helpers import get_message_content_text
+from app.services.thinking_effort import resolve_effort
 import tiktoken
 import logging
 
@@ -26,6 +27,30 @@ class GoogleService:
 
     # Models that support temperature parameter (all current models do)
     MODELS_WITH_TEMPERATURE = SUPPORTED_MODELS
+
+    # Model families that think. Matched as prefixes so new point releases in
+    # these families are covered without a code change.
+    THINKING_MODEL_PREFIXES = ("gemini-3", "gemini-2.5")
+
+    # Gemini 3 exposes thinking depth as a two-value level.
+    THINKING_LEVEL_MAP = {
+        "low": "low",
+        "medium": "low",
+        "high": "high",
+        "xhigh": "high",
+        "max": "high",
+    }
+
+    # Gemini 2.5 exposes it as a token budget instead. These sit inside the
+    # budget range every 2.5 model accepts (the tightest ceiling is Flash's
+    # 24576), so one table covers Flash and Pro alike.
+    THINKING_BUDGET_MAP = {
+        "low": 2048,
+        "medium": 8192,
+        "high": 16384,
+        "xhigh": 20480,
+        "max": 24576,
+    }
 
     def __init__(self):
         self._client = None
@@ -59,6 +84,65 @@ class GoogleService:
         """Check if model supports the temperature parameter."""
         # All Gemini models support temperature
         return True
+
+    def supports_thinking(self, model: str) -> bool:
+        """
+        Whether the model thinks and takes a thinking configuration.
+
+        Gemini 2.5 and 3 do; the 2.0 generation does not.
+        """
+        return model.startswith(self.THINKING_MODEL_PREFIXES)
+
+    def _build_thinking_config(
+        self,
+        model: str,
+        thinking_effort: Optional[str],
+    ) -> Optional["types.ThinkingConfig"]:
+        """
+        Translate a canonical effort level into a Gemini thinking config.
+
+        Google has moved this control twice, and the project's floor
+        (google-genai>=1.0.0) predates both spellings, so the field set is
+        probed at runtime rather than assumed: `thinking_level` (Gemini 3) is
+        preferred, `thinking_budget` (Gemini 2.5) is the fallback, and an SDK
+        with neither gets no thinking config at all — the model still thinks,
+        just at its own default depth.
+        """
+        if not self.supports_thinking(model):
+            return None
+
+        fields = getattr(types.ThinkingConfig, "model_fields", {})
+        effort = resolve_effort(thinking_effort)
+
+        if "thinking_level" in fields:
+            return types.ThinkingConfig(thinking_level=self.THINKING_LEVEL_MAP[effort])
+        if "thinking_budget" in fields:
+            return types.ThinkingConfig(thinking_budget=self.THINKING_BUDGET_MAP[effort])
+
+        logger.info(
+            "[THINKING] Installed google-genai exposes no thinking level/budget field; "
+            "using the model's default thinking depth"
+        )
+        return None
+
+    def _apply_thinking_config(
+        self,
+        config: "types.GenerateContentConfig",
+        model: str,
+        thinking_effort: Optional[str],
+    ) -> None:
+        """Attach a thinking config to the request when one applies."""
+        try:
+            thinking_config = self._build_thinking_config(model, thinking_effort)
+        except Exception as e:
+            # A field the installed SDK exposes but the API rejects should cost
+            # a log line, not the turn.
+            logger.warning(f"[THINKING] Could not build Gemini thinking config: {e}")
+            return
+
+        if thinking_config is not None:
+            config.thinking_config = thinking_config
+            logger.info(f"[THINKING] Gemini thinking config {thinking_config} for model {model}")
 
     def _convert_messages_to_contents(
         self,
@@ -100,6 +184,7 @@ class GoogleService:
         model: Optional[str] = None,
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
+        thinking_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Send a message to Google AI (Gemini) API.
@@ -110,6 +195,7 @@ class GoogleService:
             model: Model to use (defaults to gemini-2.5-flash)
             temperature: Temperature setting (defaults to 1.0)
             max_tokens: Max tokens in response (defaults to 4096)
+            thinking_effort: Optional thinking effort level (None uses the configured default)
 
         Returns:
             Dict with 'content', 'model', 'usage' keys
@@ -132,6 +218,8 @@ class GoogleService:
         # Add system instruction if provided
         if system_prompt:
             config.system_instruction = system_prompt
+
+        self._apply_thinking_config(config, model_name, thinking_effort)
 
         logger.info(f"[GOOGLE] Sending {len(contents)} messages to API with model={model_name}")
 
@@ -192,6 +280,7 @@ class GoogleService:
         model: Optional[str] = None,
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
+        thinking_effort: Optional[str] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """
         Send a message to Google AI (Gemini) API with streaming response.
@@ -220,6 +309,8 @@ class GoogleService:
         # Add system instruction if provided
         if system_prompt:
             config.system_instruction = system_prompt
+
+        self._apply_thinking_config(config, model_name, thinking_effort)
 
         logger.info(f"[GOOGLE] Streaming {len(contents)} messages to API with model={model_name}")
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -11,7 +11,10 @@ from datetime import datetime
 from enum import Enum
 
 from app.services import anthropic_service, openai_service
-from app.services.anthropic_service import supports_temperature as anthropic_supports_temperature
+from app.services.anthropic_service import (
+    supports_temperature as anthropic_supports_temperature,
+    supports_thinking_effort as anthropic_supports_thinking_effort,
+)
 from app.services.openai_service import OpenAIService
 from app.services.google_service import google_service, GoogleService
 from app.config import settings
@@ -195,12 +198,20 @@ class LLMService:
                 if provider_info["id"] == ModelProvider.OPENAI.value:
                     supports_temp = model["id"] not in OpenAIService.MODELS_WITHOUT_TEMPERATURE
                     supports_verbosity = model["id"] in OpenAIService.MODELS_WITH_VERBOSITY
+                    supports_effort = model["id"] in OpenAIService.MODELS_WITH_REASONING_EFFORT
                 elif provider_info["id"] == ModelProvider.ANTHROPIC.value:
                     supports_temp = anthropic_supports_temperature(model["id"])
                     supports_verbosity = False
-                else:
+                    supports_effort = anthropic_supports_thinking_effort(model["id"])
+                elif provider_info["id"] == ModelProvider.GOOGLE.value:
                     supports_temp = True
                     supports_verbosity = False
+                    supports_effort = google_service.supports_thinking(model["id"])
+                else:
+                    # MiniMax: Anthropic-compatible wire format, but no effort parameter
+                    supports_temp = True
+                    supports_verbosity = False
+                    supports_effort = False
 
                 models.append({
                     **model,
@@ -208,6 +219,7 @@ class LLMService:
                     "provider_name": provider_info["name"],
                     "temperature_supported": supports_temp,
                     "verbosity_supported": supports_verbosity,
+                    "thinking_effort_supported": supports_effort,
                 })
         return models
 
@@ -227,6 +239,7 @@ class LLMService:
         verbosity: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         provider_hint: Optional[str] = None,
+        thinking_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Send a message to the appropriate LLM provider based on model.
@@ -242,6 +255,9 @@ class LLMService:
             tools: Optional list of tool definitions (Anthropic format, converted for OpenAI)
             provider_hint: Optional provider string from entity config, used when model
                 isn't in MODEL_PROVIDER_MAP
+            thinking_effort: Thinking/reasoning depth (low, medium, high, xhigh, max).
+                Translated per provider and ignored by models with no such control;
+                None uses settings.default_thinking_effort.
 
         Returns:
             Dict with 'content', 'model', 'usage', 'stop_reason' keys.
@@ -285,6 +301,7 @@ class LLMService:
                 max_tokens=max_tokens,
                 enable_caching=enable_caching,
                 tools=tools,
+                thinking_effort=thinking_effort,
             )
         elif provider == ModelProvider.MINIMAX:
             # MiniMax uses Anthropic-compatible API, route through anthropic_service
@@ -298,6 +315,7 @@ class LLMService:
                 enable_caching=False,
                 tools=tools,
                 provider="minimax",
+                thinking_effort=thinking_effort,
             )
         elif provider == ModelProvider.OPENAI:
             return await openai_service.send_message(
@@ -308,6 +326,7 @@ class LLMService:
                 max_tokens=max_tokens,
                 verbosity=verbosity,
                 tools=tools,
+                thinking_effort=thinking_effort,
             )
         elif provider == ModelProvider.GOOGLE:
             # Tool use not currently supported for Google in this implementation
@@ -317,6 +336,7 @@ class LLMService:
                 model=model,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                thinking_effort=thinking_effort,
             )
         else:
             raise ValueError(f"Unsupported provider: {provider}")
@@ -332,6 +352,7 @@ class LLMService:
         verbosity: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         provider_hint: Optional[str] = None,
+        thinking_effort: Optional[str] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """
         Send a message to the appropriate LLM provider with streaming response.
@@ -382,6 +403,7 @@ class LLMService:
                 max_tokens=max_tokens,
                 enable_caching=enable_caching,
                 tools=tools,
+                thinking_effort=thinking_effort,
             ):
                 yield event
         elif provider == ModelProvider.MINIMAX:
@@ -396,6 +418,7 @@ class LLMService:
                 enable_caching=False,
                 tools=tools,
                 provider="minimax",
+                thinking_effort=thinking_effort,
             ):
                 yield event
         elif provider == ModelProvider.OPENAI:
@@ -407,6 +430,7 @@ class LLMService:
                 max_tokens=max_tokens,
                 verbosity=verbosity,
                 tools=tools,
+                thinking_effort=thinking_effort,
             ):
                 yield event
         elif provider == ModelProvider.GOOGLE:
@@ -417,6 +441,7 @@ class LLMService:
                 model=model,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                thinking_effort=thinking_effort,
             ):
                 yield event
         else:

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -1,6 +1,7 @@
 from typing import Optional, List, Dict, Any, AsyncIterator
 from openai import AsyncOpenAI
 from app.config import settings
+from app.services.thinking_effort import resolve_effort
 import tiktoken
 import logging
 import json
@@ -40,6 +41,26 @@ class OpenAIService:
         "gpt-5.2",
     }
 
+    # Reasoning models that accept `reasoning_effort`. The o1 preview/mini
+    # variants and the non-reasoning chat models reject it, so they are absent.
+    MODELS_WITH_REASONING_EFFORT = {
+        "o1",
+        "o3", "o3-mini",
+        "o4-mini",
+        "gpt-5.1", "gpt-5-mini",
+        "gpt-5.2",
+    }
+
+    # OpenAI's ladder is shorter than the canonical one — the two levels above
+    # "high" have no counterpart, so they collapse onto it.
+    REASONING_EFFORT_MAP = {
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "high",
+        "max": "high",
+    }
+
     def __init__(self):
         self.client = None
         self._encoder = None
@@ -59,6 +80,20 @@ class OpenAIService:
     def _supports_verbosity(self, model: str) -> bool:
         """Check if model supports the verbosity parameter."""
         return model in self.MODELS_WITH_VERBOSITY
+
+    def _supports_reasoning_effort(self, model: str) -> bool:
+        """Check if model supports the reasoning_effort parameter."""
+        return model in self.MODELS_WITH_REASONING_EFFORT
+
+    def _reasoning_effort_for(self, model: str, thinking_effort: Optional[str]) -> Optional[str]:
+        """
+        Translate a canonical thinking-effort level to OpenAI's reasoning_effort.
+
+        Returns None for models that don't take the parameter.
+        """
+        if not self._supports_reasoning_effort(model):
+            return None
+        return self.REASONING_EFFORT_MAP[resolve_effort(thinking_effort)]
 
     def _convert_tools_to_openai_format(
         self,
@@ -130,6 +165,7 @@ class OpenAIService:
         max_tokens: Optional[int] = None,
         verbosity: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
+        thinking_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Send a message to OpenAI API.
@@ -142,6 +178,7 @@ class OpenAIService:
             max_tokens: Max tokens in response (defaults to 4096)
             verbosity: Verbosity level for gpt-5.1 models (low, medium, high)
             tools: Optional list of tool definitions (Anthropic format, will be converted)
+            thinking_effort: Optional thinking effort level (None uses the configured default)
 
         Returns:
             Dict with 'content', 'model', 'usage', 'stop_reason' keys.
@@ -229,6 +266,12 @@ class OpenAIService:
         if self._supports_verbosity(model):
             api_params["verbosity"] = verbosity or settings.default_verbosity
 
+        # Reasoning depth, for models that expose it
+        reasoning_effort = self._reasoning_effort_for(model, thinking_effort)
+        if reasoning_effort:
+            api_params["reasoning_effort"] = reasoning_effort
+            logger.info(f"[THINKING] OpenAI reasoning_effort '{reasoning_effort}' for model {model}")
+
         # Add tools if provided
         if tools:
             api_params["tools"] = self._convert_tools_to_openai_format(tools)
@@ -312,6 +355,7 @@ class OpenAIService:
         max_tokens: Optional[int] = None,
         verbosity: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
+        thinking_effort: Optional[str] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """
         Send a message to OpenAI API with streaming response.
@@ -419,6 +463,12 @@ class OpenAIService:
             # Only include verbosity for models that support it (use default if not specified)
             if self._supports_verbosity(model):
                 api_params["verbosity"] = verbosity or settings.default_verbosity
+
+            # Reasoning depth, for models that expose it
+            reasoning_effort = self._reasoning_effort_for(model, thinking_effort)
+            if reasoning_effort:
+                api_params["reasoning_effort"] = reasoning_effort
+                logger.info(f"[THINKING] OpenAI reasoning_effort '{reasoning_effort}' for model {model}")
 
             # Add tools if provided
             if tools:

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -19,7 +19,14 @@ import re
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from app.models import Conversation, Message, MessageRole, ConversationType, ConversationEntity
+from app.models import (
+    Conversation,
+    Message,
+    MessageRole,
+    ConversationType,
+    ConversationEntity,
+    EntitySetting,
+)
 from app.services import memory_service, llm_service
 from app.services.tool_service import tool_service, ToolResult
 from app.services.notes_tools import (
@@ -111,6 +118,25 @@ class SessionManager:
         )
         self._sessions[conversation_id] = session
         return session
+
+    async def refresh_thinking_effort(
+        self,
+        session: ConversationSession,
+        db: AsyncSession,
+    ) -> None:
+        """
+        Point the session at the responding entity's persisted thinking effort.
+
+        Read per turn rather than cached on the session: the effort is a
+        per-entity setting, and in multi-entity conversations the responding
+        entity (and therefore the effort) changes turn to turn. A NULL setting
+        leaves the session at None, which the provider services resolve to
+        settings.default_thinking_effort.
+        """
+        if not session.entity_id:
+            return
+        setting = await db.get(EntitySetting, session.entity_id)
+        session.thinking_effort = setting.thinking_effort if setting else None
 
     def _build_notes_context_message(
         self,
@@ -276,6 +302,9 @@ class SessionManager:
         session.entity_labels = entity_labels
         session.responding_entity_label = responding_entity_label
         session.provider_hint = provider_hint
+
+        # Per-entity thinking effort (refreshed again at the start of each turn)
+        await self.refresh_thinking_effort(session, db)
 
         # Load message history
         result = await db.execute(
@@ -884,6 +913,9 @@ class SessionManager:
 
         logger.info(f"[MEMORY] Processing message for conversation {session.conversation_id[:8]}...")
 
+        # Pick up the responding entity's current thinking effort for this turn
+        await self.refresh_thinking_effort(session, db)
+
         # Step 1-2: Retrieve, re-rank by significance, and deduplicate memories
         # Validate both that Pinecone is configured AND the entity_id is valid
         if memory_service.is_configured(entity_id=session.entity_id):
@@ -1197,6 +1229,7 @@ class SessionManager:
             enable_caching=True,
             verbosity=session.verbosity,
             provider_hint=session.provider_hint,
+            thinking_effort=session.thinking_effort,
         )
 
         # Record the provider-reported prompt size against the local estimate
@@ -1288,6 +1321,9 @@ class SessionManager:
         truly_new_memory_ids = set()  # Only memories never seen before (for cache stability)
 
         logger.info(f"[MEMORY] Processing message (stream) for conversation {session.conversation_id[:8]}... entity_id={session.entity_id}, model={session.model}")
+
+        # Pick up the responding entity's current thinking effort for this turn
+        await self.refresh_thinking_effort(session, db)
 
         # Set entity label for notes tools context
         # Use responding_entity_label if available (multi-entity), otherwise look up from entity_id
@@ -1730,6 +1766,7 @@ class SessionManager:
                 verbosity=session.verbosity,
                 tools=tool_schemas,
                 provider_hint=session.provider_hint,
+                thinking_effort=session.thinking_effort,
             ):
                 if event["type"] == "token":
                     content = event["content"]

--- a/backend/app/services/thinking_effort.py
+++ b/backend/app/services/thinking_effort.py
@@ -1,0 +1,80 @@
+"""
+Thinking Effort
+
+One canonical scale for "how hard should the model think", translated per
+provider at the call site:
+
+- Anthropic: `output_config.effort` (low | medium | high | xhigh | max)
+- OpenAI:    `reasoning_effort` (low | medium | high) on reasoning models
+- Google:    `thinking_config` (thinking_level on Gemini 3, thinking_budget on 2.5)
+
+The canonical levels below are Anthropic's, because they are the finest-grained
+of the three; the other providers collapse them (see each provider service).
+Models that don't take an effort/thinking parameter simply ignore the setting —
+nothing extra is sent for them.
+
+Levels are per entity (`EntitySetting.thinking_effort`), falling back to
+`settings.default_thinking_effort` ("high") when an entity has none set.
+"""
+
+from typing import Optional, Sequence
+
+from app.config import settings
+
+# Ordered lowest → highest. This ordering is load-bearing: clamping a requested
+# level to a model's ceiling picks the highest supported level at or below it.
+EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+
+_EFFORT_RANK = {level: index for index, level in enumerate(EFFORT_LEVELS)}
+
+
+def is_valid_effort(value: Optional[str]) -> bool:
+    """Whether the value is one of the canonical effort levels."""
+    return isinstance(value, str) and value.lower() in _EFFORT_RANK
+
+
+def normalize_effort(value: Optional[str]) -> Optional[str]:
+    """
+    Normalize a caller-supplied effort level, or None if it isn't a valid one.
+
+    Empty/whitespace strings normalize to None ("no explicit setting"), which
+    callers resolve to the configured default.
+    """
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+    return candidate if candidate in _EFFORT_RANK else None
+
+
+def resolve_effort(value: Optional[str]) -> str:
+    """
+    Resolve an effort level to send, falling back to the configured default.
+
+    An unrecognized value falls back rather than raising: the setting is a
+    tuning knob, and a bad value should not take a turn down with it.
+    """
+    return normalize_effort(value) or normalize_effort(settings.default_thinking_effort) or "high"
+
+
+def clamp_effort(effort: str, supported: Sequence[str]) -> Optional[str]:
+    """
+    Clamp an effort level to the highest supported level at or below it.
+
+    Older models support a shorter ladder (no `xhigh`, no `max`); sending a
+    level they don't know is a 400, so requests above a model's ceiling are
+    lowered instead of dropped. Returns None when the model supports no
+    levels at all (i.e. takes no effort parameter).
+    """
+    if not supported:
+        return None
+    requested_rank = _EFFORT_RANK[effort]
+    candidates = [
+        level for level in supported
+        if level in _EFFORT_RANK and _EFFORT_RANK[level] <= requested_rank
+    ]
+    if not candidates:
+        # Requested level is below everything the model supports — use its floor.
+        return min(supported, key=lambda level: _EFFORT_RANK[level])
+    return max(candidates, key=lambda level: _EFFORT_RANK[level])

--- a/backend/tests/test_entities_routes.py
+++ b/backend/tests/test_entities_routes.py
@@ -456,3 +456,145 @@ class TestGetEntityStatus:
 
         response = client.get("/api/entities/nonexistent/status")
         assert response.status_code == 404
+
+
+# ============================================================
+# Tests for PUT /api/entities/{entity_id}/thinking-effort
+# ============================================================
+
+class TestEntityThinkingEffort:
+    """Tests for per-entity thinking effort."""
+
+    @patch("app.routes.entities.settings")
+    async def test_list_includes_thinking_effort_and_default(self, mock_settings, entities_client):
+        """Listing should carry each entity's effort plus the global fallback."""
+        client, session_factory = entities_client
+
+        entities = [
+            _make_entity("claude-test", "Claude", "Primary", "anthropic"),
+            _make_entity("gpt-test", "GPT", "OpenAI", "openai", "gpt-4o"),
+        ]
+        mock_settings.get_entities.return_value = entities
+        mock_settings.get_default_entity.return_value = entities[0]
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", thinking_effort="max"))
+            await session.commit()
+
+        response = await client.get("/api/entities/")
+        data = response.json()
+
+        efforts = {e["index_name"]: e["thinking_effort"] for e in data["entities"]}
+        assert efforts["claude-test"] == "max"
+        # Unset entities report None and fall back to the global default
+        assert efforts["gpt-test"] is None
+        assert data["default_thinking_effort"] == "high"
+        assert data["thinking_effort_levels"] == ["low", "medium", "high", "xhigh", "max"]
+
+    @patch("app.routes.entities.settings")
+    async def test_set_thinking_effort(self, mock_settings, entities_client):
+        """Should persist a new effort level for the entity."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        response = await client.put(
+            "/api/entities/claude-test/thinking-effort",
+            json={"thinking_effort": "xhigh"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "entity_id": "claude-test",
+            "thinking_effort": "xhigh",
+            "effective_thinking_effort": "xhigh",
+        }
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.thinking_effort == "xhigh"
+
+    @patch("app.routes.entities.settings")
+    async def test_set_thinking_effort_is_case_insensitive(self, mock_settings, entities_client):
+        """Should normalize case before persisting."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        response = await client.put(
+            "/api/entities/claude-test/thinking-effort",
+            json={"thinking_effort": "  High "},
+        )
+        assert response.status_code == 200
+        assert response.json()["thinking_effort"] == "high"
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.thinking_effort == "high"
+
+    @patch("app.routes.entities.settings")
+    async def test_clear_thinking_effort_falls_back_to_default(self, mock_settings, entities_client):
+        """Clearing should NULL the override and report the global default."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", thinking_effort="low"))
+            await session.commit()
+
+        response = await client.put(
+            "/api/entities/claude-test/thinking-effort",
+            json={"thinking_effort": None},
+        )
+        assert response.status_code == 200
+        assert response.json()["thinking_effort"] is None
+        assert response.json()["effective_thinking_effort"] == "high"
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.thinking_effort is None
+
+    @patch("app.routes.entities.settings")
+    async def test_invalid_thinking_effort_rejected(self, mock_settings, entities_client):
+        """An unrecognized level is a client error, not a silent fallback."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        response = await client.put(
+            "/api/entities/claude-test/thinking-effort",
+            json={"thinking_effort": "ludicrous"},
+        )
+        assert response.status_code == 422
+
+        async with session_factory() as session:
+            assert await session.get(EntitySetting, "claude-test") is None
+
+    @patch("app.routes.entities.settings")
+    async def test_thinking_effort_preserves_system_prompt(self, mock_settings, entities_client):
+        """Setting the effort must not disturb the entity's stored prompt."""
+        client, session_factory = entities_client
+        mock_settings.get_entity_by_index.return_value = _make_entity("claude-test")
+
+        async with session_factory() as session:
+            session.add(EntitySetting(entity_id="claude-test", system_prompt="Be Claude"))
+            await session.commit()
+
+        response = await client.put(
+            "/api/entities/claude-test/thinking-effort",
+            json={"thinking_effort": "low"},
+        )
+        assert response.status_code == 200
+
+        async with session_factory() as session:
+            setting = await session.get(EntitySetting, "claude-test")
+            assert setting.system_prompt == "Be Claude"
+            assert setting.thinking_effort == "low"
+
+    @patch("app.routes.entities.settings")
+    async def test_thinking_effort_unknown_entity_returns_404(self, mock_settings, entities_client):
+        """Should 404 for an entity that isn't configured."""
+        client, _ = entities_client
+        mock_settings.get_entity_by_index.return_value = None
+
+        response = await client.put(
+            "/api/entities/nonexistent/thinking-effort",
+            json={"thinking_effort": "high"},
+        )
+        assert response.status_code == 404

--- a/backend/tests/test_thinking_effort.py
+++ b/backend/tests/test_thinking_effort.py
@@ -1,0 +1,470 @@
+"""
+Tests for thinking effort: the canonical scale and its per-provider translation.
+"""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from app.config import settings
+from app.services.thinking_effort import (
+    EFFORT_LEVELS,
+    clamp_effort,
+    normalize_effort,
+    resolve_effort,
+)
+from app.services.anthropic_service import (
+    AnthropicService,
+    resolve_effort_for_model,
+    supported_effort_levels,
+    supports_thinking_effort,
+)
+from app.services.openai_service import OpenAIService
+
+
+def _empty_async_iterator():
+    class _Empty:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    return _Empty()
+
+
+class TestCanonicalScale:
+    """The provider-neutral level vocabulary."""
+
+    def test_levels_are_ordered_low_to_high(self):
+        assert EFFORT_LEVELS == ("low", "medium", "high", "xhigh", "max")
+
+    @pytest.mark.parametrize("value", ["low", "MEDIUM", " high ", "xhigh", "max"])
+    def test_normalize_accepts_known_levels(self, value):
+        assert normalize_effort(value) == value.strip().lower()
+
+    @pytest.mark.parametrize("value", [None, "", "   ", "ludicrous", 3, object()])
+    def test_normalize_rejects_everything_else(self, value):
+        assert normalize_effort(value) is None
+
+    def test_resolve_falls_back_to_configured_default(self):
+        with patch.object(settings, "default_thinking_effort", "medium"):
+            assert resolve_effort(None) == "medium"
+            assert resolve_effort("low") == "low"
+
+    def test_resolve_survives_a_bad_configured_default(self):
+        """A typo in .env should not take every turn down with it."""
+        with patch.object(settings, "default_thinking_effort", "enormous"):
+            assert resolve_effort(None) == "high"
+
+    def test_default_is_high(self):
+        assert settings.default_thinking_effort == "high"
+
+    def test_clamp_lowers_to_the_model_ceiling(self):
+        assert clamp_effort("max", ("low", "medium", "high")) == "high"
+        assert clamp_effort("xhigh", ("low", "medium", "high", "max")) == "high"
+
+    def test_clamp_keeps_supported_levels_untouched(self):
+        assert clamp_effort("medium", EFFORT_LEVELS) == "medium"
+
+    def test_clamp_returns_none_when_nothing_is_supported(self):
+        assert clamp_effort("high", ()) is None
+
+
+class TestAnthropicEffortLadders:
+    """Which Claude models take `output_config.effort`, and at what levels."""
+
+    @pytest.mark.parametrize("model", [
+        "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7",
+        "claude-sonnet-5", "claude-fable-5",
+    ])
+    def test_current_models_take_the_full_ladder(self, model):
+        assert supported_effort_levels(model) == EFFORT_LEVELS
+        assert resolve_effort_for_model(model, "max") == "max"
+
+    def test_4_6_generation_has_no_xhigh(self):
+        """xhigh arrived with Opus 4.7, so a request for it clamps to high."""
+        assert resolve_effort_for_model("claude-opus-4-6", "xhigh") == "high"
+        assert resolve_effort_for_model("claude-sonnet-4-6", "max") == "max"
+
+    def test_opus_4_5_tops_out_at_high(self):
+        assert resolve_effort_for_model("claude-opus-4-5-20251101", "max") == "high"
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001",
+        "claude-opus-4-20250514", "MiniMax-M2.5",
+    ])
+    def test_models_without_effort_get_nothing(self, model):
+        """These 400 on the parameter, so nothing is sent for them."""
+        assert supports_thinking_effort(model) is False
+        assert resolve_effort_for_model(model, "high") is None
+
+    def test_date_suffixed_names_match_by_prefix(self):
+        assert supports_thinking_effort("claude-opus-4-7-20260101") is True
+
+
+class TestAnthropicRequests:
+    """The effort actually placed on outgoing Anthropic requests."""
+
+    def _streaming_service(self):
+        service = AnthropicService()
+        stream_ctx = MagicMock()
+        stream_ctx.__aenter__ = AsyncMock(return_value=_empty_async_iterator())
+        stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        client = MagicMock()
+        client.messages.stream = MagicMock(return_value=stream_ctx)
+        service.client = client
+        service._minimax_client = client
+        return service, client
+
+    @pytest.mark.asyncio
+    async def test_send_message_sends_effort(self, mock_anthropic_client):
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        await service.send_message(
+            [{"role": "user", "content": "Hello!"}],
+            model="claude-opus-5",
+            thinking_effort="low",
+        )
+
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"output_config": {"effort": "low"}}
+
+    @pytest.mark.asyncio
+    async def test_send_message_uses_the_default_when_unset(self, mock_anthropic_client):
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        await service.send_message(
+            [{"role": "user", "content": "Hello!"}], model="claude-opus-5"
+        )
+
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"output_config": {"effort": "high"}}
+
+    @pytest.mark.asyncio
+    async def test_send_message_omits_effort_for_older_models(self, mock_anthropic_client):
+        service = AnthropicService()
+        service.client = mock_anthropic_client
+
+        await service.send_message(
+            [{"role": "user", "content": "Hello!"}],
+            model="claude-sonnet-4-5-20250929",
+            thinking_effort="high",
+        )
+
+        assert "extra_body" not in mock_anthropic_client.messages.create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_stream_sends_effort(self):
+        service, client = self._streaming_service()
+
+        async for _ in service.send_message_stream(
+            [], model="claude-fable-5", thinking_effort="xhigh"
+        ):
+            pass
+
+        assert client.messages.stream.call_args.kwargs["extra_body"] == {
+            "output_config": {"effort": "xhigh"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_stream_clamps_to_the_model_ceiling(self):
+        service, client = self._streaming_service()
+
+        async for _ in service.send_message_stream(
+            [], model="claude-opus-4-5-20251101", thinking_effort="max"
+        ):
+            pass
+
+        assert client.messages.stream.call_args.kwargs["extra_body"] == {
+            "output_config": {"effort": "high"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_stream_omits_effort_for_minimax(self):
+        """MiniMax speaks the Anthropic format but rejects output_config."""
+        service, client = self._streaming_service()
+
+        async for _ in service.send_message_stream(
+            [], model="claude-fable-5", provider="minimax", thinking_effort="high"
+        ):
+            pass
+
+        assert "extra_body" not in client.messages.stream.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_effort_and_thinking_display_coexist(self):
+        """Effort controls depth, display controls visibility — both are sent."""
+        service, client = self._streaming_service()
+
+        async for _ in service.send_message_stream(
+            [], model="claude-fable-5", thinking_effort="medium"
+        ):
+            pass
+
+        call_kwargs = client.messages.stream.call_args.kwargs
+        assert call_kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert call_kwargs["extra_body"] == {"output_config": {"effort": "medium"}}
+
+
+class TestOpenAIReasoningEffort:
+    """Translation onto OpenAI's shorter reasoning_effort ladder."""
+
+    def test_levels_above_high_collapse_onto_high(self):
+        service = OpenAIService()
+        assert service._reasoning_effort_for("gpt-5.1", "xhigh") == "high"
+        assert service._reasoning_effort_for("gpt-5.1", "max") == "high"
+        assert service._reasoning_effort_for("gpt-5.1", "low") == "low"
+
+    def test_non_reasoning_models_get_nothing(self):
+        service = OpenAIService()
+        assert service._reasoning_effort_for("gpt-4o", "high") is None
+        assert service._reasoning_effort_for("gpt-5.1-chat-latest", "high") is None
+
+    def test_unset_effort_uses_the_configured_default(self):
+        service = OpenAIService()
+        with patch.object(settings, "default_thinking_effort", "low"):
+            assert service._reasoning_effort_for("o3", None) == "low"
+
+    @pytest.mark.asyncio
+    async def test_send_message_sends_reasoning_effort(self):
+        service = OpenAIService()
+        client = MagicMock()
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="hi", tool_calls=None), finish_reason="stop")]
+        response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, prompt_tokens_details=None)
+        response.model = "gpt-5.1"
+        client.chat.completions.create = AsyncMock(return_value=response)
+        service.client = client
+
+        await service.send_message(
+            [{"role": "user", "content": "Hello!"}],
+            model="gpt-5.1",
+            thinking_effort="medium",
+        )
+
+        assert client.chat.completions.create.call_args.kwargs["reasoning_effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_send_message_omits_reasoning_effort_for_gpt_4o(self):
+        service = OpenAIService()
+        client = MagicMock()
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="hi", tool_calls=None), finish_reason="stop")]
+        response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, prompt_tokens_details=None)
+        response.model = "gpt-4o"
+        client.chat.completions.create = AsyncMock(return_value=response)
+        service.client = client
+
+        await service.send_message(
+            [{"role": "user", "content": "Hello!"}],
+            model="gpt-4o",
+            thinking_effort="high",
+        )
+
+        assert "reasoning_effort" not in client.chat.completions.create.call_args.kwargs
+
+
+def _google_module():
+    """
+    The google_service *module*, not the singleton instance.
+
+    `app.services` exports an instance under the same name, so the usual
+    `from app.services import google_service` import shadows the module.
+    """
+    import sys
+
+    return sys.modules["app.services.google_service"]
+
+
+class TestGoogleThinkingConfig:
+    """Translation onto Gemini's thinking level/budget, probed per SDK version."""
+
+    def test_only_thinking_models_get_a_config(self):
+        service = _google_module().GoogleService()
+        assert service.supports_thinking("gemini-3.0-pro") is True
+        assert service.supports_thinking("gemini-2.5-flash") is True
+        assert service.supports_thinking("gemini-2.0-flash") is False
+        assert service._build_thinking_config("gemini-2.0-flash", "high") is None
+
+    def test_prefers_thinking_level_when_the_sdk_exposes_it(self):
+        module = _google_module()
+        service = module.GoogleService()
+        fake_config = MagicMock()
+        fake_types = MagicMock()
+        fake_types.ThinkingConfig = MagicMock(
+            model_fields={"thinking_level": object()},
+            return_value=fake_config,
+        )
+        with patch.object(module, "types", fake_types):
+            result = service._build_thinking_config("gemini-3.0-pro", "max")
+
+        assert result is fake_config
+        fake_types.ThinkingConfig.assert_called_once_with(thinking_level="high")
+
+    def test_falls_back_to_thinking_budget(self):
+        module = _google_module()
+        service = module.GoogleService()
+        fake_config = MagicMock()
+        fake_types = MagicMock()
+        fake_types.ThinkingConfig = MagicMock(
+            model_fields={"thinking_budget": object()},
+            return_value=fake_config,
+        )
+        with patch.object(module, "types", fake_types):
+            result = service._build_thinking_config("gemini-2.5-flash", "low")
+
+        assert result is fake_config
+        fake_types.ThinkingConfig.assert_called_once_with(
+            thinking_budget=module.GoogleService.THINKING_BUDGET_MAP["low"]
+        )
+
+    def test_sends_nothing_when_the_sdk_has_neither_field(self):
+        """The pinned floor (google-genai>=1.0.0) predates both spellings."""
+        module = _google_module()
+        service = module.GoogleService()
+        fake_types = MagicMock()
+        fake_types.ThinkingConfig = MagicMock(model_fields={"include_thoughts": object()})
+        with patch.object(module, "types", fake_types):
+            assert service._build_thinking_config("gemini-2.5-flash", "high") is None
+
+    def test_a_broken_sdk_costs_a_log_line_not_the_turn(self):
+        module = _google_module()
+        service = module.GoogleService()
+        config = MagicMock()
+        config.thinking_config = None
+        fake_types = MagicMock()
+        fake_types.ThinkingConfig = MagicMock(
+            model_fields={"thinking_level": object()},
+            side_effect=TypeError("unexpected keyword"),
+        )
+        with patch.object(module, "types", fake_types):
+            service._apply_thinking_config(config, "gemini-3.0-pro", "high")
+
+        assert config.thinking_config is None
+
+
+class TestModelCapabilityFlags:
+    """The per-model flag the settings UI uses to show/hide the control."""
+
+    def test_flag_matches_provider_support(self):
+        from app.services.llm_service import llm_service
+
+        providers = [
+            {
+                "id": "anthropic",
+                "name": "Anthropic",
+                "models": [
+                    {"id": "claude-opus-5", "name": "Claude Opus 5"},
+                    {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5"},
+                ],
+                "default_model": "claude-opus-5",
+            },
+            {
+                "id": "openai",
+                "name": "OpenAI",
+                "models": [
+                    {"id": "gpt-5.1", "name": "GPT-5.1"},
+                    {"id": "gpt-4o", "name": "GPT-4o"},
+                ],
+                "default_model": "gpt-5.1",
+            },
+            {
+                "id": "google",
+                "name": "Google",
+                "models": [
+                    {"id": "gemini-3.0-pro", "name": "Gemini 3.0 Pro"},
+                    {"id": "gemini-2.0-flash", "name": "Gemini 2.0 Flash"},
+                ],
+                "default_model": "gemini-3.0-pro",
+            },
+        ]
+        with patch.object(llm_service, "get_available_providers", return_value=providers):
+            flags = {
+                m["id"]: m["thinking_effort_supported"]
+                for m in llm_service.get_all_available_models()
+            }
+
+        assert flags == {
+            "claude-opus-5": True,
+            "claude-haiku-4-5-20251001": False,
+            "gpt-5.1": True,
+            "gpt-4o": False,
+            "gemini-3.0-pro": True,
+            "gemini-2.0-flash": False,
+        }
+
+
+class TestSessionEntityEffort:
+    """The per-entity setting reaching the session that makes the API call."""
+
+    class _StubDB:
+        """Minimal stand-in for AsyncSession.get(EntitySetting, entity_id)."""
+
+        def __init__(self, rows):
+            self.rows = rows
+
+        async def get(self, model, key):
+            return self.rows.get(key)
+
+    def _session(self, entity_id):
+        from app.services.conversation_session import ConversationSession
+
+        return ConversationSession(conversation_id="conv-1", entity_id=entity_id)
+
+    @pytest.mark.asyncio
+    async def test_reads_the_responding_entitys_effort(self):
+        from app.models import EntitySetting
+        from app.services.session_manager import SessionManager
+
+        db = self._StubDB({"claude-test": EntitySetting(entity_id="claude-test", thinking_effort="max")})
+        session = self._session("claude-test")
+
+        await SessionManager().refresh_thinking_effort(session, db)
+
+        assert session.thinking_effort == "max"
+
+    @pytest.mark.asyncio
+    async def test_entity_without_a_setting_stays_on_the_default(self):
+        from app.services.session_manager import SessionManager
+
+        session = self._session("claude-test")
+        session.thinking_effort = "low"  # stale value from a previous entity
+
+        await SessionManager().refresh_thinking_effort(session, self._StubDB({}))
+
+        # None means "resolve to settings.default_thinking_effort" downstream
+        assert session.thinking_effort is None
+
+    @pytest.mark.asyncio
+    async def test_follows_the_entity_switch_in_a_multi_entity_turn(self):
+        """Each responder brings its own effort, turn to turn."""
+        from app.models import EntitySetting
+        from app.services.session_manager import SessionManager
+
+        db = self._StubDB({
+            "claude-test": EntitySetting(entity_id="claude-test", thinking_effort="max"),
+            "gpt-test": EntitySetting(entity_id="gpt-test", thinking_effort="low"),
+        })
+        manager = SessionManager()
+        session = self._session("claude-test")
+
+        await manager.refresh_thinking_effort(session, db)
+        assert session.thinking_effort == "max"
+
+        session.entity_id = "gpt-test"
+        await manager.refresh_thinking_effort(session, db)
+        assert session.thinking_effort == "low"
+
+    @pytest.mark.asyncio
+    async def test_no_entity_means_no_lookup(self):
+        from app.services.session_manager import SessionManager
+
+        class _ExplodingDB:
+            async def get(self, model, key):  # pragma: no cover - must not run
+                raise AssertionError("should not query without an entity")
+
+        session = self._session(None)
+        await SessionManager().refresh_thinking_effort(session, _ExplodingDB())
+
+        assert session.thinking_effort is None

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,9 +47,10 @@ The listing below covers the REST endpoints by resource.
 - `GET /api/memories/status/health` — health check
 
 ## Entities
-- `GET /api/entities/` — list all configured AI entities
+- `GET /api/entities/` — list all configured AI entities. Each entry carries its persisted `system_prompt` and `thinking_effort`; the response also includes `default_thinking_effort` (applied when an entity has none) and `thinking_effort_levels`
 - `GET /api/entities/{id}` — get specific entity
 - `PUT /api/entities/{id}/system-prompt` — set an entity's persisted system prompt
+- `PUT /api/entities/{id}/thinking-effort` — set an entity's thinking effort. Body: `thinking_effort` (`low`/`medium`/`high`/`xhigh`/`max`, or null to clear and follow `DEFAULT_THINKING_EFFORT`). Unknown levels return 422. Returns the stored value plus `effective_thinking_effort`
 - `GET /api/entities/{id}/status` — get entity Pinecone connection status
 
 ## Notes

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -161,6 +161,19 @@
                     <input type="number" id="temperature-number" min="0" max="2" step="0.01" value="1">
                 </div>
 
+                <div class="form-group" id="thinking-effort-group">
+                    <label for="thinking-effort-select">Thinking Effort</label>
+                    <select id="thinking-effort-select">
+                        <option value="">Default (high)</option>
+                        <option value="low">Low</option>
+                        <option value="medium">Medium</option>
+                        <option value="high">High</option>
+                        <option value="xhigh">Xhigh</option>
+                        <option value="max">Max</option>
+                    </select>
+                    <small class="form-help">How hard this entity's model thinks. Applies to the currently selected entity; levels above a model's ceiling are clamped.</small>
+                </div>
+
                 <div class="form-group" id="verbosity-group">
                     <label for="verbosity-select">Verbosity (GPT-5.x only)</label>
                     <select id="verbosity-select">

--- a/frontend/js/__tests__/entities.test.js
+++ b/frontend/js/__tests__/entities.test.js
@@ -136,6 +136,40 @@ describe('Entities Module', () => {
 
             expect(state.settings.systemPrompt).toBe('Be Claude');
         });
+
+        it('should populate the thinking effort cache and the backend default', async () => {
+            window.api.listEntities = vi.fn(() => Promise.resolve({
+                entities: [
+                    { index_name: 'entity-1', label: 'Claude', thinking_effort: 'max' },
+                    { index_name: 'entity-2', label: 'GPT', thinking_effort: null },
+                ],
+                default_entity: 'entity-1',
+                default_thinking_effort: 'medium',
+                thinking_effort_levels: ['low', 'medium', 'high'],
+            }));
+
+            await loadEntities();
+
+            expect(state.entityThinkingEfforts['entity-1']).toBe('max');
+            expect(state.entityThinkingEfforts['entity-2']).toBeNull();
+            expect(state.thinkingEffortDefault).toBe('medium');
+            expect(state.thinkingEffortLevels).toEqual(['low', 'medium', 'high']);
+        });
+
+        it('should apply the selected entity\'s effort to settings on load', async () => {
+            state.selectedEntityId = 'entity-1';
+            state.settings.thinkingEffort = 'stale';
+            window.api.listEntities = vi.fn(() => Promise.resolve({
+                entities: [
+                    { index_name: 'entity-1', label: 'Claude', thinking_effort: 'low' },
+                ],
+                default_entity: 'entity-1',
+            }));
+
+            await loadEntities();
+
+            expect(state.settings.thinkingEffort).toBe('low');
+        });
     });
 
     describe('getEntityLabel', () => {
@@ -180,6 +214,30 @@ describe('Entities Module', () => {
             handleEntityChange('entity-1');
 
             expect(mockCallbacks.onEntityChanged).toHaveBeenCalled();
+        });
+
+        it('should swap in the new entity\'s thinking effort', () => {
+            state.entities = [
+                { index_name: 'entity-1', label: 'Claude', llm_provider: 'anthropic' },
+                { index_name: 'entity-2', label: 'GPT', llm_provider: 'openai' },
+            ];
+            state.entityThinkingEfforts = { 'entity-1': 'max', 'entity-2': 'low' };
+            state.settings.thinkingEffort = 'max';
+
+            handleEntityChange('entity-2');
+
+            expect(state.settings.thinkingEffort).toBe('low');
+        });
+
+        it('should fall back to the backend default for an entity with no override', () => {
+            state.entities = [{ index_name: 'entity-2', label: 'GPT', llm_provider: 'openai' }];
+            state.entityThinkingEfforts = {};
+            state.settings.thinkingEffort = 'max';
+
+            handleEntityChange('entity-2');
+
+            // null = "no override", which the backend resolves to its default
+            expect(state.settings.thinkingEffort).toBeNull();
         });
     });
 

--- a/frontend/js/__tests__/settings.test.js
+++ b/frontend/js/__tests__/settings.test.js
@@ -14,8 +14,11 @@ import {
     loadPresets,
     modelSupportsVerbosity,
     modelSupportsTemperature,
+    modelSupportsThinkingEffort,
     updateTemperatureControlState,
     updateVerbosityControlState,
+    updateThinkingEffortControlState,
+    populateThinkingEffortSelect,
 } from '../modules/settings.js';
 
 describe('Settings Module', () => {
@@ -35,12 +38,16 @@ describe('Settings Module', () => {
         };
         state.selectedEntityId = null;
         state.entitySystemPrompts = {};
+        state.entityThinkingEfforts = {};
+        state.thinkingEffortDefault = 'high';
+        state.thinkingEffortLevels = ['low', 'medium', 'high', 'xhigh', 'max'];
         state.ttsVoices = [];
         state.ttsProvider = null;
         state.availableModels = [
-            { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet', temperature_supported: true },
-            { id: 'gpt-5.1', name: 'GPT-5.1', temperature_supported: true },
-            { id: 'o1', name: 'O1', temperature_supported: false },
+            { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet', temperature_supported: true, thinking_effort_supported: false },
+            { id: 'gpt-5.1', name: 'GPT-5.1', temperature_supported: true, thinking_effort_supported: true },
+            { id: 'o1', name: 'O1', temperature_supported: false, thinking_effort_supported: true },
+            { id: 'claude-opus-5', name: 'Claude Opus 5', temperature_supported: false, thinking_effort_supported: true },
         ];
 
         // Create mock elements matching actual module usage
@@ -52,6 +59,7 @@ describe('Settings Module', () => {
             systemPromptInput: document.createElement('textarea'),
             conversationTypeSelect: document.createElement('select'),
             verbositySelect: document.createElement('select'),
+            thinkingEffortSelect: document.createElement('select'),
             themeSelect: document.createElement('select'),
             voiceSelect: document.createElement('select'),
             researcherNameInput: document.createElement('input'),
@@ -96,6 +104,22 @@ describe('Settings Module', () => {
         verbosityFormGroup.className = 'form-group';
         verbosityFormGroup.appendChild(mockElements.verbositySelect);
         document.body.appendChild(verbosityFormGroup);
+
+        // Thinking effort: "Default" plus the backend levels, in its own group
+        const defaultEffortOption = document.createElement('option');
+        defaultEffortOption.value = '';
+        defaultEffortOption.textContent = 'Default (high)';
+        mockElements.thinkingEffortSelect.appendChild(defaultEffortOption);
+        ['low', 'medium', 'high', 'xhigh', 'max'].forEach(level => {
+            const opt = document.createElement('option');
+            opt.value = level;
+            opt.textContent = level;
+            mockElements.thinkingEffortSelect.appendChild(opt);
+        });
+        const thinkingEffortFormGroup = document.createElement('div');
+        thinkingEffortFormGroup.className = 'form-group';
+        thinkingEffortFormGroup.appendChild(mockElements.thinkingEffortSelect);
+        document.body.appendChild(thinkingEffortFormGroup);
 
         // Add theme options
         const lightOption = document.createElement('option');
@@ -386,6 +410,124 @@ describe('Settings Module', () => {
 
             const formGroup = mockElements.verbositySelect.closest('.form-group');
             expect(formGroup.style.display).toBe('none');
+        });
+    });
+    describe('thinking effort', () => {
+        describe('modelSupportsThinkingEffort', () => {
+            it('should follow the backend flag', () => {
+                expect(modelSupportsThinkingEffort('claude-opus-5')).toBe(true);
+                expect(modelSupportsThinkingEffort('claude-sonnet-4-5-20250929')).toBe(false);
+            });
+
+            it('should assume unsupported for an unknown model', () => {
+                expect(modelSupportsThinkingEffort('some-future-model')).toBe(false);
+                expect(modelSupportsThinkingEffort(null)).toBe(false);
+            });
+        });
+
+        describe('updateThinkingEffortControlState', () => {
+            it('should show the control for a model that thinks', () => {
+                mockElements.modelSelect.value = 'gpt-5.1';
+
+                updateThinkingEffortControlState();
+
+                expect(mockElements.thinkingEffortSelect.closest('.form-group').style.display).toBe('block');
+            });
+
+            it('should hide the control for a model that does not', () => {
+                mockElements.modelSelect.value = 'claude-sonnet-4-5-20250929';
+
+                updateThinkingEffortControlState();
+
+                expect(mockElements.thinkingEffortSelect.closest('.form-group').style.display).toBe('none');
+            });
+        });
+
+        describe('populateThinkingEffortSelect', () => {
+            it('should offer the backend levels plus a Default option', () => {
+                state.thinkingEffortLevels = ['low', 'high'];
+                state.thinkingEffortDefault = 'medium';
+
+                populateThinkingEffortSelect();
+
+                const options = Array.from(mockElements.thinkingEffortSelect.options);
+                expect(options.map(o => o.value)).toEqual(['', 'low', 'high']);
+                expect(options[0].textContent).toBe('Default (medium)');
+            });
+
+            it('should keep the current selection', () => {
+                mockElements.thinkingEffortSelect.value = 'max';
+
+                populateThinkingEffortSelect();
+
+                expect(mockElements.thinkingEffortSelect.value).toBe('max');
+            });
+        });
+
+        describe('initializeSettingsUI', () => {
+            it('should show the entity\'s effort', () => {
+                state.settings.thinkingEffort = 'xhigh';
+
+                initializeSettingsUI();
+
+                expect(mockElements.thinkingEffortSelect.value).toBe('xhigh');
+            });
+
+            it('should select Default when the entity has no override', () => {
+                state.settings.thinkingEffort = null;
+
+                initializeSettingsUI();
+
+                expect(mockElements.thinkingEffortSelect.value).toBe('');
+            });
+        });
+
+        describe('applySettings', () => {
+            it('should persist the effort for the selected entity', async () => {
+                state.selectedEntityId = 'claude-test';
+                window.api.updateEntityThinkingEffort = vi.fn(() => Promise.resolve({}));
+                mockElements.thinkingEffortSelect.value = 'max';
+
+                await applySettings();
+
+                expect(state.settings.thinkingEffort).toBe('max');
+                expect(window.api.updateEntityThinkingEffort).toHaveBeenCalledWith('claude-test', 'max');
+                expect(state.entityThinkingEfforts['claude-test']).toBe('max');
+            });
+
+            it('should send null when Default is chosen, clearing the override', async () => {
+                state.selectedEntityId = 'claude-test';
+                state.entityThinkingEfforts = { 'claude-test': 'low' };
+                window.api.updateEntityThinkingEffort = vi.fn(() => Promise.resolve({}));
+                mockElements.thinkingEffortSelect.value = '';
+
+                await applySettings();
+
+                expect(state.settings.thinkingEffort).toBeNull();
+                expect(window.api.updateEntityThinkingEffort).toHaveBeenCalledWith('claude-test', null);
+                expect(state.entityThinkingEfforts['claude-test']).toBeNull();
+            });
+
+            it('should not call the backend when the effort is unchanged', async () => {
+                state.selectedEntityId = 'claude-test';
+                state.entityThinkingEfforts = { 'claude-test': 'high' };
+                window.api.updateEntityThinkingEffort = vi.fn(() => Promise.resolve({}));
+                mockElements.thinkingEffortSelect.value = 'high';
+
+                await applySettings();
+
+                expect(window.api.updateEntityThinkingEffort).not.toHaveBeenCalled();
+            });
+
+            it('should not persist an effort in multi-entity mode', async () => {
+                state.selectedEntityId = 'multi-entity';
+                window.api.updateEntityThinkingEffort = vi.fn(() => Promise.resolve({}));
+                mockElements.thinkingEffortSelect.value = 'low';
+
+                await applySettings();
+
+                expect(window.api.updateEntityThinkingEffort).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -70,6 +70,15 @@ class ApiClient {
         });
     }
 
+    // Persist how hard this entity's model should think (low, medium, high,
+    // xhigh, max). Pass null to clear it and follow the backend default.
+    async updateEntityThinkingEffort(entityId, thinkingEffort) {
+        return this.request(`/entities/${entityId}/thinking-effort`, {
+            method: 'PUT',
+            body: { thinking_effort: thinkingEffort },
+        });
+    }
+
     // Conversations
     async listConversations(limit = 50, offset = 0, entityId = null) {
         let url = `/conversations/?limit=${limit}&offset=${offset}`;

--- a/frontend/js/app-modular.js
+++ b/frontend/js/app-modular.js
@@ -127,6 +127,7 @@ import {
     modelSupportsTemperature,
     updateTemperatureControlState,
     updateVerbosityControlState,
+    updateThinkingEffortControlState,
     updateTemperatureRange,
     syncTemperatureInputs,
     updateModelIndicator,
@@ -229,6 +230,7 @@ class App {
             presetSelect: document.getElementById('preset-select'),
             themeSelect: document.getElementById('theme-select'),
             verbositySelect: document.getElementById('verbosity-select'),
+            thinkingEffortSelect: document.getElementById('thinking-effort-select'),
             researcherNameInput: document.getElementById('researcher-name-input'),
             enterInsertsNewlineCheckbox: document.getElementById('enter-inserts-newline'),
             voiceSelect: document.getElementById('voice-select'),
@@ -498,6 +500,7 @@ class App {
         this.elements.modelSelect?.addEventListener('change', () => {
             updateTemperatureControlState();
             updateVerbosityControlState();
+            updateThinkingEffortControlState();
         });
         this.elements.presetSelect?.addEventListener('change', (e) => loadPreset(e.target.value));
 

--- a/frontend/js/modules/entities.js
+++ b/frontend/js/modules/entities.js
@@ -52,13 +52,21 @@ export async function loadEntities() {
         console.log('[Entities] Parsed entities:', entities);
         state.entities = entities;
 
-        // The backend is the source of truth for per-entity system prompts.
-        // Rebuild the in-memory cache from the response so prompts survive
-        // across sessions/browsers (no client-side persistence).
+        // The backend is the source of truth for per-entity system prompts and
+        // thinking effort. Rebuild the in-memory caches from the response so
+        // both survive across sessions/browsers (no client-side persistence).
         state.entitySystemPrompts = {};
+        state.entityThinkingEfforts = {};
         entities.forEach(entity => {
             state.entitySystemPrompts[entity.index_name] = entity.system_prompt ?? null;
+            state.entityThinkingEfforts[entity.index_name] = entity.thinking_effort ?? null;
         });
+        if (response.default_thinking_effort) {
+            state.thinkingEffortDefault = response.default_thinking_effort;
+        }
+        if (Array.isArray(response.thinking_effort_levels) && response.thinking_effort_levels.length) {
+            state.thinkingEffortLevels = response.thinking_effort_levels;
+        }
 
         // Update entity selector
         console.log('[Entities] entitySelect element:', elements.entitySelect);
@@ -103,6 +111,7 @@ export async function loadEntities() {
         // event, so handleEntityChange won't run on initial load — do it here.
         if (state.selectedEntityId && state.selectedEntityId !== 'multi-entity') {
             state.settings.systemPrompt = state.entitySystemPrompts[state.selectedEntityId] ?? null;
+            state.settings.thinkingEffort = state.entityThinkingEfforts[state.selectedEntityId] ?? null;
         }
 
         updateEntityDescription();
@@ -211,6 +220,10 @@ export function handleEntityChange(entityId) {
         } else {
             state.settings.systemPrompt = null;
         }
+
+        // Restore entity-specific thinking effort. Unlike the prompt, absence
+        // is meaningful here: null means "use the backend default".
+        state.settings.thinkingEffort = state.entityThinkingEfforts[entityId] ?? null;
     }
 
     updateEntityDescription();

--- a/frontend/js/modules/settings.js
+++ b/frontend/js/modules/settings.js
@@ -47,6 +47,8 @@ export async function applySettings() {
     state.settings.systemPrompt = elements.systemPromptInput.value.trim() || null;
     state.settings.conversationType = elements.conversationTypeSelect.value;
     state.settings.verbosity = elements.verbositySelect.value;
+    // Empty option = "Default", i.e. no per-entity override
+    state.settings.thinkingEffort = elements.thinkingEffortSelect?.value || null;
 
     // Save researcher name
     state.settings.researcherName = elements.researcherNameInput.value.trim() || '';
@@ -76,6 +78,18 @@ export async function applySettings() {
             } catch (error) {
                 console.error('Failed to save entity system prompt:', error);
                 showToast('Failed to save system prompt', 'error');
+            }
+        }
+
+        // Thinking effort is per-entity too, and lives in the same table.
+        const newEffort = state.settings.thinkingEffort;
+        if ((state.entityThinkingEfforts[entityId] ?? null) !== newEffort) {
+            state.entityThinkingEfforts[entityId] = newEffort;
+            try {
+                await api.updateEntityThinkingEffort(entityId, newEffort);
+            } catch (error) {
+                console.error('Failed to save entity thinking effort:', error);
+                showToast('Failed to save thinking effort', 'error');
             }
         }
     }
@@ -233,6 +247,60 @@ export function updateVerbosityControlState() {
 }
 
 /**
+ * Check if a model supports a thinking/reasoning effort control
+ * @param {string} modelId - Model ID to check
+ * @returns {boolean}
+ */
+export function modelSupportsThinkingEffort(modelId) {
+    if (!modelId) return false;
+    // The backend owns which models accept an effort parameter (the ladders
+    // differ per provider and per model generation). Absent the flag — a model
+    // not in the available-models list — assume unsupported rather than
+    // offering a control that would be ignored.
+    const model = state.availableModels.find(m => m.id === modelId);
+    return model ? model.thinking_effort_supported === true : false;
+}
+
+/**
+ * Populate the thinking effort dropdown from the levels the backend accepts,
+ * with a leading "Default" option that clears the per-entity override.
+ */
+export function populateThinkingEffortSelect() {
+    if (!elements.thinkingEffortSelect) return;
+
+    const current = elements.thinkingEffortSelect.value;
+    elements.thinkingEffortSelect.innerHTML = '';
+
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = `Default (${state.thinkingEffortDefault})`;
+    elements.thinkingEffortSelect.appendChild(defaultOption);
+
+    state.thinkingEffortLevels.forEach(level => {
+        const option = document.createElement('option');
+        option.value = level;
+        option.textContent = level.charAt(0).toUpperCase() + level.slice(1);
+        elements.thinkingEffortSelect.appendChild(option);
+    });
+
+    elements.thinkingEffortSelect.value = current;
+}
+
+/**
+ * Update thinking effort control visibility based on the selected model
+ */
+export function updateThinkingEffortControlState() {
+    if (!elements.modelSelect || !elements.thinkingEffortSelect) return;
+
+    const supportsEffort = modelSupportsThinkingEffort(elements.modelSelect.value);
+
+    const formGroup = elements.thinkingEffortSelect.closest('.form-group');
+    if (formGroup) {
+        formGroup.style.display = supportsEffort ? 'block' : 'none';
+    }
+}
+
+/**
  * Update temperature range based on current entity's provider
  */
 export function updateTemperatureRange() {
@@ -382,6 +450,11 @@ export function initializeSettingsUI() {
     if (elements.verbositySelect) {
         elements.verbositySelect.value = state.settings.verbosity || 'medium';
     }
+    if (elements.thinkingEffortSelect) {
+        populateThinkingEffortSelect();
+        // '' selects the "Default" option — no per-entity override
+        elements.thinkingEffortSelect.value = state.settings.thinkingEffort || '';
+    }
     if (elements.researcherNameInput) {
         elements.researcherNameInput.value = state.settings.researcherName || '';
     }
@@ -391,4 +464,5 @@ export function initializeSettingsUI() {
 
     updateTemperatureControlState();
     updateVerbosityControlState();
+    updateThinkingEffortControlState();
 }

--- a/frontend/js/modules/state.js
+++ b/frontend/js/modules/state.js
@@ -16,6 +16,13 @@ export const state = {
     selectedEntityId: null,
     entities: [],
     entitySystemPrompts: {},
+    // Per-entity thinking effort, mirrored from the entities API response.
+    // null for an entity means "use the backend default" (thinkingEffortDefault).
+    entityThinkingEfforts: {},
+    // The level the backend applies when an entity has none of its own
+    thinkingEffortDefault: 'high',
+    // Levels the backend accepts, ascending (overwritten from the API response)
+    thinkingEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
     entityModels: {},  // Per-entity model selection persistence
     // Configured default_model that was in effect when each entityModels entry
     // was saved. Used to detect when an entity's .env default_model has changed
@@ -55,6 +62,8 @@ export const state = {
         systemPrompt: null,
         conversationType: 'normal',
         verbosity: 'medium',
+        // null = follow the backend default for this entity
+        thinkingEffort: null,
         researcherName: '',
         enterInsertsNewline: false,
     },
@@ -150,10 +159,13 @@ export function clearAudioCache() {
     state.audioCache.clear();
 }
 
-// NOTE: Per-entity system prompts are NOT stored client-side. The backend
-// (entity_settings table, /api/entities/{id}/system-prompt) is the source of
-// truth; the cache in state.entitySystemPrompts is populated from the entities
-// API response on load. See modules/entities.js and modules/settings.js.
+// NOTE: Per-entity system prompts and thinking effort are NOT stored
+// client-side. The backend
+// (entity_settings table, /api/entities/{id}/system-prompt and
+// /api/entities/{id}/thinking-effort) is the source of truth; the caches in
+// state.entitySystemPrompts and state.entityThinkingEfforts are populated from
+// the entities API response on load. See modules/entities.js and
+// modules/settings.js.
 //
 // LEGACY_ENTITY_PROMPTS_KEY is only read once at startup to migrate any
 // prompts a previous version saved in localStorage up to the backend.


### PR DESCRIPTION
## Summary

Implements a canonical thinking effort scale ("low", "medium", "high", "xhigh", "max") that translates per-provider to control how hard models think/reason. Effort is configurable globally (via `settings.default_thinking_effort`, defaulting to "high") and per-entity (persisted in `EntitySetting.thinking_effort`), with provider-specific support:

- **Anthropic:** `output_config.effort` (full 5-level ladder, varies by model generation)
- **OpenAI:** `reasoning_effort` (3-level ladder on o1/o3/gpt-5.x; collapses xhigh/max to high)
- **Google:** `thinking_config` (thinking_level on Gemini 3, thinking_budget on 2.5; probed at runtime)
- **Unsupported models:** effort setting is silently ignored (no parameter sent)

## Key Changes

**Backend:**
- New `app/services/thinking_effort.py`: canonical scale, normalization, resolution, and clamping logic
- `AnthropicService`: model-specific effort ladders (Opus 5 supports max, Opus 4.5 caps at high, older models get nothing); effort sent via `extra_body` for SDK compatibility
- `OpenAIService`: reasoning_effort mapping and model detection (o1/o3/gpt-5.x only)
- `GoogleService`: thinking_config builder with SDK version detection (prefers thinking_level, falls back to thinking_budget)
- `EntitySetting` model: new `thinking_effort` column (nullable, None = use global default)
- `SessionManager.refresh_thinking_effort()`: loads per-entity effort per turn (responding entity's setting)
- `LLMService.get_all_available_models()`: adds `thinking_effort_supported` flag per model for UI
- `routes/entities.py`: new `PUT /api/entities/{entity_id}/thinking-effort` endpoint; list response includes `default_thinking_effort` and `thinking_effort_levels`
- Database migration: adds `thinking_effort` column to `entity_settings` table
- Comprehensive test suite (`test_thinking_effort.py`): 470 lines covering canonical scale, per-provider translation, request formation, and model capability flags

**Frontend:**
- `state.js`: new `entityThinkingEfforts`, `thinkingEffortDefault`, `thinkingEffortLevels` state
- `settings.js`: `modelSupportsThinkingEffort()`, `updateThinkingEffortControlState()`, `populateThinkingEffortSelect()` functions; effort persisted per-entity via API
- `entities.js`: loads effort cache and backend default from list response; applies selected entity's effort to settings
- `api.js`: `updateEntityThinkingEffort()` method
- `index.html`: thinking effort select control (hidden for unsupported models)
- Test coverage: entity loading, control visibility, per-entity persistence

**Config & Docs:**
- `config.py`: `default_thinking_effort` setting (env: `DEFAULT_THINKING_EFFORT`, default: "high")
- `CLAUDE.md`: updated with thinking effort architecture
- `docs/api.md`: endpoint documentation

## Implementation Details

- **Model detection:** Anthropic and Google use prefix matching to handle date-suffixed model names; OpenAI uses exact set membership
- **Clamping:** requests above a model's ceiling are lowered rather than dropped (e.g., "max" on Opus 4.5 becomes "high")
- **Fallback resilience:** bad configured defaults don't crash turns; unrecognized values fall back to "high"
- **SDK compatibility:** Anthropic effort sent via `extra_body` (works on anthropic>=0.40.0); Google config probed at runtime to handle SDK version differences
- **Per-turn resolution:** effort refreshed from DB each turn so multi-entity conversations use the responding entity's setting
- **UI integration:** control shown/hidden based on backend capability flag; "Default" option clears per-entity override

https://claude.ai/code/session_012kin17ScdNj5UxAD8AYjZL