### PR TITLE
Fix message input layout to maintain button height on textarea resize

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -40,6 +40,9 @@
     --font-mono: 'Consolas', 'Monaco', 'Courier New', monospace;
     --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 
+    /* Layout */
+    --input-btn-height: 44px;
+
     /* Scrollbar colors */
     --scrollbar-thumb: #333;
     --scrollbar-thumb-hover: #444;
@@ -1153,9 +1156,19 @@ body.resizing-input {
 
 .input-container {
     display: flex;
+    /* Bottom-aligned rather than stretched: the buttons keep their own height
+       when the user drags the divider to make the textarea taller. */
+    align-items: flex-end;
     gap: 12px;
     max-width: 800px;
     margin: 0 auto;
+}
+
+/* Every control beside the textarea holds one fixed height, whatever the
+   height of the message entry area. */
+.input-container > button {
+    flex: 0 0 auto;
+    height: var(--input-btn-height);
 }
 
 #message-input {
@@ -1168,7 +1181,7 @@ body.resizing-input {
     font-family: var(--font-sans);
     font-size: 0.95rem;
     resize: none;
-    min-height: 44px;
+    min-height: var(--input-btn-height);
     max-height: 200px;
     overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
Refactors the message input container layout to prevent buttons from stretching when the user resizes the textarea. Buttons now maintain a fixed height regardless of textarea expansion, improving the UI consistency and user experience.

## Key Changes
- Added `--input-btn-height: 44px` CSS variable to centralize the standard button height
- Changed `.input-container` to use `align-items: flex-end` instead of default stretch behavior, so buttons align to the bottom rather than expanding vertically
- Added explicit height and flex rules for `.input-container > button` to maintain fixed `44px` height
- Updated `#message-input` to use the new CSS variable for `min-height` instead of hardcoded value

## Implementation Details
- The layout now uses flexbox's `flex-end` alignment to bottom-align controls while allowing the textarea to grow independently
- Buttons use `flex: 0 0 auto` to prevent flex growth/shrink, ensuring they stay at their declared height
- Centralizing the height value in a CSS variable makes future adjustments easier and keeps the design consistent across the input area

https://claude.ai/code/session_01H84SkTrwhFdf7RaeCNsL69