### PR TITLE
Remove "Experiential Interpretability Research" subtitle

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,1 @@
-# Here I Am - Experiential Interpretability Research Application
+# Here I Am

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -105,7 +105,6 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Here I Am",
-    description="Experiential Interpretability Research Application",
     version="0.1.0",
     lifespan=lifespan,
 )

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -144,12 +144,6 @@ html, body {
     font-size: 1.5rem;
     font-weight: 600;
     color: var(--text-primary);
-    margin-bottom: 4px;
-}
-
-.app-subtitle {
-    font-size: 0.75rem;
-    color: var(--text-muted);
 }
 
 /* Entity Selector */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,6 @@
         <aside class="sidebar">
             <div class="sidebar-header">
                 <h1 class="app-title">Here I Am</h1>
-                <p class="app-subtitle">Experiential Interpretability Research</p>
             </div>
 
             <!-- Entity Selector -->

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "here-i-am-frontend",
   "version": "1.0.0",
-  "description": "Frontend for Here I Am - Experiential Interpretability Research Application",
+  "description": "Frontend for Here I Am",
   "type": "module",
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Summary
Removes the "Experiential Interpretability Research Application" subtitle and description strings from the application, simplifying the branding to just "Here I Am" across all user-facing and configuration surfaces.

## Changes
- **Frontend UI:** Removed `.app-subtitle` CSS class and the subtitle paragraph from the sidebar header in `index.html`
- **Frontend styles:** Deleted `.app-subtitle` style rule and the `margin-bottom` from `.app-title` in `styles.css`
- **Backend metadata:** Removed the `description` parameter from the FastAPI app initialization in `main.py`
- **Documentation strings:** Updated package description in `package.json` and module docstring in `backend/app/__init__.py` to remove the full subtitle

## Notes
This is a branding simplification that affects the application's public-facing name and metadata without changing any functional behavior.

https://claude.ai/code/session_01RuB3gh6KekinxAMxWE5FrJ